### PR TITLE
refactor: remove hardcoded dataset lists, use dynamic STAC catalog retrieval

### DIFF
--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -572,9 +572,13 @@ class GeoAgent:
                 f"{time_range.get('start_date', '')}/{time_range.get('end_date', '')}"
             )
 
-        # Build collection: use planner output directly; fallback to Sentinel-2 if absent
+        # Build collection: use planner output directly
         dataset = plan.dataset
-        collection = dataset if dataset else "sentinel-2-l2a"
+        if not dataset:
+            # No specific dataset identified - let user specify or handle downstream
+            collection = "collection-id-here"
+        else:
+            collection = dataset
 
         # Cloud cover filter only for imagery collections
         cloud_filter = ""
@@ -854,25 +858,15 @@ m
         location = self._extract_location(query)
         time_range = self._extract_time_range(query_lower)
 
+        # NOTE: Hardcoded dataset mappings removed. Let the data agent search 
+        # across available catalogs when no specific dataset is identified.
         dataset = None
         analysis_type = None
-        if "sentinel-1" in query_lower:
-            dataset = "sentinel-1-grd"
-        elif "sentinel" in query_lower or "sentinel-2" in query_lower:
-            dataset = "sentinel-2-l2a"
-        elif "landsat" in query_lower:
-            dataset = "landsat-c2-l2"
-        elif "naip" in query_lower:
-            dataset = "naip"
-        elif "modis" in query_lower:
-            dataset = "modis-09A1-061"
-        elif any(
+        if any(
             kw in query_lower for kw in ["land cover", "landcover", "lulc", "land use"]
         ):
-            dataset = "io-lulc-9-class"
             analysis_type = "land_cover"
         elif any(kw in query_lower for kw in ["dem", "elevation", "terrain"]):
-            dataset = "cop-dem-glo-30"
             analysis_type = "elevation"
 
         parameters = {}

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -858,7 +858,7 @@ m
         location = self._extract_location(query)
         time_range = self._extract_time_range(query_lower)
 
-        # NOTE: Hardcoded dataset mappings removed. Let the data agent search 
+        # NOTE: Hardcoded dataset mappings removed. Let the data agent search
         # across available catalogs when no specific dataset is identified.
         dataset = None
         analysis_type = None

--- a/geoagent/core/data_agent.py
+++ b/geoagent/core/data_agent.py
@@ -364,56 +364,6 @@ class DataAgent:
             # Use the planner-provided dataset directly as the collection ID
             params["collections"] = [plan.dataset]
 
-        # Resolve collection from analysis_type or intent if not already set
-        if "collections" not in params:
-            analysis_type = (plan.analysis_type or "").lower()
-            intent_lower = plan.intent.lower()
-
-            # Check analysis_type first (most reliable signal from planner)
-            if analysis_type in ("land_cover", "classification", "lulc"):
-                params["collections"] = ["io-lulc-9-class"]
-            elif analysis_type in (
-                "elevation",
-                "dem",
-                "terrain",
-                "slope",
-                "hillshade",
-            ):
-                params["collections"] = ["cop-dem-glo-30"]
-            elif analysis_type in ("water_mapping",):
-                params["collections"] = ["jrc-gsw"]
-            elif analysis_type in ("fire_detection",):
-                params["collections"] = ["modis-14A1-061"]
-            elif analysis_type in ("snow_cover",):
-                params["collections"] = ["modis-10A1-061"]
-            elif analysis_type in ("surface_temperature",):
-                params["collections"] = ["modis-11A1-061"]
-            elif analysis_type in ("event_impact",):
-                params["collections"] = ["sentinel-1-grd"]
-            # Then check intent keywords
-            elif any(
-                kw in intent_lower
-                for kw in ["land cover", "landcover", "lulc", "land use"]
-            ):
-                params["collections"] = ["io-lulc-9-class"]
-            elif any(
-                kw in intent_lower
-                for kw in ["dem", "elevation", "terrain", "height", "topograph"]
-            ):
-                params["collections"] = ["cop-dem-glo-30"]
-            elif any(
-                kw in intent_lower
-                for kw in [
-                    "ndvi",
-                    "evi",
-                    "vegetation",
-                    "spectral",
-                    "band",
-                    "imagery",
-                ]
-            ):
-                params["collections"] = ["sentinel-2-l2a"]
-
         # Add cloud cover filter only for imagery collections (not DEM/land cover)
         # Heuristic: imagery collections often contain these keywords
         current_collections = set(params.get("collections", []))

--- a/geoagent/core/planner.py
+++ b/geoagent/core/planner.py
@@ -15,87 +15,8 @@ logger = logging.getLogger(__name__)
 # Comprehensive mapping from query keywords/topics to Planetary Computer
 # collection IDs.  Used by the Planner as a fallback when the LLM does not
 # set a dataset explicitly.
-COLLECTION_MAPPING: Dict[str, str] = {
-    # Optical Imagery
-    "sentinel-2": "sentinel-2-l2a",
-    "sentinel 2": "sentinel-2-l2a",
-    "landsat": "landsat-c2-l2",
-    "hls": "hls-l30",
-    "naip": "naip",
-    "aster": "aster-l1t",
-    # SAR / Radar
-    "sentinel-1": "sentinel-1-grd",
-    "sentinel 1": "sentinel-1-grd",
-    "radar": "sentinel-1-grd",
-    "sar": "sentinel-1-grd",
-    "sentinel-1 rtc": "sentinel-1-rtc",
-    "alos palsar": "alos-dem",
-    # Elevation / DEM / Terrain
-    "elevation": "cop-dem-glo-30",
-    "dem": "cop-dem-glo-30",
-    "terrain": "cop-dem-glo-30",
-    "copernicus dem": "cop-dem-glo-30",
-    "nasadem": "nasadem",
-    "alos dem": "alos-dem",
-    "alos world": "alos-dem",
-    "lidar": "3dep-lidar-dsm",
-    "lidar height": "3dep-lidar-hag",
-    "3dep": "3dep-lidar-dsm",
-    # Land Cover
-    "land cover": "io-lulc-9-class",
-    "land use": "io-lulc-9-class",
-    "lulc": "io-lulc-9-class",
-    "cropland": "usda-cdl",
-    "crop": "usda-cdl",
-    # Vegetation
-    "ndvi": "sentinel-2-l2a",
-    "vegetation index": "modis-13Q1-061",
-    "vegetation indices": "modis-13Q1-061",
-    "modis vegetation": "modis-13Q1-061",
-    "evi": "modis-13Q1-061",
-    "leaf area": "modis-15A2H-061",
-    "lai": "modis-15A2H-061",
-    "net production": "modis-17A2H-061",
-    "npp": "modis-17A2H-061",
-    "gross primary": "modis-17A2H-061",
-    "gpp": "modis-17A2H-061",
-    # Water
-    "surface water": "jrc-gsw",
-    "water": "jrc-gsw",
-    "flood": "sentinel-1-grd",
-    "ndwi": "sentinel-2-l2a",
-    "mndwi": "sentinel-2-l2a",
-    # Fire / Thermal
-    "fire": "modis-14A1-061",
-    "wildfire": "modis-14A1-061",
-    "thermal anomaly": "modis-14A1-061",
-    "thermal anomalies": "modis-14A1-061",
-    "burn": "modis-14A1-061",
-    "burned area": "modis-14A1-061",
-    "burn severity": "modis-14A1-061",
-    # Temperature
-    "temperature": "modis-11A1-061",
-    "surface temperature": "modis-11A1-061",
-    "land surface temperature": "modis-11A1-061",
-    "lst": "modis-11A1-061",
-    "sea surface temperature": "modis-11A1-061",
-    "sst": "modis-11A1-061",
-    # Snow / Ice
-    "snow": "modis-10A1-061",
-    "snow cover": "modis-10A1-061",
-    "ice": "modis-10A1-061",
-    # Atmosphere
-    "albedo": "modis-43A3-061",
-    "brdf": "modis-43A4-061",
-    "nadir brdf": "modis-43A4-061",
-    "reflectance": "modis-09A1-061",
-    "surface reflectance": "modis-09A1-061",
-    # Other
-    "nightlight": "viirs-nighttime-lights",
-    "night light": "viirs-nighttime-lights",
-    "population": "gridded-pop",
-    "buildings": "ms-buildings",
-}
+# NOTE: COLLECTION_MAPPING has been removed. Collections are now dynamically 
+# fetched from STAC catalogs via CatalogRegistry.get_collection_index().
 
 
 class _PlannerLLMSchema(BaseModel):
@@ -164,22 +85,9 @@ If no collection fits, leave dataset as None.
 
 {collections}
 
-Collection mapping guidance (use these when the query mentions a topic but
-not a specific collection):
-- Surface water / flood mapping → "jrc-gsw" or "sentinel-1-grd"
-- Fire / wildfire / burn / thermal anomaly → "modis-14A1-061"
-- Snow / ice cover → "modis-10A1-061"
-- Surface temperature / LST / SST → "modis-11A1-061"
-- Vegetation indices (MODIS) → "modis-13Q1-061"
-- Leaf area index → "modis-15A2H-061"
-- Net primary production / GPP → "modis-17A2H-061"
-- Nighttime lights → "viirs-nighttime-lights"
-- Cropland / crop type → "usda-cdl"
-- Population density → "gridded-pop"
-- Building footprints → "ms-buildings"
-- LIDAR / 3DEP → "3dep-lidar-dsm"
-- NAIP aerial imagery → "naip"
-- HLS (Harmonized Landsat Sentinel) → "hls-l30"
+Choose the most appropriate collection from the available catalog list above.
+The LLM should analyze the query and select the best-matching collection ID
+from the dynamically-provided collection list.
 
 CRITICAL RULES:
 - Only use "sentinel-2-l2a" when the user explicitly asks for satellite imagery, spectral indices (NDVI, EVI), or Sentinel-2
@@ -451,31 +359,8 @@ class Planner:
         except Exception:
             pass
 
-    @staticmethod
-    def _resolve_collection(
-        intent: str,
-        analysis_type: Optional[str] = None,
-    ) -> Optional[str]:
-        """Resolve a Planetary Computer collection ID from query context.
-
-        Uses :data:`COLLECTION_MAPPING` to find the best-matching collection
-        when the LLM did not set one explicitly.
-
-        Args:
-            intent: The raw intent / query string.
-            analysis_type: Optional analysis type hint (e.g. ``"fire_detection"``).
-
-        Returns:
-            A collection ID string, or ``None`` if no match was found.
-        """
-        text = f"{intent} {analysis_type or ''}".lower()
-
-        # Try longest keys first for more specific matches (e.g. "land cover"
-        # before "land").
-        for key in sorted(COLLECTION_MAPPING, key=len, reverse=True):
-            if key in text:
-                return COLLECTION_MAPPING[key]
-        return None
+    # NOTE: _resolve_collection() method removed - collections are now resolved
+    # dynamically from STAC catalogs via the LLM using the provided collection list.
 
     @staticmethod
     def _convert_to_planner_output(result: _PlannerLLMSchema) -> PlannerOutput:
@@ -505,13 +390,8 @@ class Planner:
         if result.max_items is not None:
             parameters["max_items"] = result.max_items
 
-        # Resolve collection via COLLECTION_MAPPING when LLM left dataset empty
+        # Use dataset directly from LLM output (no fallback collection mapping)
         dataset = result.dataset
-        if not dataset:
-            dataset = Planner._resolve_collection(
-                result.intent.value,
-                result.analysis_type,
-            )
 
         return PlannerOutput(
             intent=result.intent.value,

--- a/geoagent/core/planner.py
+++ b/geoagent/core/planner.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # Comprehensive mapping from query keywords/topics to Planetary Computer
 # collection IDs.  Used by the Planner as a fallback when the LLM does not
 # set a dataset explicitly.
-# NOTE: COLLECTION_MAPPING has been removed. Collections are now dynamically 
+# NOTE: COLLECTION_MAPPING has been removed. Collections are now dynamically
 # fetched from STAC catalogs via CatalogRegistry.get_collection_index().
 
 

--- a/geoagent/core/tools/stac.py
+++ b/geoagent/core/tools/stac.py
@@ -97,21 +97,13 @@ def search_stac(
             client = None
 
         if not client:
-            # Default catalog URLs
-            catalog_urls = {
-                "microsoft-pc": "https://planetarycomputer.microsoft.com/api/stac/v1",
-                "earth-search": "https://earth-search.aws.element84.com/v1",
-                "usgs-landsat": "https://landsatlook.usgs.gov/stac-server",
-                "cop-dem": "https://copernicus-dem-30m.s3.amazonaws.com/stac/catalog.json",
-            }
-
-            catalog_url = catalog_urls.get(catalog, catalog)
-            if not catalog_url.startswith("http"):
-                raise ValueError(
-                    f"Unknown catalog '{catalog}'. Available: {list(catalog_urls.keys())}"
-                )
-
-            client = Client.open(catalog_url)
+            # Fallback to creating client directly with URL if registry not available
+            from geoagent.catalogs.registry import get_registry
+            try:
+                registry = get_registry()
+                client = registry.get_client(catalog)
+            except Exception as e:
+                raise ValueError(f"Failed to get catalog client '{catalog}': {e}")
 
         # Build search parameters
         search_params = {}
@@ -227,15 +219,13 @@ def get_stac_collections(catalog: str = "microsoft-pc") -> List[Dict[str, Any]]:
             client = None
 
         if not client:
-            # Default catalog URLs
-            catalog_urls = {
-                "microsoft-pc": "https://planetarycomputer.microsoft.com/api/stac/v1",
-                "earth-search": "https://earth-search.aws.element84.com/v1",
-                "usgs-landsat": "https://landsatlook.usgs.gov/stac-server",
-            }
-
-            catalog_url = catalog_urls.get(catalog, catalog)
-            client = Client.open(catalog_url)
+            # Fallback to creating client via registry
+            from geoagent.catalogs.registry import get_registry
+            try:
+                registry = get_registry()
+                client = registry.get_client(catalog)
+            except Exception as e:
+                raise RuntimeError(f"Failed to get catalog client '{catalog}': {e}")
 
         collections = []
         for collection in client.get_collections():

--- a/geoagent/core/tools/stac.py
+++ b/geoagent/core/tools/stac.py
@@ -99,6 +99,7 @@ def search_stac(
         if not client:
             # Fallback to creating client directly with URL if registry not available
             from geoagent.catalogs.registry import get_registry
+
             try:
                 registry = get_registry()
                 client = registry.get_client(catalog)
@@ -221,6 +222,7 @@ def get_stac_collections(catalog: str = "microsoft-pc") -> List[Dict[str, Any]]:
         if not client:
             # Fallback to creating client via registry
             from geoagent.catalogs.registry import get_registry
+
             try:
                 registry = get_registry()
                 client = registry.get_client(catalog)


### PR DESCRIPTION
## Summary

Removes hardcoded dataset/collection mappings throughout the codebase. Collections are now resolved entirely through the dynamic STAC catalog retrieval system (`CatalogRegistry.get_collection_index()`) that was already in place but underutilized.

## Changes

### `geoagent/core/planner.py`
- Removed `COLLECTION_MAPPING` dict (~80 hardcoded keyword→collection ID mappings)
- Removed hardcoded "Collection mapping guidance" section from `SYSTEM_PROMPT`
- Removed `_resolve_collection()` static method and its fallback usage
- The LLM now relies on the dynamically-fetched collection list injected via `{collections}` in the prompt

### `geoagent/core/data_agent.py`
- Removed hardcoded collection resolution block in `_build_stac_params()` (the big if/elif chain mapping analysis_type → collection IDs)
- Simplified to use `plan.dataset` directly from the planner

### `geoagent/core/tools/stac.py`
- Replaced hardcoded `catalog_urls` fallback dicts with proper `CatalogRegistry` usage in both `search_stac()` and `get_stac_collections()`

### `geoagent/core/agent.py`
- Removed hardcoded dataset mappings in `_parse_query_fallback()`
- Removed `sentinel-2-l2a` default fallback in `_generate_search_code()`

## Stats
- **4 files changed**: 31 insertions, 217 deletions
- All tests pass ✅
- Pre-commit clean ✅

## What's preserved
- `BUILTIN_CATALOGS` in `registry.py` (STAC API endpoints — these are fine)
- `CatalogRegistry` class and `get_collection_index()`
- `SYSTEM_PROMPT` examples and intent mapping
- `Planner.__init__` collections parameter and prompt formatting