### PR TITLE
feat: v1.0 DeepAgents-based rewrite — Phase 1 foundation

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -33,7 +33,7 @@ jobs:
               run: codespell --skip="*.csv,*.geojson,*.json,*.js,*.html,*cff,*.pdf,./.git" --ignore-words-list="aci,acount,alos,hist"
             - name: PKG-TEST
               run: |
-                  python -m unittest discover tests/
+                  pytest tests/ -v
             - name: Build docs
               run: |
                   mkdocs build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,6 @@ jobs:
                   codespell --skip="*.csv,*.geojson,*.json,*.js,*.html,*cff,./.git" --ignore-words-list="aci,alos,hist"
             - name: PKG-TEST
               run: |
-                  python -m unittest discover tests/
+                  pytest tests/ -v
             - run: mkdocs gh-deploy --force
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,6 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { os: ubuntu-latest, py: "3.10" }
                     - { os: ubuntu-latest, py: "3.11" }
                     - { os: ubuntu-latest, py: "3.12" }
                     - { os: ubuntu-latest, py: "3.13" }
@@ -40,8 +39,8 @@ jobs:
             - name: Install dependencies
               run: |
                   pip install --user -r requirements.txt
+                  pip install pytest
                   pip install .
             - name: PKG-TEST
               run: |
-                  python -m unittest discover tests/
-
+                  pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -9,25 +9,42 @@
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/geoagent.svg)](https://anaconda.org/conda-forge/geoagent)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-An AI agent for geospatial data analysis and visualization.
+A centralized AI agent framework for Open Geospatial Python packages and QGIS plugins. GeoAgent is the shared AI layer that lets `leafmap`, `anymap`, `geoai`, `geemap`, and QGIS plugins (GeoAI, GEE Data Catalogs, NASA Earthdata, ...) plug their tools into a common agent runtime built on [DeepAgents](https://github.com/langchain-ai/deepagents) without each project re-implementing its own orchestration.
 
 - **Documentation**: <https://geoagent.gishub.org>
 - **Source code**: <https://github.com/opengeos/GeoAgent>
 - **PyPI**: <https://pypi.python.org/pypi/geoagent>
 
+## Why a centralized agent layer?
+
+Downstream packages should focus on what they do best — mapping, ML, data access — and leave agent orchestration to a single place. GeoAgent provides:
+
+- A **DeepAgents-based core** that handles tool calling, subagent dispatch, human-in-the-loop confirmation, and conversation state.
+- **Tool adapters** that wrap live runtime objects (a `leafmap.Map`, an `anymap.Map`, the QGIS `iface`, a GeoAI workflow) into LangChain tools the agent can call directly.
+- A **`@geo_tool` decorator** with safety classification so destructive operations (remove, save, export, download, run-processing) require user approval before they execute.
+- A **runtime context** (`GeoAgentContext`) that carries the current map, QGIS interface, working directory, and user preferences into every tool invocation.
+- **Per-package helpers** — `geoagent.for_leafmap(m)`, `geoagent.for_anymap(m)`, `geoagent.for_qgis(iface)` — that build a ready-to-use agent in one line.
+
+Downstream packages register their own tools via `register_many(my_tools)` and instantiate an agent via `geoagent.create_geo_agent(...)`; they do not depend on `langgraph`, `langchain-openai`, or any LLM SDK directly.
+
 ## Features
 
-- Natural language interface for geospatial data workflows
-- 4-agent LangGraph pipeline: Planner, Data, Analysis, Visualization
-- Multi-LLM support (OpenAI, Anthropic, Google Gemini, Ollama)
-- Multi-catalog STAC search (Earth Search, Planetary Computer, USGS, NASA CMR)
-- Code transparency showing generated Python code at each step
-- Jupyter-native with interactive MapLibre maps via leafmap
-- DuckDB spatial SQL for GeoParquet and Overture Maps
-- Raster analysis with xarray, rioxarray, and rasterio
-- Vector operations with geopandas
+- **Centralized agent runtime** built on [DeepAgents](https://github.com/langchain-ai/deepagents) (LangGraph under the hood)
+- **Live map control** for `leafmap.Map` and `anymap.Map`: list/add/remove layers, zoom, pan, change basemap, save HTML
+- **QGIS plugin integration**, import-safe outside QGIS — the `qgis` package is never imported at module load
+- **GeoAI workflows**: segmentation, object detection, image classification (when `geoai` is installed)
+- **Earth Engine** and **NASA Earthdata** tools (opt-in extras)
+- **STAC search** across Earth Search, Planetary Computer, USGS, and NASA CMR catalogs
+- **Spatial SQL** with DuckDB for GeoParquet and Overture Maps
+- **Raster** (xarray / rioxarray / rasterio) and **vector** (geopandas) analysis tools
+- **Multi-LLM support**: OpenAI, Anthropic, Google Gemini, Ollama
+- **Human-in-the-loop confirmation** via a pluggable `ConfirmCallback` for destructive operations
+- **Code transparency** — generated Python code is returned for reproducibility
+- **Mock-friendly testing** with `geoagent.testing` mocks for leafmap, anymap, and QGIS
 
 ## Installation
+
+GeoAgent v1.0 requires **Python 3.11+**.
 
 ```bash
 pip install geoagent
@@ -39,71 +56,67 @@ Or install from conda-forge:
 conda install -c conda-forge geoagent
 ```
 
-With all optional dependencies:
+### Optional extras
+
+Pick the extras you need; the base install stays lightweight.
+
+| Extra | Adds | When to install |
+|---|---|---|
+| `[openai]` | `langchain-openai` | OpenAI / Azure OpenAI models |
+| `[anthropic]` | `langchain-anthropic` | Anthropic Claude models |
+| `[google]` | `langchain-google-genai` | Google Gemini models |
+| `[ollama]` | `langchain-ollama` | Local Ollama models |
+| `[llm]` | all of the above |  |
+| `[anymap]` | `anymap` | anymap-based maps |
+| `[geoai]` | `geoai` | GeoAI segmentation / detection / classification |
+| `[earthengine]` | `earthengine-api` | Google Earth Engine |
+| `[nasa_earthdata]` | `earthaccess` | NASA Earthdata search & download |
+| `[ui]` | `solara` | the Solara web UI |
+| `[all]` | everything above |  |
 
 ```bash
-pip install "geoagent[all]"
+# Common combos
+pip install "geoagent[openai,leafmap]"       # leafmap + OpenAI agent
+pip install "geoagent[anthropic,geoai]"      # Claude + GeoAI segmentation
+pip install "geoagent[ollama]"               # local LLM only
+pip install "geoagent[all]"                  # everything
 ```
 
-## LLM Setup
+QGIS itself is environment-installed (system package), so the `[qgis]` marker extra exists for completeness; the QGIS tools auto-detect QGIS at runtime.
+
+## LLM setup
 
 GeoAgent supports multiple LLM providers. You need at least one configured to use the agent.
 
-### Supported Providers
+| Provider       | Default Model                | API Key Env Variable | Install Extra                       |
+| -------------- | ---------------------------- | -------------------- | ----------------------------------- |
+| OpenAI         | `gpt-4.1`                    | `OPENAI_API_KEY`     | `pip install "geoagent[openai]"`    |
+| Anthropic      | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[anthropic]"` |
+| Google Gemini  | `gemini-2.5-flash`           | `GOOGLE_API_KEY`     | `pip install "geoagent[google]"`    |
+| Ollama (local) | `llama3.1`                   | *(none needed)*      | `pip install "geoagent[ollama]"`    |
 
-| Provider       | Default Model                | API Key Env Variable | Install Extra                    |
-| -------------- | ---------------------------- | -------------------- | -------------------------------- |
-| OpenAI         | `gpt-4.1`                    | `OPENAI_API_KEY`     | *(included)*                     |
-| Anthropic      | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[llm]"`    |
-| Google Gemini  | `gemini-2.5-flash`           | `GOOGLE_API_KEY`     | `pip install "geoagent[llm]"`    |
-| Ollama (local) | `llama3.1`                   | *(none needed)*      | `pip install "geoagent[ollama]"` |
-
-### Setting API Keys
-
-Set your API key as an environment variable:
+### Setting API keys
 
 ```bash
-# OpenAI (included by default)
 export OPENAI_API_KEY="your-openai-key"
-
-# Anthropic
 export ANTHROPIC_API_KEY="your-anthropic-key"
-
-# Google Gemini
 export GOOGLE_API_KEY="your-google-key"
 ```
 
-You can also add these to a `.env` file or your shell profile (`~/.bashrc`, `~/.zshrc`).
-
-### Choosing a Provider
-
-By default, GeoAgent auto-detects available providers by checking environment variables in order: OpenAI → Anthropic → Google → Ollama. The first available provider is used.
-
-To specify a provider and model explicitly:
+By default, GeoAgent auto-detects the first provider with credentials in the order OpenAI → Anthropic → Google → Ollama. To pick a provider and model explicitly:
 
 ```python
 from geoagent import GeoAgent
 
-# Use the default provider (auto-detected)
-agent = GeoAgent()
-
-# Use a specific provider
-agent = GeoAgent(provider="anthropic")
-
-# Use a specific provider and model
-agent = GeoAgent(provider="openai", model="gpt-4o-mini")
-agent = GeoAgent(provider="google", model="gemini-2.5-flash")
+agent = GeoAgent()                                          # auto-detect
+agent = GeoAgent(provider="anthropic")                      # named provider
+agent = GeoAgent(provider="openai", model="gpt-4o-mini")    # provider + model
 ```
 
-### Using Ollama (Local LLMs)
-
-To run GeoAgent with a local LLM via [Ollama](https://ollama.com/), no API key is needed:
+### Local LLMs via Ollama
 
 ```bash
-# Install Ollama and pull a model
 ollama pull llama3.1
-
-# Install the Ollama extra
 pip install "geoagent[ollama]"
 ```
 
@@ -111,9 +124,7 @@ pip install "geoagent[ollama]"
 agent = GeoAgent(provider="ollama", model="llama3.1")
 ```
 
-### Using a Custom LLM Instance
-
-You can pass any LangChain-compatible chat model directly:
+### Custom LangChain chat model
 
 ```python
 from langchain_openai import ChatOpenAI
@@ -122,15 +133,96 @@ llm = ChatOpenAI(model="gpt-4o", temperature=0.0)
 agent = GeoAgent(llm=llm)
 ```
 
-## Quick Start
+## Quick start
 
 ```python
 from geoagent import GeoAgent
 
 agent = GeoAgent()
 result = agent.chat("Show NDVI for San Francisco in July 2024")
-result.map   # displays interactive map in Jupyter
-print(result.code)  # shows the generated Python code
+result.map          # interactive map widget for Jupyter
+print(result.code)  # the generated Python code
+```
+
+## Working with a live map (leafmap / anymap)
+
+```python
+import leafmap
+from geoagent import for_leafmap
+
+m = leafmap.Map(center=[35.96, -83.92], zoom=10)
+agent = for_leafmap(m)
+
+agent.invoke({"messages": [
+    {"role": "user", "content": "Add a Sentinel-2 layer for Knoxville and zoom to it."}
+]})
+
+m  # the agent has mutated the map in place
+```
+
+The same pattern works for `anymap`:
+
+```python
+from anymap import Map
+from geoagent import for_anymap
+
+agent = for_anymap(Map())
+```
+
+## Working from a QGIS plugin
+
+```python
+from qgis.utils import iface
+from geoagent import for_qgis
+
+agent = for_qgis(iface)
+agent.invoke({"messages": [
+    {"role": "user", "content": "Zoom to the active layer and list all project layers."}
+]})
+```
+
+The QGIS adapter is **import-safe outside QGIS**: `import geoagent.tools.qgis` works on any Python and the tool list is empty until a real `iface` is supplied. You can also pre-build agents in headless tests with the supplied mocks.
+
+## Safety and confirmation
+
+Tools are classified as either safe (inspect, list, zoom, pan, get-state, generate-code) or **confirmation-required** (remove, delete, save, export, download, run long processing jobs, submit Earth Engine tasks). Confirmation-required tools are wired into deepagents' `interrupt_on` so the agent pauses before they execute.
+
+The host application supplies a `ConfirmCallback` to bridge those interrupts to its UI:
+
+```python
+from geoagent import GeoAgent, ConfirmRequest
+
+def confirm(request: ConfirmRequest) -> bool:
+    print(f"Approve {request.tool_name}({request.args})? [y/N]")
+    return input().strip().lower() == "y"
+
+agent = GeoAgent(confirm=confirm)
+```
+
+Built-in callbacks ship for Jupyter (`input()` prompt), Solara (modal dialog), and CLI (`y/N`); the default `auto_approve_safe_only` rejects every confirmation request, so confirmation-required tools never run silently.
+
+## Defining your own tool
+
+Tools are plain Python functions wrapped with `@geo_tool`. The decorator produces a LangChain `BaseTool`, so the result plugs straight into `create_geo_agent(tools=[...])`.
+
+```python
+from geoagent import geo_tool, create_geo_agent
+
+@geo_tool(category="data", requires_confirmation=False)
+def search_my_catalog(query: str, limit: int = 10) -> list[dict]:
+    """Search a domain-specific catalog and return matches."""
+    ...
+
+agent = create_geo_agent(tools=[search_my_catalog])
+```
+
+Confirmation-required tools auto-populate `interrupt_on`:
+
+```python
+@geo_tool(category="io", requires_confirmation=True)
+def overwrite_dataset(path: str) -> str:
+    """Overwrite an existing dataset."""
+    ...
 ```
 
 ## Web UI
@@ -165,12 +257,29 @@ launch_ui()
 
 ## Architecture
 
-GeoAgent uses a 4-agent pipeline orchestrated by LangGraph:
+```
+geoagent/
+├── core/             # @geo_tool, GeoAgentContext, registry, safety, factory
+├── tools/            # leafmap / anymap / qgis / geoai / earthengine /
+│   └── data/         #   nasa_earthdata / stac + raster, vector, duckdb, viz
+├── agents/           # subagent specs (mapping, qgis, geoai, earthdata, ...)
+├── integrations/     # jupyter, qgis plugin, solara, cli helpers
+├── testing/          # MockLeafmap, MockAnymap, MockQGISIface, MockQGISProject
+└── ui/               # Solara pages
+```
 
-1. **Planner** parses natural language into structured parameters
-2. **Data Agent** searches STAC catalogs and retrieves geospatial data
-3. **Analysis Agent** computes indices and statistics with transparent code generation
-4. **Visualization Agent** renders results on interactive leafmap MapLibre maps
+The runtime is a [DeepAgents](https://github.com/langchain-ai/deepagents) `create_deep_agent` graph configured with:
+
+- **Tools** assembled by per-package factories (`leafmap_tools(m)`, `qgis_tools(iface)`, ...) and registered with `@geo_tool` metadata
+- **Subagents** for planning, data search, raster/vector analysis, mapping, QGIS, GeoAI, and Earthdata workflows
+- **`interrupt_on`** auto-built from tool metadata for human-in-the-loop confirmation
+- **`context_schema=GeoAgentContext`** to carry runtime state into tools
+
+## Migration from v0.x
+
+GeoAgent v1.0 is a substantial rewrite. The core public API (`from geoagent import GeoAgent; agent.chat(...)`) is preserved, but internals are now built on [DeepAgents](https://github.com/langchain-ai/deepagents) and require Python 3.11+. The legacy LangChain 0.3 / LangGraph 0.2 stack is no longer used; deepagents pulls LangChain 1.x transitively.
+
+If you held references to legacy modules under `geoagent.core.tools.*`, they continue to work as-is for now and are also re-exported (with `@geo_tool` metadata) from the new `geoagent.tools.*` and `geoagent.tools.data.*` paths.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,95 +9,116 @@
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/geoagent.svg)](https://anaconda.org/conda-forge/geoagent)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-An AI agent for geospatial data analysis and visualization.
+A centralized AI agent framework for Open Geospatial Python packages and QGIS plugins. GeoAgent is the shared AI layer that lets `leafmap`, `anymap`, `geoai`, `geemap`, and QGIS plugins (GeoAI, GEE Data Catalogs, NASA Earthdata, ...) plug their tools into a common agent runtime built on [DeepAgents](https://github.com/langchain-ai/deepagents) without each project re-implementing its own orchestration.
 
 - **Documentation**: <https://geoagent.gishub.org>
 - **Source code**: <https://github.com/opengeos/GeoAgent>
 - **PyPI**: <https://pypi.python.org/pypi/geoagent>
 
+## Why a centralized agent layer?
+
+Downstream packages should focus on what they do best — mapping, ML, data access — and leave agent orchestration to a single place. GeoAgent provides:
+
+- A **DeepAgents-based core** that handles tool calling, subagent dispatch, human-in-the-loop confirmation, and conversation state.
+- **Tool adapters** that wrap live runtime objects (a `leafmap.Map`, an `anymap.Map`, the QGIS `iface`, a GeoAI workflow) into LangChain tools the agent can call directly.
+- A **`@geo_tool` decorator** with safety classification so destructive operations (remove, save, export, download, run-processing) require user approval before they execute.
+- A **runtime context** (`GeoAgentContext`) that carries the current map, QGIS interface, working directory, and user preferences into every tool invocation.
+- **Per-package helpers** — `geoagent.for_leafmap(m)`, `geoagent.for_anymap(m)`, `geoagent.for_qgis(iface)` — that build a ready-to-use agent in one line.
+
+Downstream packages register their own tools via `register_many(my_tools)` and instantiate an agent via `geoagent.create_geo_agent(...)`; they do not depend on `langgraph`, `langchain-openai`, or any LLM SDK directly.
+
 ## Features
 
-- Natural language interface for geospatial data workflows
-- 4-agent LangGraph pipeline: Planner, Data, Analysis, Visualization
-- Multi-LLM support (OpenAI, Anthropic, Google Gemini, Ollama)
-- Multi-catalog STAC search (Earth Search, Planetary Computer, USGS, NASA CMR)
-- Code transparency showing generated Python code at each step
-- Jupyter-native with interactive MapLibre maps via leafmap
-- DuckDB spatial SQL for GeoParquet and Overture Maps
-- Raster analysis with xarray, rioxarray, and rasterio
-- Vector operations with geopandas
+- **Centralized agent runtime** built on [DeepAgents](https://github.com/langchain-ai/deepagents) (LangGraph under the hood)
+- **Live map control** for `leafmap.Map` and `anymap.Map`: list/add/remove layers, zoom, pan, change basemap, save HTML
+- **QGIS plugin integration**, import-safe outside QGIS — the `qgis` package is never imported at module load
+- **GeoAI workflows**: segmentation, object detection, image classification (when `geoai` is installed)
+- **Earth Engine** and **NASA Earthdata** tools (opt-in extras)
+- **STAC search** across Earth Search, Planetary Computer, USGS, and NASA CMR catalogs
+- **Spatial SQL** with DuckDB for GeoParquet and Overture Maps
+- **Raster** (xarray / rioxarray / rasterio) and **vector** (geopandas) analysis tools
+- **Multi-LLM support**: OpenAI, Anthropic, Google Gemini, Ollama
+- **Human-in-the-loop confirmation** via a pluggable `ConfirmCallback` for destructive operations
+- **Code transparency** — generated Python code is returned for reproducibility
+- **Mock-friendly testing** with `geoagent.testing` mocks for leafmap, anymap, and QGIS
 
 ## Installation
+
+GeoAgent v1.0 requires **Python 3.11+**.
 
 ```bash
 pip install geoagent
 ```
 
-With all optional dependencies:
+### Optional extras
+
+Pick the extras you need; the base install stays lightweight.
+
+| Extra | Adds | When to install |
+|---|---|---|
+| `[openai]` | `langchain-openai` | OpenAI / Azure OpenAI models |
+| `[anthropic]` | `langchain-anthropic` | Anthropic Claude models |
+| `[google]` | `langchain-google-genai` | Google Gemini models |
+| `[ollama]` | `langchain-ollama` | Local Ollama models |
+| `[llm]` | all of the above |  |
+| `[anymap]` | `anymap` | anymap-based maps |
+| `[geoai]` | `geoai` | GeoAI segmentation / detection / classification |
+| `[earthengine]` | `earthengine-api` | Google Earth Engine |
+| `[nasa_earthdata]` | `earthaccess` | NASA Earthdata search & download |
+| `[ui]` | `solara` | the Solara web UI |
+| `[all]` | everything above |  |
 
 ```bash
-pip install "geoagent[all]"
+pip install "geoagent[openai,leafmap]"       # leafmap + OpenAI agent
+pip install "geoagent[anthropic,geoai]"      # Claude + GeoAI segmentation
+pip install "geoagent[ollama]"               # local LLM only
+pip install "geoagent[all]"                  # everything
 ```
 
-## LLM Setup
+QGIS itself is environment-installed (system package), so the `[qgis]` marker extra exists for completeness; the QGIS tools auto-detect QGIS at runtime.
+
+## LLM setup
 
 GeoAgent supports multiple LLM providers. You need at least one configured to use the agent.
 
-### Supported Providers
+### Supported providers
 
-| Provider       | Default Model                | API Key Env Variable | Install Extra                    |
-| -------------- | ---------------------------- | -------------------- | -------------------------------- |
-| OpenAI         | `gpt-4.1`                    | `OPENAI_API_KEY`     | *(included)*                     |
-| Anthropic      | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[llm]"`    |
-| Google Gemini  | `gemini-2.5-flash`           | `GOOGLE_API_KEY`     | `pip install "geoagent[llm]"`    |
-| Ollama (local) | `llama3.1`                   | *(none needed)*      | `pip install "geoagent[ollama]"` |
+| Provider       | Default Model                | API Key Env Variable | Install Extra                       |
+| -------------- | ---------------------------- | -------------------- | ----------------------------------- |
+| OpenAI         | `gpt-4.1`                    | `OPENAI_API_KEY`     | `pip install "geoagent[openai]"`    |
+| Anthropic      | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[anthropic]"` |
+| Google Gemini  | `gemini-2.5-flash`           | `GOOGLE_API_KEY`     | `pip install "geoagent[google]"`    |
+| Ollama (local) | `llama3.1`                   | *(none needed)*      | `pip install "geoagent[ollama]"`    |
 
-### Setting API Keys
-
-Set your API key as an environment variable:
+### Setting API keys
 
 ```bash
-# OpenAI (included by default)
 export OPENAI_API_KEY="your-openai-key"
-
-# Anthropic
 export ANTHROPIC_API_KEY="your-anthropic-key"
-
-# Google Gemini
 export GOOGLE_API_KEY="your-google-key"
 ```
 
 You can also add these to a `.env` file or your shell profile (`~/.bashrc`, `~/.zshrc`).
 
-### Choosing a Provider
+### Choosing a provider
 
-By default, GeoAgent auto-detects available providers by checking environment variables in order: OpenAI → Anthropic → Google → Ollama. The first available provider is used.
-
-To specify a provider and model explicitly:
+By default, GeoAgent auto-detects the first provider with credentials in the order OpenAI → Anthropic → Google → Ollama.
 
 ```python
 from geoagent import GeoAgent
 
-# Use the default provider (auto-detected)
-agent = GeoAgent()
-
-# Use a specific provider
-agent = GeoAgent(provider="anthropic")
-
-# Use a specific provider and model
-agent = GeoAgent(provider="openai", model="gpt-4o-mini")
+agent = GeoAgent()                                          # auto-detect
+agent = GeoAgent(provider="anthropic")                      # named provider
+agent = GeoAgent(provider="openai", model="gpt-4o-mini")    # provider + model
 agent = GeoAgent(provider="google", model="gemini-2.5-flash")
 ```
 
-### Using Ollama (Local LLMs)
+### Using Ollama (local LLMs)
 
 To run GeoAgent with a local LLM via [Ollama](https://ollama.com/), no API key is needed:
 
 ```bash
-# Install Ollama and pull a model
 ollama pull llama3.1
-
-# Install the Ollama extra
 pip install "geoagent[ollama]"
 ```
 
@@ -105,7 +126,7 @@ pip install "geoagent[ollama]"
 agent = GeoAgent(provider="ollama", model="llama3.1")
 ```
 
-### Using a Custom LLM Instance
+### Using a custom LLM instance
 
 You can pass any LangChain-compatible chat model directly:
 
@@ -116,15 +137,96 @@ llm = ChatOpenAI(model="gpt-4o", temperature=0.0)
 agent = GeoAgent(llm=llm)
 ```
 
-## Quick Start
+## Quick start
 
 ```python
 from geoagent import GeoAgent
 
 agent = GeoAgent()
 result = agent.chat("Show NDVI for San Francisco in July 2024")
-result.map   # displays interactive map in Jupyter
-print(result.code)  # shows the generated Python code
+result.map          # interactive map widget for Jupyter
+print(result.code)  # the generated Python code
+```
+
+## Working with a live map (leafmap / anymap)
+
+```python
+import leafmap
+from geoagent import for_leafmap
+
+m = leafmap.Map(center=[35.96, -83.92], zoom=10)
+agent = for_leafmap(m)
+
+agent.invoke({"messages": [
+    {"role": "user", "content": "Add a Sentinel-2 layer for Knoxville and zoom to it."}
+]})
+
+m  # the agent has mutated the map in place
+```
+
+The same pattern works for `anymap`:
+
+```python
+from anymap import Map
+from geoagent import for_anymap
+
+agent = for_anymap(Map())
+```
+
+## Working from a QGIS plugin
+
+```python
+from qgis.utils import iface
+from geoagent import for_qgis
+
+agent = for_qgis(iface)
+agent.invoke({"messages": [
+    {"role": "user", "content": "Zoom to the active layer and list all project layers."}
+]})
+```
+
+The QGIS adapter is **import-safe outside QGIS**: `import geoagent.tools.qgis` works on any Python and the tool list is empty until a real `iface` is supplied. You can also pre-build agents in headless tests with the supplied mocks.
+
+## Safety and confirmation
+
+Tools are classified as either safe (inspect, list, zoom, pan, get-state, generate-code) or **confirmation-required** (remove, delete, save, export, download, run long processing jobs, submit Earth Engine tasks). Confirmation-required tools are wired into deepagents' `interrupt_on` so the agent pauses before they execute.
+
+The host application supplies a `ConfirmCallback` to bridge those interrupts to its UI:
+
+```python
+from geoagent import GeoAgent, ConfirmRequest
+
+def confirm(request: ConfirmRequest) -> bool:
+    print(f"Approve {request.tool_name}({request.args})? [y/N]")
+    return input().strip().lower() == "y"
+
+agent = GeoAgent(confirm=confirm)
+```
+
+Built-in callbacks ship for Jupyter (`input()` prompt), Solara (modal dialog), and CLI (`y/N`); the default `auto_approve_safe_only` rejects every confirmation request, so confirmation-required tools never run silently.
+
+## Defining your own tool
+
+Tools are plain Python functions wrapped with `@geo_tool`. The decorator produces a LangChain `BaseTool`, so the result plugs straight into `create_geo_agent(tools=[...])`.
+
+```python
+from geoagent import geo_tool, create_geo_agent
+
+@geo_tool(category="data", requires_confirmation=False)
+def search_my_catalog(query: str, limit: int = 10) -> list[dict]:
+    """Search a domain-specific catalog and return matches."""
+    ...
+
+agent = create_geo_agent(tools=[search_my_catalog])
+```
+
+Confirmation-required tools auto-populate `interrupt_on`:
+
+```python
+@geo_tool(category="io", requires_confirmation=True)
+def overwrite_dataset(path: str) -> str:
+    """Overwrite an existing dataset."""
+    ...
 ```
 
 ## Web UI
@@ -140,12 +242,29 @@ The UI opens on a home page — click **Chat** to start querying. See [Web UI](u
 
 ## Architecture
 
-GeoAgent uses a 4-agent pipeline orchestrated by LangGraph:
+```
+geoagent/
+├── core/             # @geo_tool, GeoAgentContext, registry, safety, factory
+├── tools/            # leafmap / anymap / qgis / geoai / earthengine /
+│   └── data/         #   nasa_earthdata / stac + raster, vector, duckdb, viz
+├── agents/           # subagent specs (mapping, qgis, geoai, earthdata, ...)
+├── integrations/     # jupyter, qgis plugin, solara, cli helpers
+├── testing/          # MockLeafmap, MockAnymap, MockQGISIface, MockQGISProject
+└── ui/               # Solara pages
+```
 
-1. **Planner** parses natural language into structured parameters
-2. **Data Agent** searches STAC catalogs and retrieves geospatial data
-3. **Analysis Agent** computes indices and statistics with transparent code generation
-4. **Visualization Agent** renders results on interactive leafmap MapLibre maps
+The runtime is a [DeepAgents](https://github.com/langchain-ai/deepagents) `create_deep_agent` graph configured with:
+
+- **Tools** assembled by per-package factories (`leafmap_tools(m)`, `qgis_tools(iface)`, ...) and registered with `@geo_tool` metadata
+- **Subagents** for planning, data search, raster/vector analysis, mapping, QGIS, GeoAI, and Earthdata workflows
+- **`interrupt_on`** auto-built from tool metadata for human-in-the-loop confirmation
+- **`context_schema=GeoAgentContext`** to carry runtime state into tools
+
+## Migration from v0.x
+
+GeoAgent v1.0 is a substantial rewrite. The core public API (`from geoagent import GeoAgent; agent.chat(...)`) is preserved, but internals are now built on [DeepAgents](https://github.com/langchain-ai/deepagents) and require Python 3.11+. The legacy LangChain 0.3 / LangGraph 0.2 stack is no longer used; deepagents pulls LangChain 1.x transitively.
+
+If you held references to legacy modules under `geoagent.core.tools.*`, they continue to work as-is for now and are also re-exported (with `@geo_tool` metadata) from the new `geoagent.tools.*` and `geoagent.tools.data.*` paths.
 
 ## License
 

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -13,6 +13,7 @@ from geoagent.core.decorators import (
     geo_tool,
     get_geo_meta,
     needs_confirmation,
+    stamp_geo_meta,
 )
 from geoagent.core.result import GeoAgentResponse
 from geoagent.core.safety import (
@@ -23,20 +24,15 @@ from geoagent.core.safety import (
     build_interrupt_on,
 )
 
-# Factory functions are lazily importable so deepagents missing doesn't
-# break `import geoagent`.
-try:
-    from geoagent.core.factory import (
-        create_geo_agent,
-        for_anymap,
-        for_leafmap,
-        for_qgis,
-    )
-except ImportError:  # pragma: no cover - exercised when deepagents missing
-    create_geo_agent = None  # type: ignore[assignment]
-    for_anymap = None  # type: ignore[assignment]
-    for_leafmap = None  # type: ignore[assignment]
-    for_qgis = None  # type: ignore[assignment]
+# Factory module imports deepagents lazily inside its function bodies, so
+# importing the factory itself should not fail when deepagents is absent.
+# Importing unconditionally avoids masking unrelated import-time errors.
+from geoagent.core.factory import (
+    create_geo_agent,
+    for_anymap,
+    for_leafmap,
+    for_qgis,
+)
 
 # Backward-compatible legacy GeoAgent class (Phase 2 will rebuild this on
 # top of the deepagents factory).
@@ -92,6 +88,7 @@ __all__ = [
     "geo_tool",
     "get_geo_meta",
     "needs_confirmation",
+    "stamp_geo_meta",
     "ConfirmCallback",
     "ConfirmRequest",
     "auto_approve_all",

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -1,56 +1,109 @@
-"""GeoAgent - An AI agent for geospatial data analysis and visualization."""
+"""GeoAgent - centralized AI agent framework for Open Geospatial tools."""
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.2.0"
+__version__ = "1.0.0"
 
-from geoagent.core.llm import get_llm, get_default_llm
+# LLM provider factory (always available)
+from geoagent.core.llm import get_llm, get_default_llm, resolve_model
 
+# New v1 surface
+from geoagent.core.context import GeoAgentContext
+from geoagent.core.decorators import (
+    geo_tool,
+    get_geo_meta,
+    needs_confirmation,
+)
+from geoagent.core.result import GeoAgentResponse
+from geoagent.core.safety import (
+    ConfirmCallback,
+    ConfirmRequest,
+    auto_approve_all,
+    auto_approve_safe_only,
+    build_interrupt_on,
+)
+
+# Factory functions are lazily importable so deepagents missing doesn't
+# break `import geoagent`.
+try:
+    from geoagent.core.factory import (
+        create_geo_agent,
+        for_anymap,
+        for_leafmap,
+        for_qgis,
+    )
+except ImportError:  # pragma: no cover - exercised when deepagents missing
+    create_geo_agent = None  # type: ignore[assignment]
+    for_anymap = None  # type: ignore[assignment]
+    for_leafmap = None  # type: ignore[assignment]
+    for_qgis = None  # type: ignore[assignment]
+
+# Backward-compatible legacy GeoAgent class (Phase 2 will rebuild this on
+# top of the deepagents factory).
 try:
     from geoagent.core.agent import GeoAgent
 except ImportError:
-    GeoAgent = None
+    GeoAgent = None  # type: ignore[assignment]
 
-# Import tool functions for direct use
+# Legacy v0.x tool re-exports (preserve names from the previous public API).
 try:
     from geoagent.core.tools.stac import search_stac, get_stac_collections
     from geoagent.core.tools.duckdb_tool import (
-        query_spatial_data,
-        query_overture,
         analyze_spatial_data,
+        query_overture,
+        query_spatial_data,
     )
     from geoagent.core.tools.raster import (
-        load_raster,
         compute_index,
+        load_raster,
         raster_to_array,
         zonal_stats,
     )
     from geoagent.core.tools.vector import (
+        analyze_geometries,
+        buffer_analysis,
         read_vector,
         spatial_filter,
-        buffer_analysis,
         spatial_join,
-        analyze_geometries,
     )
     from geoagent.core.tools.viz import (
-        show_on_map,
         add_cog_layer,
-        add_vector_layer,
-        split_map,
-        create_choropleth_map,
         add_pmtiles_layer,
+        add_vector_layer,
         create_3d_terrain_map,
+        create_choropleth_map,
         save_map,
+        show_on_map,
+        split_map,
     )
 except ImportError:
-    # Tools may not be available if dependencies are missing
     pass
 
 __all__ = [
-    "GeoAgent",
+    # Versioning
+    "__version__",
+    # New v1 surface
+    "create_geo_agent",
+    "for_leafmap",
+    "for_anymap",
+    "for_qgis",
+    "GeoAgentContext",
+    "GeoAgentResponse",
+    "geo_tool",
+    "get_geo_meta",
+    "needs_confirmation",
+    "ConfirmCallback",
+    "ConfirmRequest",
+    "auto_approve_all",
+    "auto_approve_safe_only",
+    "build_interrupt_on",
+    # LLM providers
     "get_llm",
     "get_default_llm",
-    # Tool functions
+    "resolve_model",
+    # Backward-compat legacy class
+    "GeoAgent",
+    # Legacy tool functions
     "search_stac",
     "get_stac_collections",
     "query_spatial_data",

--- a/geoagent/core/context.py
+++ b/geoagent/core/context.py
@@ -1,0 +1,61 @@
+"""Runtime context object passed to GeoAgent runs.
+
+The :class:`GeoAgentContext` is a thin dataclass that carries non-LLM-visible
+runtime state into tool invocations: the live map widget, the QGIS interface
+and project handles, the working directory, and user preferences. Live mutable
+objects (the map widget, the QGIS iface) are typically captured via closure in
+the tool factories under :mod:`geoagent.tools`; LLM-visible scalars (workdir,
+current layer, user_preferences) are exposed to deepagents as a typed
+``context_schema`` and accessed by tools through LangChain's ``ToolRuntime``
+injection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass
+class GeoAgentContext:
+    """Runtime context for a GeoAgent invocation.
+
+    Attributes:
+        map_obj: A live interactive map instance (e.g. ``leafmap.Map`` or
+            ``anymap.Map``). Captured by closure in :func:`leafmap_tools` /
+            :func:`anymap_tools`; not serialised across the LLM boundary.
+        qgis_iface: The QGIS ``QgisInterface`` (typically ``qgis.utils.iface``)
+            when running inside a QGIS Python environment.
+        qgis_project: The active ``QgsProject`` handle. Optional even when
+            ``qgis_iface`` is provided; tools fall back to
+            ``QgsProject.instance()``.
+        workdir: Working directory used for downloads, exports, and other I/O
+            tools. Defaults to the current working directory.
+        current_layer: Optional name of the layer the user most recently
+            referenced. The coordinator may set this so subsequent commands
+            ("zoom to it", "buffer the selected layer") have a target.
+        user_preferences: Free-form user-level preferences (e.g. preferred
+            basemap, default colormap). Tools and prompts may consult this
+            dict to tailor outputs.
+    """
+
+    map_obj: Optional[Any] = None
+    qgis_iface: Optional[Any] = None
+    qgis_project: Optional[Any] = None
+    workdir: Path = field(default_factory=Path.cwd)
+    current_layer: Optional[str] = None
+    user_preferences: dict[str, Any] = field(default_factory=dict)
+
+    def with_overrides(self, **kwargs: Any) -> "GeoAgentContext":
+        """Return a copy of this context with selected fields overridden.
+
+        Args:
+            **kwargs: Field overrides; unknown fields raise ``TypeError``.
+
+        Returns:
+            A new :class:`GeoAgentContext` instance.
+        """
+        from dataclasses import replace
+
+        return replace(self, **kwargs)

--- a/geoagent/core/decorators.py
+++ b/geoagent/core/decorators.py
@@ -120,3 +120,31 @@ def get_category(tool_obj: BaseTool) -> Optional[str]:
 def get_required_packages(tool_obj: BaseTool) -> list[str]:
     """Return the list of Python packages required by ``tool_obj``."""
     return list(get_geo_meta(tool_obj).get("requires_packages", []))
+
+
+def stamp_geo_meta(tool_obj: BaseTool, **fields: Any) -> BaseTool:
+    """Stamp GeoAgent metadata onto an already-built LangChain tool.
+
+    Useful when a tool was created with the plain LangChain ``@tool``
+    decorator (e.g. legacy v0.x tools, or tools imported from another
+    package) and needs to be enrolled in the GeoAgent registry without
+    re-decorating it.
+
+    Existing values under ``tool.metadata["geo"]`` are preserved; ``fields``
+    are merged in on top.
+
+    Args:
+        tool_obj: A LangChain ``BaseTool``.
+        **fields: GeoAgent metadata keys (``category``,
+            ``requires_confirmation``, ``requires_packages``,
+            ``context_keys``).
+
+    Returns:
+        The same tool object, with ``metadata["geo"]`` updated in place.
+    """
+    meta = dict(tool_obj.metadata or {})
+    geo = dict(meta.get(GEO_META_KEY, {}))
+    geo.update(fields)
+    meta[GEO_META_KEY] = geo
+    tool_obj.metadata = meta
+    return tool_obj

--- a/geoagent/core/decorators.py
+++ b/geoagent/core/decorators.py
@@ -1,0 +1,122 @@
+"""The ``@geo_tool`` decorator used by all GeoAgent tool adapters.
+
+``geo_tool`` wraps :func:`langchain_core.tools.tool` so the resulting object is
+still a :class:`~langchain_core.tools.BaseTool` and can be passed unchanged to
+:func:`deepagents.create_deep_agent` as part of its ``tools=...`` argument. It
+additionally stamps GeoAgent-specific metadata onto ``tool.metadata["geo"]``
+so the tool registry, the safety module, and downstream UIs can introspect:
+
+* ``category``: a coarse capability label (``"map"``, ``"qgis"``, ``"data"``,
+  ``"ai"``, ``"io"``).
+* ``requires_confirmation``: whether the tool should be wired into deepagents'
+  ``interrupt_on`` so the user is prompted before execution.
+* ``requires_packages``: optional Python packages whose absence should cause
+  the registry to silently skip the tool (e.g. ``("qgis",)`` for QGIS tools).
+* ``context_keys``: which :class:`GeoAgentContext` fields the tool consults at
+  runtime (informational only — closures handle live objects directly).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Optional
+
+from langchain_core.tools import BaseTool, tool as _lc_tool
+
+GEO_META_KEY = "geo"
+"""The key inside ``BaseTool.metadata`` that holds the GeoAgent metadata dict."""
+
+
+def geo_tool(
+    *,
+    category: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    requires_confirmation: bool = False,
+    requires_packages: Iterable[str] = (),
+    context_keys: Iterable[str] = (),
+) -> Callable[[Callable[..., Any]], BaseTool]:
+    """Decorate a Python callable as a GeoAgent tool.
+
+    The returned object is a LangChain :class:`BaseTool`, so it can be passed
+    directly to :func:`deepagents.create_deep_agent`. GeoAgent metadata is
+    stored on ``tool.metadata["geo"]``.
+
+    Args:
+        category: Coarse capability label, one of ``"map"``, ``"qgis"``,
+            ``"data"``, ``"ai"``, ``"io"``. Used by
+            :func:`geoagent.core.registry.get_tools` to filter.
+        name: Optional explicit tool name. Defaults to the function name.
+        description: Optional explicit description. Defaults to the function's
+            docstring.
+        requires_confirmation: If true, the tool is added to deepagents'
+            ``interrupt_on`` so the user must approve before execution.
+        requires_packages: Python packages that must be importable for this
+            tool to be available. The registry skips tools whose required
+            packages are missing.
+        context_keys: :class:`GeoAgentContext` fields the tool reads at
+            runtime. Informational only.
+
+    Returns:
+        A decorator that turns the function into a :class:`BaseTool`.
+
+    Example:
+        >>> @geo_tool(category="map", requires_confirmation=True)
+        ... def remove_layer(name: str) -> str:
+        ...     '''Remove the named layer from the map.'''
+        ...     ...
+    """
+
+    def deco(fn: Callable[..., Any]) -> BaseTool:
+        if name is not None:
+            built = _lc_tool(name)(fn)
+        else:
+            built = _lc_tool(fn)
+        if description is not None:
+            built.description = description
+        meta = dict(built.metadata or {})
+        meta[GEO_META_KEY] = {
+            "category": category,
+            "requires_confirmation": bool(requires_confirmation),
+            "requires_packages": list(requires_packages),
+            "context_keys": list(context_keys),
+        }
+        built.metadata = meta
+        return built
+
+    return deco
+
+
+def get_geo_meta(tool_obj: BaseTool) -> dict[str, Any]:
+    """Return the GeoAgent metadata dict stamped on a tool.
+
+    Args:
+        tool_obj: A LangChain ``BaseTool``.
+
+    Returns:
+        The metadata dict, or an empty dict if the tool was not produced by
+        :func:`geo_tool`.
+    """
+    return (tool_obj.metadata or {}).get(GEO_META_KEY, {})
+
+
+def needs_confirmation(tool_obj: BaseTool) -> bool:
+    """Return whether ``tool_obj`` requires user confirmation before running.
+
+    Args:
+        tool_obj: A LangChain ``BaseTool``.
+
+    Returns:
+        ``True`` if the tool's GeoAgent metadata sets
+        ``requires_confirmation``; ``False`` otherwise.
+    """
+    return bool(get_geo_meta(tool_obj).get("requires_confirmation"))
+
+
+def get_category(tool_obj: BaseTool) -> Optional[str]:
+    """Return the tool's GeoAgent category, or ``None`` if not stamped."""
+    return get_geo_meta(tool_obj).get("category")
+
+
+def get_required_packages(tool_obj: BaseTool) -> list[str]:
+    """Return the list of Python packages required by ``tool_obj``."""
+    return list(get_geo_meta(tool_obj).get("requires_packages", []))

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -1,0 +1,240 @@
+"""Agent factory functions.
+
+The :func:`create_geo_agent` function is the canonical entry point for
+building a deepagents-based GeoAgent runtime. The :func:`for_leafmap`,
+:func:`for_anymap`, and :func:`for_qgis` helpers are convenience wrappers
+that bind the factory to a specific runtime resource (a map widget or a
+QGIS interface) and select an appropriate default tool set.
+
+deepagents is imported lazily inside the function bodies so that
+``import geoagent`` keeps working on a system where deepagents is not yet
+installed; callers get a clear ``ImportError`` only if they actually
+construct an agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+from langchain_core.tools import BaseTool
+
+from .context import GeoAgentContext
+from .prompts import COORDINATOR_PROMPT
+from .safety import ConfirmCallback, build_interrupt_on
+
+
+def _require_deepagents() -> Any:
+    """Import :mod:`deepagents` lazily and raise a friendly error if absent."""
+    try:
+        from deepagents import create_deep_agent
+
+        return create_deep_agent
+    except ImportError as exc:  # pragma: no cover - exercised only when missing
+        raise ImportError(
+            "deepagents is not installed. Install it with "
+            "`pip install GeoAgent` (deepagents is a base dependency in v1+) "
+            "or `pip install deepagents>=0.5.3`."
+        ) from exc
+
+
+def _as_list(value: Optional[Iterable[BaseTool]]) -> list[BaseTool]:
+    return list(value) if value is not None else []
+
+
+def create_geo_agent(
+    *,
+    tools: Optional[Iterable[BaseTool]] = None,
+    extra_tools: Optional[Iterable[BaseTool]] = None,
+    context: Optional[GeoAgentContext] = None,
+    system_prompt: Optional[str] = None,
+    model: Any = None,
+    provider: Optional[str] = None,
+    llm: Any = None,
+    subagents: Optional[list[Any]] = None,
+    checkpointer: Any = None,
+    confirm: Optional[ConfirmCallback] = None,
+    debug: bool = False,
+) -> Any:
+    """Build a deepagents-compiled GeoAgent runnable.
+
+    Args:
+        tools: Explicit tool list. If ``None``, the registry is used.
+        extra_tools: Additional tools appended to ``tools``.
+        context: Runtime context. Defaults to an empty
+            :class:`GeoAgentContext`. The dataclass type is passed to
+            deepagents as ``context_schema``.
+        system_prompt: Coordinator system prompt. Defaults to
+            :data:`COORDINATOR_PROMPT`.
+        model: A pre-built LangChain ``BaseChatModel``, or a deepagents-style
+            string like ``"openai:gpt-4o"``. Mutually exclusive with
+            ``provider`` / ``llm``.
+        provider: A provider name (``"openai"``, ``"anthropic"``, ``"google"``,
+            ``"ollama"``). Resolved via :func:`geoagent.core.llm.resolve_model`.
+        llm: A pre-built LangChain ``BaseChatModel`` (alias of ``model`` for
+            users coming from the v0.x API).
+        subagents: List of deepagents subagent specs. Phase 1 ships with no
+            built-in subagents; pass an explicit list when ready.
+        checkpointer: A LangGraph ``Checkpointer`` for thread persistence.
+        confirm: Reserved for use by the :class:`GeoAgent` facade in Phase 2.
+            Currently unused at the factory layer; included so callers can
+            construct full configurations now without re-plumbing later.
+        debug: Forwarded to deepagents.
+
+    Returns:
+        A compiled deepagents agent (a LangGraph ``CompiledStateGraph``).
+        Invoke via ``.invoke({"messages": [...]})`` or ``.stream(...)``.
+    """
+    create_deep_agent = _require_deepagents()
+    del confirm  # placeholder for the Phase 2 facade
+
+    from .llm import resolve_model
+
+    resolved_model = resolve_model(llm=llm or model, provider=provider)
+
+    tool_list = _as_list(tools) + _as_list(extra_tools)
+    interrupt_on = build_interrupt_on(tool_list) or None
+
+    context = context or GeoAgentContext()
+
+    return create_deep_agent(
+        model=resolved_model,
+        tools=tool_list,
+        system_prompt=system_prompt or COORDINATOR_PROMPT,
+        subagents=subagents,
+        interrupt_on=interrupt_on,
+        context_schema=type(context),
+        checkpointer=checkpointer,
+        debug=debug,
+    )
+
+
+def for_leafmap(
+    m: Any,
+    *,
+    include_stac: bool = True,
+    include_data: bool = False,
+    extra_tools: Optional[Iterable[BaseTool]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Build an agent bound to a live ``leafmap.Map`` instance.
+
+    Args:
+        m: A ``leafmap.Map`` (or compatible mock) instance.
+        include_stac: If ``True``, append ``stac_tools()``.
+        include_data: If ``True``, append the raster, vector, and DuckDB
+            data tool sets.
+        extra_tools: Additional tools appended to the assembled list.
+        **kwargs: Forwarded to :func:`create_geo_agent`.
+
+    Returns:
+        A compiled deepagents agent.
+    """
+    from geoagent.tools.leafmap import leafmap_tools
+
+    tools: list[BaseTool] = list(leafmap_tools(m))
+    if include_stac:
+        from geoagent.tools.stac import stac_tools
+
+        tools += stac_tools()
+    if include_data:
+        from geoagent.tools.data.raster import raster_tools
+        from geoagent.tools.data.vector import vector_tools
+        from geoagent.tools.data.duckdb import duckdb_tools
+
+        tools += raster_tools() + vector_tools() + duckdb_tools()
+    if extra_tools is not None:
+        tools += list(extra_tools)
+    context = kwargs.pop("context", None) or GeoAgentContext(map_obj=m)
+    return create_geo_agent(tools=tools, context=context, **kwargs)
+
+
+def for_anymap(
+    m: Any,
+    *,
+    include_stac: bool = True,
+    include_data: bool = False,
+    extra_tools: Optional[Iterable[BaseTool]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Build an agent bound to a live ``anymap.Map`` instance.
+
+    Args:
+        m: An ``anymap.Map`` (or compatible mock) instance.
+        include_stac: If ``True``, append ``stac_tools()``.
+        include_data: If ``True``, append the raster, vector, and DuckDB
+            data tool sets.
+        extra_tools: Additional tools appended to the assembled list.
+        **kwargs: Forwarded to :func:`create_geo_agent`.
+
+    Returns:
+        A compiled deepagents agent.
+    """
+    from geoagent.tools.anymap import anymap_tools
+
+    tools: list[BaseTool] = list(anymap_tools(m))
+    if include_stac:
+        from geoagent.tools.stac import stac_tools
+
+        tools += stac_tools()
+    if include_data:
+        from geoagent.tools.data.raster import raster_tools
+        from geoagent.tools.data.vector import vector_tools
+        from geoagent.tools.data.duckdb import duckdb_tools
+
+        tools += raster_tools() + vector_tools() + duckdb_tools()
+    if extra_tools is not None:
+        tools += list(extra_tools)
+    context = kwargs.pop("context", None) or GeoAgentContext(map_obj=m)
+    return create_geo_agent(tools=tools, context=context, **kwargs)
+
+
+def for_qgis(
+    iface: Any,
+    project: Any = None,
+    *,
+    include_stac: bool = True,
+    include_data: bool = False,
+    extra_tools: Optional[Iterable[BaseTool]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Build an agent bound to a live QGIS ``QgisInterface``.
+
+    Args:
+        iface: The QGIS ``QgisInterface``. Pass ``None`` to build an agent
+            with no QGIS-specific tools (useful for testing the path).
+        project: Optional ``QgsProject`` instance.
+        include_stac: If ``True``, append ``stac_tools()``.
+        include_data: If ``True``, append the raster, vector, and DuckDB
+            data tool sets.
+        extra_tools: Additional tools.
+        **kwargs: Forwarded to :func:`create_geo_agent`.
+
+    Returns:
+        A compiled deepagents agent.
+    """
+    from geoagent.tools.qgis import qgis_tools
+
+    tools: list[BaseTool] = list(qgis_tools(iface, project))
+    if include_stac:
+        from geoagent.tools.stac import stac_tools
+
+        tools += stac_tools()
+    if include_data:
+        from geoagent.tools.data.raster import raster_tools
+        from geoagent.tools.data.vector import vector_tools
+
+        tools += raster_tools() + vector_tools()
+    if extra_tools is not None:
+        tools += list(extra_tools)
+    context = kwargs.pop("context", None) or GeoAgentContext(
+        qgis_iface=iface, qgis_project=project
+    )
+    return create_geo_agent(tools=tools, context=context, **kwargs)
+
+
+__all__ = [
+    "create_geo_agent",
+    "for_leafmap",
+    "for_anymap",
+    "for_qgis",
+]

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -58,8 +58,12 @@ def create_geo_agent(
     """Build a deepagents-compiled GeoAgent runnable.
 
     Args:
-        tools: Explicit tool list. If ``None``, the registry is used.
-        extra_tools: Additional tools appended to ``tools``.
+        tools: Explicit base tool list. If ``None``, no base tools are used;
+            callers typically obtain a list from the per-package factories
+            (:func:`for_leafmap` etc.) or from
+            :func:`geoagent.core.registry.get_tools`.
+        extra_tools: Additional tools appended to ``tools`` after both inputs
+            are normalised to lists.
         context: Runtime context. Defaults to an empty
             :class:`GeoAgentContext`. The dataclass type is passed to
             deepagents as ``context_schema``.
@@ -89,7 +93,7 @@ def create_geo_agent(
 
     from .llm import resolve_model
 
-    resolved_model = resolve_model(llm=llm or model, provider=provider)
+    resolved_model = resolve_model(llm=llm, provider=provider, model=model)
 
     tool_list = _as_list(tools) + _as_list(extra_tools)
     interrupt_on = build_interrupt_on(tool_list) or None

--- a/geoagent/core/llm.py
+++ b/geoagent/core/llm.py
@@ -237,3 +237,39 @@ def check_api_keys() -> Dict[str, bool]:
         name: config["env_var"] is None or bool(os.getenv(config["env_var"]))
         for name, config in PROVIDERS.items()
     }
+
+
+def resolve_model(
+    llm: Optional[Any] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    **kwargs: Any,
+) -> Any:
+    """Resolve the tri-form ``llm`` / ``provider`` / ``model`` arguments.
+
+    GeoAgent's public API accepts any of three forms for picking the LLM:
+
+    * an explicit ``llm`` object (a LangChain ``BaseChatModel`` instance),
+    * a ``provider`` name (e.g. ``"openai"``) plus an optional ``model``,
+    * neither, in which case :func:`get_default_llm` picks the first
+      available provider from the environment.
+
+    This function normalises all three into a single ``BaseChatModel`` ready
+    to pass to :func:`deepagents.create_deep_agent` as its ``model=``
+    argument.
+
+    Args:
+        llm: A pre-built LangChain chat model. Returned unchanged if given.
+        provider: A provider name from :data:`PROVIDERS`.
+        model: A model name override for ``provider``.
+        **kwargs: Forwarded to :func:`get_llm` when constructing a new model.
+
+    Returns:
+        A LangChain ``BaseChatModel`` (or :class:`MockLLM` when no provider
+        is available and no ``llm`` was supplied).
+    """
+    if llm is not None:
+        return llm
+    if provider is not None:
+        return get_llm(provider=provider, model=model, **kwargs)
+    return get_default_llm(**kwargs)

--- a/geoagent/core/llm.py
+++ b/geoagent/core/llm.py
@@ -272,4 +272,8 @@ def resolve_model(
         return llm
     if provider is not None:
         return get_llm(provider=provider, model=model, **kwargs)
+    if isinstance(model, str) and ":" in model:
+        # deepagents-style "provider:model" string — split and dispatch.
+        head, _, tail = model.partition(":")
+        return get_llm(provider=head, model=tail, **kwargs)
     return get_default_llm(**kwargs)

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -1,0 +1,72 @@
+"""System prompts shared by the GeoAgent coordinator and subagents.
+
+The prompts here are intentionally short scaffolds for Phase 1. Phase 2 will
+expand them with the routing heuristics and analysis patterns salvaged from
+the legacy v0.x agents (planner, data, analysis, viz, context).
+"""
+
+from __future__ import annotations
+
+COORDINATOR_PROMPT = """You are GeoAgent, a coordinating agent for geospatial \
+analysis and visualization. You work with the user's interactive map, QGIS \
+project, and remote-sensing datasets to answer geospatial questions and \
+manipulate maps.
+
+Available capabilities depend on the runtime context:
+- If a map object is available, use the map-control tools to add layers, \
+zoom, change basemap, and inspect map state.
+- If a QGIS interface is available, use the QGIS tools to read project \
+layers, run processing algorithms, and modify the canvas.
+- For data search and analysis, use the STAC, raster, vector, DuckDB, \
+Earth Engine, and NASA Earthdata tools as appropriate.
+
+Always prefer non-destructive (read-only) tools first when planning. \
+Confirmation-required tools (remove, delete, save, export, download) will \
+prompt the user before executing; explain what you intend to do before \
+calling them so the user can approve confidently.
+
+When you produce Python code for the user (e.g. PyQGIS snippets), keep it \
+short, runnable, and well-commented.
+"""
+
+PLANNER_PROMPT = """You are the Planner subagent. Decompose the user's query \
+into: intent (search / analyze / visualize / explain / monitor), location \
+(if any), time range (if any), dataset hint (if any), analysis type, and \
+parameters. Return a structured summary the coordinator can use to delegate."""
+
+DATA_PROMPT = """You are the Data subagent. Use STAC search and DuckDB \
+spatial-SQL tools to retrieve the requested datasets. Report the URLs and \
+metadata you found; do not download large files unless the user asked for \
+it."""
+
+ANALYSIS_PROMPT = """You are the Analysis subagent. Run raster and vector \
+analysis tools to compute the user's request: spectral indices (NDVI, NDWI, \
+EVI), zonal statistics, buffers, joins, and so on. Generate clear, runnable \
+Python code that reproduces what you did."""
+
+VIZ_PROMPT = """You are the Visualisation subagent. Use the map tools to \
+render the requested data on the user's map: add COG / STAC / vector / \
+PMTiles layers, set basemap, and zoom appropriately."""
+
+MAPPING_PROMPT = """You are the Mapping subagent. You manipulate the user's \
+interactive map widget directly: add and remove layers, change basemap, \
+zoom, pan. Always confirm the layer name with the user before destructive \
+operations like remove_layer or save_map."""
+
+QGIS_PROMPT = """You are the QGIS subagent. You operate inside a running \
+QGIS Python environment. Use the iface and project tools to list layers, \
+zoom, add data, and run processing algorithms. Prefer non-destructive \
+inspection before any modification, and explain processing parameters \
+clearly before running them."""
+
+GEOAI_PROMPT = """You are the GeoAI subagent. Run segmentation, object \
+detection, or classification on raster imagery. Always describe expected \
+outputs (raster mask vs. vector boundaries) before running."""
+
+EARTHDATA_PROMPT = """You are the Earthdata subagent. Search NASA's CMR for \
+granules matching the user's criteria. Confirm the bounding box and time \
+window before any download."""
+
+CONTEXT_PROMPT = """You are the Context subagent. Answer the user's \
+geospatial question conversationally without fetching data, when the \
+question is purely explanatory."""

--- a/geoagent/core/registry.py
+++ b/geoagent/core/registry.py
@@ -1,0 +1,128 @@
+"""Capability-tagged tool registry.
+
+The registry is a process-wide singleton dict that lets downstream packages
+register :func:`geoagent.core.decorators.geo_tool`-decorated tools and lets
+the agent factory pick a subset of them at construction time. Tools whose
+``requires_packages`` are not importable are silently filtered out so that
+``import geoagent.tools.qgis`` works on a non-QGIS Python without raising.
+
+Typical usage in a downstream package's tool module::
+
+    from geoagent.core.registry import register
+    from geoagent.core.decorators import geo_tool
+
+    @register
+    @geo_tool(category="data", requires_packages=("pystac_client",))
+    def my_tool(...): ...
+
+The factory then calls :func:`get_tools` with category filters to assemble
+the active tool list for an agent.
+"""
+
+from __future__ import annotations
+
+from importlib.util import find_spec
+from typing import Iterable, Optional
+
+from langchain_core.tools import BaseTool
+
+from .decorators import get_geo_meta
+
+_TOOLS: dict[str, BaseTool] = {}
+_PKG_CACHE: dict[str, bool] = {}
+
+
+def _have(pkg: str) -> bool:
+    """Cached check for whether a Python package is importable.
+
+    Args:
+        pkg: A top-level distribution / module name (e.g. ``"qgis"``,
+            ``"leafmap"``).
+
+    Returns:
+        ``True`` if the package can be located by
+        :func:`importlib.util.find_spec`.
+    """
+    if pkg not in _PKG_CACHE:
+        try:
+            _PKG_CACHE[pkg] = find_spec(pkg) is not None
+        except (ImportError, ValueError):
+            _PKG_CACHE[pkg] = False
+    return _PKG_CACHE[pkg]
+
+
+def register(tool: BaseTool) -> BaseTool:
+    """Register a single tool in the global registry.
+
+    Idempotent: re-registering a tool with the same name overwrites the
+    previous entry. Returns the tool to support decorator-style usage.
+
+    Args:
+        tool: A LangChain ``BaseTool`` (typically produced by
+            :func:`geo_tool`).
+
+    Returns:
+        The same tool, unchanged.
+    """
+    _TOOLS[tool.name] = tool
+    return tool
+
+
+def register_many(tools: Iterable[BaseTool]) -> None:
+    """Register an iterable of tools.
+
+    Args:
+        tools: Tools to register.
+    """
+    for t in tools:
+        register(t)
+
+
+def unregister(name: str) -> None:
+    """Remove a tool from the registry by name. No-op if absent."""
+    _TOOLS.pop(name, None)
+
+
+def clear() -> None:
+    """Remove all registered tools. Primarily useful in tests."""
+    _TOOLS.clear()
+
+
+def all_tools() -> list[BaseTool]:
+    """Return every registered tool, regardless of availability."""
+    return list(_TOOLS.values())
+
+
+def get_tools(
+    categories: Optional[Iterable[str]] = None,
+    available_only: bool = True,
+) -> list[BaseTool]:
+    """Return registered tools filtered by category and availability.
+
+    Args:
+        categories: If provided, only return tools whose ``category`` is in
+            this iterable. ``None`` returns all categories.
+        available_only: If ``True`` (the default), drop tools whose
+            ``requires_packages`` are not importable.
+
+    Returns:
+        A list of matching ``BaseTool`` instances, in insertion order.
+    """
+    cats = set(categories) if categories else None
+    out: list[BaseTool] = []
+    for tool in _TOOLS.values():
+        meta = get_geo_meta(tool)
+        if cats is not None and meta.get("category") not in cats:
+            continue
+        if available_only:
+            required = meta.get("requires_packages", [])
+            if required and not all(_have(pkg) for pkg in required):
+                continue
+        out.append(tool)
+    return out
+
+
+def is_available(tool: BaseTool) -> bool:
+    """Return whether ``tool``'s required Python packages are importable."""
+    required = get_geo_meta(tool).get("requires_packages", [])
+    return all(_have(pkg) for pkg in required)

--- a/geoagent/core/result.py
+++ b/geoagent/core/result.py
@@ -1,0 +1,50 @@
+"""Public response object returned from :meth:`GeoAgent.chat`.
+
+The field names are kept compatible with the v0.x ``GeoAgentResponse`` type
+so downstream code holding the dataclass continues to work, but the fields
+are no longer typed against the deleted v0.x ``PlannerOutput`` /
+``DataResult`` / ``AnalysisResult`` models. Callers should treat ``plan``,
+``data``, and ``analysis`` as opaque dicts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class GeoAgentResponse:
+    """Result of a single :meth:`GeoAgent.chat` call.
+
+    Attributes:
+        plan: Structured plan produced by the planner subagent, if any.
+        data: Data-fetch result (e.g. STAC items, GeoDataFrame metadata).
+        analysis: Analysis output (e.g. zonal stats, computed indices).
+        map: The interactive map widget rendered for this query, when
+            applicable. May be the same object passed in as ``target_map``.
+        code: Python code generated during the run for reproducibility.
+        answer_text: A plain-text answer for explanatory queries that did
+            not produce structured data.
+        success: Whether the query completed without error.
+        error_message: Error string when ``success`` is ``False``.
+        execution_time: Wall-clock seconds spent in the agent run.
+        executed_tools: Names of tools the agent actually called, in order.
+        cancelled_tools: Names of tools the user cancelled via the
+            :class:`ConfirmCallback`.
+        messages: The raw deepagents message log (LangChain messages) for
+            advanced inspection. Optional and may be omitted for brevity.
+    """
+
+    plan: Any = None
+    data: Any = None
+    analysis: Any = None
+    map: Any = None
+    code: str = ""
+    answer_text: Optional[str] = None
+    success: bool = True
+    error_message: Optional[str] = None
+    execution_time: float = 0.0
+    executed_tools: list[str] = field(default_factory=list)
+    cancelled_tools: list[str] = field(default_factory=list)
+    messages: Optional[list[Any]] = None

--- a/geoagent/core/safety.py
+++ b/geoagent/core/safety.py
@@ -1,0 +1,112 @@
+"""Safety classification and confirmation-callback bridge.
+
+GeoAgent classifies tools into "safe" (read-only inspection, navigation,
+preview) and "confirmation-required" (destructive, expensive, or
+externally-visible) actions. Confirmation-required tools are wired into
+deepagents' ``interrupt_on`` mechanism so the agent pauses before executing
+them.
+
+The :class:`ConfirmRequest` / :data:`ConfirmCallback` pair is the integration
+point between the GeoAgent runtime and the host environment (Jupyter, Solara,
+CLI, custom UI). The host supplies a :data:`ConfirmCallback` to
+:class:`geoagent.GeoAgent`, and the facade routes each interrupt through that
+callback to decide whether to resume or cancel.
+
+Built-in default callbacks are provided here:
+
+* :func:`auto_approve_safe_only`: reject everything (safe fallback when no
+  callback is supplied — confirmation-required tools never execute).
+* :func:`auto_approve_all`: approve everything (only suitable for tests or
+  trusted scripts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Optional
+
+from langchain_core.tools import BaseTool
+
+from .decorators import get_geo_meta, needs_confirmation
+
+
+@dataclass
+class ConfirmRequest:
+    """A pending tool invocation awaiting user approval.
+
+    Attributes:
+        tool_name: The name of the tool deepagents is about to call.
+        args: The arguments the LLM proposed to pass to the tool.
+        description: A short human-readable description of the tool, lifted
+            from ``tool.description``.
+        category: The tool's GeoAgent category (``"map"``, ``"qgis"``,
+            ``"data"``, ``"ai"``, ``"io"``) when known.
+        metadata: The full GeoAgent metadata dict for the tool (handy for
+            UIs that want to render extra context).
+    """
+
+    tool_name: str
+    args: dict[str, Any]
+    description: str = ""
+    category: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+ConfirmCallback = Callable[[ConfirmRequest], bool]
+"""A callable that receives a :class:`ConfirmRequest` and returns ``True`` to
+approve the call or ``False`` to reject it."""
+
+
+def build_interrupt_on(tools: Iterable[BaseTool]) -> dict[str, bool]:
+    """Build the deepagents ``interrupt_on`` dict from tool metadata.
+
+    Args:
+        tools: An iterable of tools (typically the full set passed to
+            :func:`create_geo_agent`).
+
+    Returns:
+        A mapping of ``{tool_name: True}`` for every tool whose
+        :func:`needs_confirmation` returns ``True``. Empty dict if no tool
+        requires confirmation.
+    """
+    return {t.name: True for t in tools if needs_confirmation(t)}
+
+
+def make_confirm_request(tool: BaseTool, args: dict[str, Any]) -> ConfirmRequest:
+    """Build a :class:`ConfirmRequest` for an interrupt firing on ``tool``."""
+    meta = get_geo_meta(tool)
+    return ConfirmRequest(
+        tool_name=tool.name,
+        args=dict(args),
+        description=tool.description or "",
+        category=meta.get("category"),
+        metadata=meta,
+    )
+
+
+def auto_approve_safe_only(request: ConfirmRequest) -> bool:
+    """Default conservative callback: rejects every confirmation request.
+
+    Used when the user hasn't supplied a ``confirm`` callback to
+    :class:`geoagent.GeoAgent`. Because only confirmation-required tools
+    reach this callback, the effect is "let safe tools run, block everything
+    that needs approval."
+
+    Args:
+        request: The pending tool invocation.
+
+    Returns:
+        Always ``False``.
+    """
+    del request
+    return False
+
+
+def auto_approve_all(request: ConfirmRequest) -> bool:
+    """Permissive callback that approves every request.
+
+    Suitable for tests or tightly controlled automation. Do not use as a
+    default in interactive applications.
+    """
+    del request
+    return True

--- a/geoagent/testing/__init__.py
+++ b/geoagent/testing/__init__.py
@@ -1,0 +1,24 @@
+"""Testing helpers for GeoAgent.
+
+Public surface includes mock map widgets and a mock QGIS interface so tools
+in :mod:`geoagent.tools` can be exercised without leafmap, anymap, or QGIS
+installed.
+"""
+
+from ._mocks import (
+    MockAnymap,
+    MockLeafmap,
+    MockQGISCanvas,
+    MockQGISIface,
+    MockQGISLayer,
+    MockQGISProject,
+)
+
+__all__ = [
+    "MockLeafmap",
+    "MockAnymap",
+    "MockQGISIface",
+    "MockQGISProject",
+    "MockQGISLayer",
+    "MockQGISCanvas",
+]

--- a/geoagent/testing/_mocks.py
+++ b/geoagent/testing/_mocks.py
@@ -1,0 +1,390 @@
+"""Mock objects for GeoAgent tests.
+
+These mocks let the tool adapters in :mod:`geoagent.tools` be exercised in
+CI without leafmap, anymap, or QGIS installed. Each mock implements the
+minimum API surface that GeoAgent's tools call.
+
+They are deliberately simple and not intended as full-fidelity emulators of
+the real packages — they exist to verify that GeoAgent invokes the right
+methods with the right arguments, not to validate real geospatial behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class MockLeafmap:
+    """Stand-in for ``leafmap.Map`` / ``leafmap.maplibregl.Map``.
+
+    Stores added layers as plain dicts on ``self.layers`` so tests can
+    assert on layer composition. Keeps the simplest possible state for
+    center, zoom, basemap, and title.
+    """
+
+    def __init__(
+        self,
+        center: list[float] | None = None,
+        zoom: int = 5,
+        height: str = "600px",
+        **kwargs: Any,
+    ) -> None:
+        self.layers: list[dict[str, Any]] = []
+        self.center: list[float] = list(center) if center else [0.0, 0.0]
+        self.zoom: int = zoom
+        self.height: str = height
+        self.title: str = ""
+        self._style: str = "open-street-map"
+        self._bounds: Optional[list[list[float]]] = None
+        self.kwargs = kwargs
+
+    # ----- viewport -----
+    def set_center(self, lon: float, lat: float, zoom: Optional[int] = None) -> None:
+        self.center = [lon, lat]
+        if zoom is not None:
+            self.zoom = zoom
+
+    def set_zoom(self, zoom: int) -> None:
+        self.zoom = zoom
+
+    def fit_bounds(self, bounds: list[list[float]]) -> None:
+        self._bounds = bounds
+
+    def get_center(self) -> list[float]:
+        return list(self.center)
+
+    def get_zoom(self) -> int:
+        return self.zoom
+
+    def get_bounds(self) -> Optional[list[list[float]]]:
+        return self._bounds
+
+    # ----- basemap -----
+    def add_basemap(self, basemap: str = "open-street-map") -> None:
+        self._style = basemap
+
+    # ----- layers -----
+    def add_layer(self, layer_dict: dict[str, Any]) -> None:
+        self.layers.append(dict(layer_dict))
+
+    def add_geojson(
+        self,
+        data: Any,
+        layer_name: str | None = None,
+        style: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.layers.append(
+            {
+                "type": "geojson",
+                "data": data,
+                "name": layer_name or f"GeoJSON Layer {len(self.layers) + 1}",
+                "style": style,
+                **kwargs,
+            }
+        )
+
+    def add_cog_layer(
+        self,
+        url: str,
+        name: str | None = None,
+        fit_bounds: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self.layers.append(
+            {
+                "type": "cog",
+                "url": url,
+                "name": name or f"COG Layer {len(self.layers) + 1}",
+                "fit_bounds": fit_bounds,
+                **kwargs,
+            }
+        )
+
+    def add_raster(
+        self,
+        url: str,
+        layer_name: str | None = None,
+        fit_bounds: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self.add_cog_layer(url, name=layer_name, fit_bounds=fit_bounds, **kwargs)
+
+    def add_pmtiles(self, url: str, name: str | None = None, **kwargs: Any) -> None:
+        self.layers.append(
+            {
+                "type": "pmtiles",
+                "url": url,
+                "name": name or f"PMTiles Layer {len(self.layers) + 1}",
+                **kwargs,
+            }
+        )
+
+    def add_xyz_tile_layer(
+        self,
+        url: str,
+        name: str | None = None,
+        attribution: str = "",
+        **kwargs: Any,
+    ) -> None:
+        self.layers.append(
+            {
+                "type": "xyz",
+                "url": url,
+                "name": name or f"XYZ Layer {len(self.layers) + 1}",
+                "attribution": attribution,
+                **kwargs,
+            }
+        )
+
+    def add_stac_layer(
+        self,
+        collection: str,
+        item: str | None = None,
+        assets: list[str] | None = None,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.layers.append(
+            {
+                "type": "stac",
+                "collection": collection,
+                "item": item,
+                "assets": list(assets) if assets else [],
+                "name": name or f"STAC {collection}",
+                **kwargs,
+            }
+        )
+
+    def remove_layer(self, name: str) -> bool:
+        before = len(self.layers)
+        self.layers = [layer for layer in self.layers if layer.get("name") != name]
+        return len(self.layers) != before
+
+    # ----- annotations / IO -----
+    def add_title(self, title: str) -> None:
+        self.title = title
+
+    def to_html(self, filename: str | None = None) -> str:
+        layer_list = "".join(
+            f"<li>{layer.get('name', 'Unnamed')} ({layer.get('type', 'unknown')})</li>"
+            for layer in self.layers
+        )
+        html = (
+            f"<div><h3>{self.title}</h3>"
+            f"<p>Mock map. Center: {self.center}, Zoom: {self.zoom}</p>"
+            f"<ul>{layer_list}</ul></div>"
+        )
+        if filename:
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(html)
+        return html
+
+    def __repr__(self) -> str:
+        return (
+            f"MockLeafmap(center={self.center}, zoom={self.zoom}, "
+            f"layers={len(self.layers)})"
+        )
+
+
+class MockAnymap(MockLeafmap):
+    """Stand-in for ``anymap.Map``.
+
+    The two libraries' high-level APIs are similar enough that for testing
+    purposes :class:`MockAnymap` reuses :class:`MockLeafmap`. The class
+    name is what tools use to detect "anymap-style" map objects via
+    ``type(map_obj).__module__``.
+    """
+
+    __module__ = "anymap.testing"
+
+
+class MockQGISLayer:
+    """Minimal stand-in for ``QgsMapLayer`` (vector or raster).
+
+    Attributes:
+        layer_name: The display name returned by :meth:`name`.
+        source_uri: The source string returned by :meth:`source`.
+        layer_type: ``"vector"`` or ``"raster"``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        source: str = "",
+        layer_type: str = "vector",
+        fields: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.layer_name = name
+        self.source_uri = source
+        self.layer_type = layer_type
+        self._fields = list(fields) if fields else []
+        self._selected: list[dict[str, Any]] = []
+        self._visible = True
+
+    def name(self) -> str:
+        return self.layer_name
+
+    def source(self) -> str:
+        return self.source_uri
+
+    def type(self) -> str:
+        return self.layer_type
+
+    def isValid(self) -> bool:
+        return True
+
+    def fields(self) -> list[dict[str, Any]]:
+        return list(self._fields)
+
+    def selectedFeatures(self) -> list[dict[str, Any]]:
+        return list(self._selected)
+
+    def id(self) -> str:
+        return self.layer_name
+
+    @property
+    def visible(self) -> bool:
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool) -> None:
+        self._visible = bool(value)
+
+
+class MockQGISCanvas:
+    """Stand-in for ``QgsMapCanvas``.
+
+    Tracks a numeric scale and an extent tuple so tests can assert on
+    zoom/pan calls.
+    """
+
+    def __init__(self) -> None:
+        self.scale_value: float = 1000.0
+        self.extent_value: tuple[float, float, float, float] = (
+            -180.0,
+            -90.0,
+            180.0,
+            90.0,
+        )
+        self.refresh_count: int = 0
+
+    def zoomIn(self) -> None:
+        self.scale_value /= 2
+
+    def zoomOut(self) -> None:
+        self.scale_value *= 2
+
+    def zoomByFactor(self, factor: float) -> None:
+        self.scale_value *= factor
+
+    def setExtent(self, extent: tuple[float, float, float, float]) -> None:
+        self.extent_value = tuple(extent)  # type: ignore[assignment]
+
+    def extent(self) -> tuple[float, float, float, float]:
+        return self.extent_value
+
+    def zoomToFullExtent(self) -> None:
+        self.extent_value = (-180.0, -90.0, 180.0, 90.0)
+
+    def refresh(self) -> None:
+        self.refresh_count += 1
+
+    def scale(self) -> float:
+        return self.scale_value
+
+
+class MockQGISProject:
+    """Stand-in for ``QgsProject``.
+
+    Stores layers in a dict keyed by layer name. ``addMapLayer`` and
+    ``removeMapLayer`` accept either a :class:`MockQGISLayer` or a layer
+    name string.
+    """
+
+    def __init__(self) -> None:
+        self._layers: dict[str, MockQGISLayer] = {}
+
+    def addMapLayer(self, layer: MockQGISLayer) -> MockQGISLayer:
+        self._layers[layer.name()] = layer
+        return layer
+
+    def removeMapLayer(self, key: Any) -> None:
+        if isinstance(key, MockQGISLayer):
+            self._layers.pop(key.name(), None)
+        else:
+            self._layers.pop(key, None)
+
+    def mapLayers(self) -> dict[str, MockQGISLayer]:
+        return dict(self._layers)
+
+    def mapLayersByName(self, name: str) -> list[MockQGISLayer]:
+        return [layer for layer in self._layers.values() if layer.name() == name]
+
+    @classmethod
+    def instance(cls) -> "MockQGISProject":
+        return cls()
+
+
+class _MockMessageBar:
+    def pushMessage(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        """No-op message-bar push, matching ``QgsMessageBar`` shape."""
+        return None
+
+
+class MockQGISIface:
+    """Stand-in for ``qgis.utils.iface``.
+
+    Holds a :class:`MockQGISCanvas` and an active layer reference, plus
+    the ``addVectorLayer`` / ``addRasterLayer`` shortcuts that the QGIS
+    Python console exposes.
+    """
+
+    def __init__(self, project: Optional[MockQGISProject] = None) -> None:
+        self._canvas = MockQGISCanvas()
+        self._active: Optional[MockQGISLayer] = None
+        self._project = project or MockQGISProject()
+
+    def mapCanvas(self) -> MockQGISCanvas:
+        return self._canvas
+
+    def activeLayer(self) -> Optional[MockQGISLayer]:
+        return self._active
+
+    def setActiveLayer(self, layer: MockQGISLayer) -> None:
+        self._active = layer
+
+    def addVectorLayer(
+        self, path: str, name: str, provider: str = "ogr"
+    ) -> MockQGISLayer:
+        layer = MockQGISLayer(name, source=path, layer_type="vector")
+        self._project.addMapLayer(layer)
+        return layer
+
+    def addRasterLayer(self, path: str, name: str) -> MockQGISLayer:
+        layer = MockQGISLayer(name, source=path, layer_type="raster")
+        self._project.addMapLayer(layer)
+        return layer
+
+    def messageBar(self) -> _MockMessageBar:
+        return _MockMessageBar()
+
+    def project(self) -> MockQGISProject:
+        return self._project
+
+    def zoomFull(self) -> None:
+        self._canvas.zoomToFullExtent()
+
+    def zoomToActiveLayer(self) -> None:
+        if self._active is not None:
+            self._canvas.refresh()
+
+
+__all__ = [
+    "MockLeafmap",
+    "MockAnymap",
+    "MockQGISIface",
+    "MockQGISProject",
+    "MockQGISLayer",
+    "MockQGISCanvas",
+]

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -1,0 +1,15 @@
+"""Tool adapter modules for GeoAgent.
+
+Each submodule exposes a factory function (e.g. :func:`leafmap_tools`,
+:func:`qgis_tools`) that returns a list of LangChain ``BaseTool`` objects
+bound to a live runtime resource via closure. Modules import safely on
+systems where the underlying optional package is missing; the factories
+return an empty list in that case so callers can rely on:
+
+    tools = leafmap_tools(m) + qgis_tools(iface) + stac_tools()
+    create_geo_agent(tools=tools, ...)
+
+without guarding each call.
+"""
+
+__all__: list[str] = []

--- a/geoagent/tools/anymap.py
+++ b/geoagent/tools/anymap.py
@@ -1,0 +1,351 @@
+"""Tool adapters for ``anymap.Map`` instances.
+
+The :func:`anymap_tools` factory returns a list of GeoAgent-decorated tools
+bound to a single live ``anymap.Map`` (or compatible mock) via closure.
+
+anymap is a newer, lighter-weight alternative to leafmap with a similar
+top-level API. Where method names diverge, the tool bodies use ``_safe_call``
+to try the closest equivalents.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools.leafmap import _safe_call
+
+
+def anymap_tools(m: Any) -> list[BaseTool]:
+    """Build the anymap tool set bound to a live map instance.
+
+    Args:
+        m: An ``anymap.Map`` instance, or a compatible mock. Passing
+            ``None`` returns an empty list.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances.
+    """
+    if m is None:
+        return []
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def list_layers() -> list[dict[str, Any]]:
+        """List the layers currently on the map.
+
+        Returns:
+            A list of dicts ``{"name": ..., "type": ...}``.
+        """
+        layers = getattr(m, "layers", None) or []
+        out: list[dict[str, Any]] = []
+        for layer in layers:
+            if isinstance(layer, dict):
+                out.append(
+                    {
+                        "name": layer.get("name", "Unnamed"),
+                        "type": layer.get("type", "unknown"),
+                    }
+                )
+            else:
+                out.append(
+                    {
+                        "name": getattr(layer, "name", str(layer)),
+                        "type": type(layer).__name__,
+                    }
+                )
+        return out
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def add_layer(url: str, name: str, layer_type: str = "auto") -> str:
+        """Add a layer to the map by URL.
+
+        Args:
+            url: The data URL.
+            name: Display name.
+            layer_type: One of ``"raster"``, ``"vector"``, ``"cog"``,
+                ``"pmtiles"``, ``"xyz"``, or ``"auto"``.
+
+        Returns:
+            A status string.
+        """
+        kind = layer_type.lower()
+        if kind == "auto":
+            lower = url.lower()
+            if any(lower.endswith(ext) for ext in (".geojson", ".json", ".shp")):
+                kind = "vector"
+            elif lower.endswith(".pmtiles"):
+                kind = "pmtiles"
+            elif lower.endswith(".tif") or lower.endswith(".tiff"):
+                kind = "cog"
+            else:
+                kind = "raster"
+        if kind == "vector":
+            _safe_call(m, ["add_geojson", "add_vector"], url, layer_name=name)
+        elif kind in ("cog", "raster"):
+            _safe_call(m, ["add_raster", "add_cog_layer"], url, layer_name=name)
+        elif kind == "pmtiles":
+            _safe_call(m, ["add_pmtiles", "add_pmtiles_layer"], url, name=name)
+        elif kind == "xyz":
+            _safe_call(m, ["add_xyz_tile_layer", "add_tile_layer"], url, name=name)
+        else:
+            return f"Unknown layer_type {layer_type!r}."
+        return f"Added {kind} layer {name!r} from {url}."
+
+    @geo_tool(
+        category="map",
+        requires_confirmation=True,
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def remove_layer(name: str) -> str:
+        """Remove a named layer from the map.
+
+        Args:
+            name: Display name of the layer.
+
+        Returns:
+            A status string.
+        """
+        if hasattr(m, "remove_layer"):
+            removed = m.remove_layer(name)
+            if removed in (None, True):
+                return f"Removed layer {name!r}."
+            return f"Layer {name!r} not found."
+        return f"Layer {name!r} could not be removed (no remove_layer method)."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def set_center(lat: float, lon: float, zoom: Optional[int] = None) -> str:
+        """Centre the map on a coordinate.
+
+        Args:
+            lat: Latitude.
+            lon: Longitude.
+            zoom: Optional new zoom level.
+
+        Returns:
+            A status string.
+        """
+        _safe_call(m, ["set_center"], lon, lat, zoom)
+        return f"Centred on ({lat}, {lon})."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def set_zoom(zoom: int) -> str:
+        """Set the zoom level.
+
+        Args:
+            zoom: New zoom level.
+
+        Returns:
+            A status string.
+        """
+        if hasattr(m, "set_zoom"):
+            m.set_zoom(zoom)
+        else:
+            m.zoom = zoom
+        return f"Zoom set to {zoom}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def zoom_in(steps: int = 1) -> str:
+        """Zoom in by a number of steps."""
+        current = getattr(m, "zoom", 0) or 0
+        new_zoom = int(current) + int(steps)
+        if hasattr(m, "set_zoom"):
+            m.set_zoom(new_zoom)
+        else:
+            m.zoom = new_zoom
+        return f"Zoomed in to {new_zoom}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def zoom_out(steps: int = 1) -> str:
+        """Zoom out by a number of steps."""
+        current = getattr(m, "zoom", 0) or 0
+        new_zoom = max(0, int(current) - int(steps))
+        if hasattr(m, "set_zoom"):
+            m.set_zoom(new_zoom)
+        else:
+            m.zoom = new_zoom
+        return f"Zoomed out to {new_zoom}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def zoom_to_bounds(west: float, south: float, east: float, north: float) -> str:
+        """Zoom the map to a bounding box.
+
+        Args:
+            west: Western longitude.
+            south: Southern latitude.
+            east: Eastern longitude.
+            north: Northern latitude.
+
+        Returns:
+            A status string.
+        """
+        bounds = [[west, south], [east, north]]
+        _safe_call(m, ["fit_bounds", "zoom_to_bounds"], bounds)
+        return f"Zoomed to bounds [{west}, {south}, {east}, {north}]."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def change_basemap(basemap: str) -> str:
+        """Change the basemap style.
+
+        Args:
+            basemap: Basemap identifier (e.g. ``"CartoDB.Positron"``).
+
+        Returns:
+            A status string.
+        """
+        _safe_call(m, ["add_basemap", "set_basemap"], basemap)
+        return f"Basemap set to {basemap!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def add_vector_data(
+        path_or_url: str,
+        name: str,
+        style: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Add a vector dataset.
+
+        Args:
+            path_or_url: Source path or URL.
+            name: Display name.
+            style: Optional style dict.
+
+        Returns:
+            A status string.
+        """
+        _safe_call(
+            m,
+            ["add_geojson", "add_vector"],
+            path_or_url,
+            layer_name=name,
+            style=style or {},
+        )
+        return f"Added vector layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def add_raster_data(
+        path_or_url: str,
+        name: str,
+        colormap: str = "viridis",
+    ) -> str:
+        """Add a raster dataset.
+
+        Args:
+            path_or_url: Source path or URL.
+            name: Display name.
+            colormap: Colormap name.
+
+        Returns:
+            A status string.
+        """
+        _safe_call(
+            m,
+            ["add_raster", "add_cog_layer"],
+            path_or_url,
+            layer_name=name,
+            colormap=colormap,
+        )
+        return f"Added raster layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("anymap",),
+        context_keys=("map_obj",),
+    )
+    def get_map_state() -> dict[str, Any]:
+        """Return centre, zoom, bounds, basemap, and layer count."""
+        return {
+            "center": list(getattr(m, "center", []) or []),
+            "zoom": getattr(m, "zoom", None),
+            "bounds": getattr(m, "_bounds", None),
+            "basemap": getattr(m, "_style", None),
+            "layer_count": len(getattr(m, "layers", []) or []),
+        }
+
+    @geo_tool(
+        category="map",
+        requires_confirmation=True,
+        requires_packages=("anymap",),
+        context_keys=("map_obj", "workdir"),
+    )
+    def save_map(path: str) -> str:
+        """Export the map to a standalone HTML file.
+
+        Args:
+            path: Destination file path.
+
+        Returns:
+            The absolute path of the saved file.
+        """
+        from pathlib import Path
+
+        out = Path(path).expanduser().resolve()
+        if hasattr(m, "to_html"):
+            m.to_html(str(out))
+        elif hasattr(m, "save"):
+            m.save(str(out))
+        else:
+            raise AttributeError(
+                f"{type(m).__name__} has no to_html() or save() method."
+            )
+        return str(out)
+
+    return [
+        list_layers,
+        add_layer,
+        remove_layer,
+        set_center,
+        set_zoom,
+        zoom_in,
+        zoom_out,
+        zoom_to_bounds,
+        change_basemap,
+        add_vector_data,
+        add_raster_data,
+        get_map_state,
+        save_map,
+    ]
+
+
+__all__ = ["anymap_tools"]

--- a/geoagent/tools/data/__init__.py
+++ b/geoagent/tools/data/__init__.py
@@ -1,0 +1,9 @@
+"""Data manipulation tools (raster, vector, DuckDB spatial SQL, viz).
+
+Each submodule exposes a ``*_tools()`` factory that returns a list of
+LangChain ``BaseTool`` instances stamped with GeoAgent metadata. All wrap
+existing implementations from :mod:`geoagent.core.tools` to preserve
+behaviour while adding the new category and confirmation metadata.
+"""
+
+__all__: list[str] = []

--- a/geoagent/tools/data/duckdb.py
+++ b/geoagent/tools/data/duckdb.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from langchain_core.tools import BaseTool
 
-from geoagent.tools.stac import _stamp
+from geoagent.core.decorators import stamp_geo_meta
 
 
 def duckdb_tools() -> list[BaseTool]:
@@ -29,7 +29,7 @@ def duckdb_tools() -> list[BaseTool]:
     requirements = ["duckdb"]
     tools = (query_spatial_data, query_overture, analyze_spatial_data)
     for tool in tools:
-        _stamp(
+        stamp_geo_meta(
             tool,
             category="data",
             requires_confirmation=False,

--- a/geoagent/tools/data/duckdb.py
+++ b/geoagent/tools/data/duckdb.py
@@ -1,0 +1,41 @@
+"""DuckDB spatial SQL tools.
+
+Wraps the v0.x DuckDB tools (:mod:`geoagent.core.tools.duckdb_tool`) with
+GeoAgent metadata.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+
+from geoagent.tools.stac import _stamp
+
+
+def duckdb_tools() -> list[BaseTool]:
+    """Build the DuckDB spatial SQL tool set.
+
+    Returns:
+        ``query_spatial_data``, ``query_overture``, ``analyze_spatial_data``.
+    """
+    try:
+        from geoagent.core.tools.duckdb_tool import (
+            query_spatial_data,
+            query_overture,
+            analyze_spatial_data,
+        )
+    except ImportError:
+        return []
+
+    requirements = ["duckdb"]
+    tools = (query_spatial_data, query_overture, analyze_spatial_data)
+    for tool in tools:
+        _stamp(
+            tool,
+            category="data",
+            requires_confirmation=False,
+            requires_packages=requirements,
+        )
+    return list(tools)
+
+
+__all__ = ["duckdb_tools"]

--- a/geoagent/tools/data/raster.py
+++ b/geoagent/tools/data/raster.py
@@ -1,0 +1,43 @@
+"""Raster analysis tools.
+
+Wraps the v0.x raster tools (:mod:`geoagent.core.tools.raster`) with GeoAgent
+metadata so they show up in the new registry under ``category="data"``.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+
+from geoagent.tools.stac import _stamp
+
+
+def raster_tools() -> list[BaseTool]:
+    """Build the raster tool set.
+
+    Returns:
+        ``load_raster``, ``compute_index``, ``raster_to_array``,
+        ``zonal_stats`` — each a LangChain ``BaseTool``.
+    """
+    try:
+        from geoagent.core.tools.raster import (
+            load_raster,
+            compute_index,
+            raster_to_array,
+            zonal_stats,
+        )
+    except ImportError:
+        return []
+
+    requirements = ["rasterio", "rioxarray", "xarray"]
+    for tool in (load_raster, compute_index, raster_to_array, zonal_stats):
+        _stamp(
+            tool,
+            category="data",
+            requires_confirmation=False,
+            requires_packages=requirements,
+        )
+
+    return [load_raster, compute_index, raster_to_array, zonal_stats]
+
+
+__all__ = ["raster_tools"]

--- a/geoagent/tools/data/raster.py
+++ b/geoagent/tools/data/raster.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from langchain_core.tools import BaseTool
 
-from geoagent.tools.stac import _stamp
+from geoagent.core.decorators import stamp_geo_meta
 
 
 def raster_tools() -> list[BaseTool]:
@@ -30,7 +30,7 @@ def raster_tools() -> list[BaseTool]:
 
     requirements = ["rasterio", "rioxarray", "xarray"]
     for tool in (load_raster, compute_index, raster_to_array, zonal_stats):
-        _stamp(
+        stamp_geo_meta(
             tool,
             category="data",
             requires_confirmation=False,

--- a/geoagent/tools/data/vector.py
+++ b/geoagent/tools/data/vector.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from langchain_core.tools import BaseTool
 
-from geoagent.tools.stac import _stamp
+from geoagent.core.decorators import stamp_geo_meta
 
 
 def vector_tools() -> list[BaseTool]:
@@ -38,7 +38,7 @@ def vector_tools() -> list[BaseTool]:
         analyze_geometries,
     )
     for tool in tools:
-        _stamp(
+        stamp_geo_meta(
             tool,
             category="data",
             requires_confirmation=False,

--- a/geoagent/tools/data/vector.py
+++ b/geoagent/tools/data/vector.py
@@ -1,0 +1,50 @@
+"""Vector analysis tools.
+
+Wraps the v0.x vector tools (:mod:`geoagent.core.tools.vector`) with
+GeoAgent metadata.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+
+from geoagent.tools.stac import _stamp
+
+
+def vector_tools() -> list[BaseTool]:
+    """Build the vector tool set.
+
+    Returns:
+        ``read_vector``, ``spatial_filter``, ``buffer_analysis``,
+        ``spatial_join``, ``analyze_geometries``.
+    """
+    try:
+        from geoagent.core.tools.vector import (
+            read_vector,
+            spatial_filter,
+            buffer_analysis,
+            spatial_join,
+            analyze_geometries,
+        )
+    except ImportError:
+        return []
+
+    requirements = ["geopandas", "shapely"]
+    tools = (
+        read_vector,
+        spatial_filter,
+        buffer_analysis,
+        spatial_join,
+        analyze_geometries,
+    )
+    for tool in tools:
+        _stamp(
+            tool,
+            category="data",
+            requires_confirmation=False,
+            requires_packages=requirements,
+        )
+    return list(tools)
+
+
+__all__ = ["vector_tools"]

--- a/geoagent/tools/data/viz.py
+++ b/geoagent/tools/data/viz.py
@@ -1,0 +1,64 @@
+"""Data-side visualisation tools (map snapshot helpers).
+
+Wraps the v0.x visualisation helpers (:mod:`geoagent.core.tools.viz`) with
+GeoAgent metadata. These differ from the live-map control tools in
+:mod:`geoagent.tools.leafmap`: viz tools build a new map for one-shot
+rendering, whereas the leafmap tools mutate an existing map widget.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+
+from geoagent.tools.stac import _stamp
+
+
+def viz_tools() -> list[BaseTool]:
+    """Build the viz tool set.
+
+    Returns:
+        ``show_on_map``, ``add_cog_layer``, ``add_vector_layer``,
+        ``split_map``, ``create_choropleth_map``, ``add_pmtiles_layer``,
+        ``create_3d_terrain_map``, ``save_map``.
+    """
+    try:
+        from geoagent.core.tools.viz import (
+            show_on_map,
+            add_cog_layer,
+            add_vector_layer,
+            split_map,
+            create_choropleth_map,
+            add_pmtiles_layer,
+            create_3d_terrain_map,
+            save_map,
+        )
+    except ImportError:
+        return []
+
+    requirements = ["leafmap"]
+    safe_tools = (
+        show_on_map,
+        add_cog_layer,
+        add_vector_layer,
+        split_map,
+        create_choropleth_map,
+        add_pmtiles_layer,
+        create_3d_terrain_map,
+    )
+    for tool in safe_tools:
+        _stamp(
+            tool,
+            category="map",
+            requires_confirmation=False,
+            requires_packages=requirements,
+        )
+    _stamp(
+        save_map,
+        category="io",
+        requires_confirmation=True,
+        requires_packages=requirements,
+    )
+    return list(safe_tools) + [save_map]
+
+
+__all__ = ["viz_tools"]

--- a/geoagent/tools/data/viz.py
+++ b/geoagent/tools/data/viz.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from langchain_core.tools import BaseTool
 
-from geoagent.tools.stac import _stamp
+from geoagent.core.decorators import stamp_geo_meta
 
 
 def viz_tools() -> list[BaseTool]:
@@ -46,7 +46,7 @@ def viz_tools() -> list[BaseTool]:
         create_3d_terrain_map,
     )
     for tool in safe_tools:
-        _stamp(
+        stamp_geo_meta(
             tool,
             category="map",
             requires_confirmation=False,

--- a/geoagent/tools/earthengine.py
+++ b/geoagent/tools/earthengine.py
@@ -1,0 +1,194 @@
+"""Tool adapters for Google Earth Engine.
+
+Import-safe when ``earthengine-api`` (``ee``) is not installed.
+:func:`earthengine_tools` returns an empty list when EE is unavailable or
+not initialised.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import geo_tool
+
+try:
+    import ee  # type: ignore[import-not-found]
+
+    _EE_AVAILABLE = True
+except ImportError:
+    ee = None  # type: ignore[assignment]
+    _EE_AVAILABLE = False
+
+
+def earthengine_tools(ee_initialized: bool = True) -> list[BaseTool]:
+    """Build the Earth Engine tool set.
+
+    Args:
+        ee_initialized: Pass ``False`` to skip building tools even when ``ee``
+            is importable, e.g. when ``ee.Initialize()`` has not been called
+            yet. Useful for plugins that defer EE auth until the user
+            chooses to use it.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances, or empty if Earth Engine
+        is unavailable.
+    """
+    if not _EE_AVAILABLE or not ee_initialized:
+        return []
+
+    @geo_tool(
+        category="data",
+        requires_packages=("ee",),
+    )
+    def search_collection(query: str, max_results: int = 10) -> list[dict[str, Any]]:
+        """Search the Earth Engine catalog for collections matching a query.
+
+        Args:
+            query: Free-text search string.
+            max_results: Maximum number of collections to return.
+
+        Returns:
+            A list of dicts with ``id``, ``title``, and ``description`` keys
+            (when available).
+        """
+        try:
+            data = ee.data.listAssets(  # type: ignore[union-attr]
+                {"parent": "projects/earthengine-public/assets", "filter": query}
+            )
+        except Exception as exc:
+            return [{"error": str(exc)}]
+        assets = data.get("assets", [])[:max_results]
+        return [{"id": a.get("name", ""), "type": a.get("type", "")} for a in assets]
+
+    @geo_tool(
+        category="data",
+        requires_packages=("ee",),
+    )
+    def get_image_metadata(asset_id: str) -> dict[str, Any]:
+        """Return key metadata for an EE Image asset.
+
+        Args:
+            asset_id: Earth Engine asset ID.
+
+        Returns:
+            A metadata dict from ``ee.Image.getInfo()``.
+        """
+        return ee.Image(asset_id).getInfo()  # type: ignore[union-attr]
+
+    @geo_tool(
+        category="data",
+        requires_packages=("ee",),
+    )
+    def compute_index(
+        asset_id: str,
+        index: str = "NDVI",
+        red_band: str = "B4",
+        nir_band: str = "B8",
+    ) -> dict[str, Any]:
+        """Compute a spectral index on an EE Image.
+
+        Args:
+            asset_id: Earth Engine asset ID for the source image.
+            index: Index name (``"NDVI"``, ``"NDWI"``, ``"EVI"``).
+            red_band: Red band name.
+            nir_band: NIR band name.
+
+        Returns:
+            A dict with ``"asset_id"`` and ``"index"`` keys describing the
+            computed image (left as a server-side reference; serialise via
+            ``getInfo`` only on small AOIs).
+        """
+        image = ee.Image(asset_id)  # type: ignore[union-attr]
+        if index.upper() == "NDVI":
+            result = image.normalizedDifference([nir_band, red_band]).rename("NDVI")
+        elif index.upper() == "NDWI":
+            result = image.normalizedDifference([nir_band, red_band]).rename("NDWI")
+        else:
+            raise ValueError(f"Unsupported index {index!r}.")
+        return {"asset_id": asset_id, "index": index, "image_id": str(result)}
+
+    @geo_tool(
+        category="io",
+        requires_confirmation=True,
+        requires_packages=("ee",),
+    )
+    def export_to_drive(
+        asset_id: str,
+        description: str,
+        folder: str = "GeoAgentExports",
+        scale: int = 30,
+    ) -> dict[str, Any]:
+        """Submit an Earth Engine export task to Google Drive.
+
+        Args:
+            asset_id: Earth Engine image asset ID.
+            description: Task description (used as the filename prefix).
+            folder: Destination Drive folder.
+            scale: Pixel scale in metres.
+
+        Returns:
+            A dict with the task id and status.
+        """
+        image = ee.Image(asset_id)  # type: ignore[union-attr]
+        task = ee.batch.Export.image.toDrive(  # type: ignore[union-attr]
+            image=image,
+            description=description,
+            folder=folder,
+            scale=scale,
+        )
+        task.start()
+        return {"task_id": task.id, "status": "STARTED", "description": description}
+
+    @geo_tool(
+        category="io",
+        requires_confirmation=True,
+        requires_packages=("ee",),
+    )
+    def submit_task(asset_id: str, description: str) -> dict[str, Any]:
+        """Submit a generic export task for an EE asset.
+
+        Args:
+            asset_id: Earth Engine asset ID.
+            description: Task description.
+
+        Returns:
+            A dict with the task id.
+        """
+        image = ee.Image(asset_id)  # type: ignore[union-attr]
+        task = ee.batch.Export.image.toAsset(  # type: ignore[union-attr]
+            image=image, description=description
+        )
+        task.start()
+        return {"task_id": task.id, "status": "STARTED"}
+
+    @geo_tool(
+        category="data",
+        requires_packages=("ee",),
+    )
+    def get_task_status(task_id: str) -> dict[str, Any]:
+        """Return the status of a submitted EE task.
+
+        Args:
+            task_id: Task id from a previous export call.
+
+        Returns:
+            The task status dict reported by Earth Engine.
+        """
+        for task in ee.batch.Task.list():  # type: ignore[union-attr]
+            if getattr(task, "id", None) == task_id:
+                return task.status()
+        return {"task_id": task_id, "status": "UNKNOWN"}
+
+    return [
+        search_collection,
+        get_image_metadata,
+        compute_index,
+        export_to_drive,
+        submit_task,
+        get_task_status,
+    ]
+
+
+__all__ = ["earthengine_tools"]

--- a/geoagent/tools/earthengine.py
+++ b/geoagent/tools/earthengine.py
@@ -86,14 +86,16 @@ def earthengine_tools(ee_initialized: bool = True) -> list[BaseTool]:
         index: str = "NDVI",
         red_band: str = "B4",
         nir_band: str = "B8",
+        green_band: str = "B3",
     ) -> dict[str, Any]:
         """Compute a spectral index on an EE Image.
 
         Args:
             asset_id: Earth Engine asset ID for the source image.
-            index: Index name (``"NDVI"``, ``"NDWI"``, ``"EVI"``).
-            red_band: Red band name.
-            nir_band: NIR band name.
+            index: Index name (``"NDVI"``, ``"NDWI"``).
+            red_band: Red band name (used by NDVI).
+            nir_band: NIR band name (used by NDVI and NDWI).
+            green_band: Green band name (used by NDWI).
 
         Returns:
             A dict with ``"asset_id"`` and ``"index"`` keys describing the
@@ -101,10 +103,13 @@ def earthengine_tools(ee_initialized: bool = True) -> list[BaseTool]:
             ``getInfo`` only on small AOIs).
         """
         image = ee.Image(asset_id)  # type: ignore[union-attr]
-        if index.upper() == "NDVI":
+        idx = index.upper()
+        if idx == "NDVI":
+            # NDVI = (NIR - Red) / (NIR + Red)
             result = image.normalizedDifference([nir_band, red_band]).rename("NDVI")
-        elif index.upper() == "NDWI":
-            result = image.normalizedDifference([nir_band, red_band]).rename("NDWI")
+        elif idx == "NDWI":
+            # NDWI (McFeeters) = (Green - NIR) / (Green + NIR)
+            result = image.normalizedDifference([green_band, nir_band]).rename("NDWI")
         else:
             raise ValueError(f"Unsupported index {index!r}.")
         return {"asset_id": asset_id, "index": index, "image_id": str(result)}

--- a/geoagent/tools/geoai.py
+++ b/geoagent/tools/geoai.py
@@ -1,0 +1,136 @@
+"""Tool adapters for the ``geoai`` package.
+
+This module is import-safe when ``geoai`` is not installed: the top-level
+import is guarded, and :func:`geoai_tools` returns an empty list in that
+case so the registry transparently filters these tools out.
+
+The tool functions wrap the most commonly used ``geoai`` entry points:
+segmentation, object detection, and image classification.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import geo_tool
+
+try:
+    import geoai  # type: ignore[import-not-found]
+
+    _GEOAI_AVAILABLE = True
+except ImportError:
+    geoai = None  # type: ignore[assignment]
+    _GEOAI_AVAILABLE = False
+
+
+def geoai_tools() -> list[BaseTool]:
+    """Build the geoai tool set.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances. Empty when ``geoai`` is
+        not importable.
+    """
+    if not _GEOAI_AVAILABLE:
+        return []
+
+    @geo_tool(
+        category="ai",
+        requires_packages=("geoai",),
+        context_keys=("workdir",),
+    )
+    def segment_image(
+        image_path: str,
+        model: str = "geodeep",
+        output_path: Optional[str] = None,
+        output_format: str = "raster",
+    ) -> dict[str, Any]:
+        """Run instance / semantic segmentation on a raster image.
+
+        Args:
+            image_path: Source raster path or URL.
+            model: GeoAI model identifier (default ``"geodeep"``).
+            output_path: Optional destination path. If omitted, geoai
+                chooses a default in the working directory.
+            output_format: ``"raster"`` or ``"vector"``.
+
+        Returns:
+            A dict with ``"output_path"`` and any model-reported metrics.
+        """
+        kwargs: dict[str, Any] = {"output_format": output_format}
+        if output_path is not None:
+            kwargs["output_path"] = output_path
+        if hasattr(geoai, "geodeep_segment"):
+            result = geoai.geodeep_segment(image_path, model=model, **kwargs)
+        elif hasattr(geoai, "semantic_segmentation"):
+            result = geoai.semantic_segmentation(image_path, model=model, **kwargs)
+        else:
+            raise RuntimeError(
+                "geoai does not expose geodeep_segment or semantic_segmentation."
+            )
+        return {"output_path": output_path, "result": result}
+
+    @geo_tool(
+        category="ai",
+        requires_packages=("geoai",),
+        context_keys=("workdir",),
+    )
+    def detect_objects(
+        image_path: str,
+        model: str = "geodeep",
+        labels: Optional[list[str]] = None,
+        output_path: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Detect objects in a raster image.
+
+        Args:
+            image_path: Source raster path or URL.
+            model: Model identifier.
+            labels: Optional class label list to restrict detection.
+            output_path: Optional vector output path.
+
+        Returns:
+            A dict with ``"output_path"`` and the raw detection result.
+        """
+        kwargs: dict[str, Any] = {}
+        if labels is not None:
+            kwargs["labels"] = labels
+        if output_path is not None:
+            kwargs["output_path"] = output_path
+        if hasattr(geoai, "geodeep_detect"):
+            result = geoai.geodeep_detect(image_path, model=model, **kwargs)
+        elif hasattr(geoai, "object_detection"):
+            result = geoai.object_detection(image_path, model=model, **kwargs)
+        else:
+            raise RuntimeError(
+                "geoai does not expose geodeep_detect or object_detection."
+            )
+        return {"output_path": output_path, "result": result}
+
+    @geo_tool(
+        category="ai",
+        requires_packages=("geoai",),
+        context_keys=("workdir",),
+    )
+    def classify_image(
+        image_path: str,
+        model: str = "geodeep",
+    ) -> dict[str, Any]:
+        """Classify an entire image to a single category.
+
+        Args:
+            image_path: Source raster path or URL.
+            model: Model identifier.
+
+        Returns:
+            A dict with ``"label"`` and ``"score"`` keys.
+        """
+        if hasattr(geoai, "image_classification"):
+            return geoai.image_classification(image_path, model=model)
+        raise RuntimeError("geoai does not expose image_classification.")
+
+    return [segment_image, detect_objects, classify_image]
+
+
+__all__ = ["geoai_tools"]

--- a/geoagent/tools/leafmap.py
+++ b/geoagent/tools/leafmap.py
@@ -18,9 +18,16 @@ from langchain_core.tools import BaseTool
 
 from geoagent.core.decorators import geo_tool
 
+_NAME_KW_ALIASES = ("name", "layer_name")
+
 
 def _safe_call(obj: Any, names: list[str], *args: Any, **kwargs: Any) -> Any:
     """Call the first available method on ``obj`` from ``names``.
+
+    If the chosen method rejects a ``name=`` / ``layer_name=`` kwarg with a
+    ``TypeError``, retry with the other alias before giving up. leafmap and
+    anymap occasionally disagree on which spelling each helper expects, and
+    the fallback methods we degrade to may use the alternate alias.
 
     Args:
         obj: Target object (a leafmap Map or similar).
@@ -33,10 +40,29 @@ def _safe_call(obj: Any, names: list[str], *args: Any, **kwargs: Any) -> Any:
 
     Raises:
         AttributeError: If none of ``names`` exists on ``obj``.
+        TypeError: If the chosen method rejects the kwargs even after
+            trying the alternative ``name`` / ``layer_name`` alias.
     """
     for n in names:
-        if hasattr(obj, n):
-            return getattr(obj, n)(*args, **kwargs)
+        if not hasattr(obj, n):
+            continue
+        method = getattr(obj, n)
+        try:
+            return method(*args, **kwargs)
+        except TypeError:
+            # Try the alternate spelling of the layer-name kwarg, if any.
+            for primary, alternate in (
+                ("name", "layer_name"),
+                ("layer_name", "name"),
+            ):
+                if primary in kwargs and alternate not in kwargs:
+                    alt = dict(kwargs)
+                    alt[alternate] = alt.pop(primary)
+                    try:
+                        return method(*args, **alt)
+                    except TypeError:
+                        continue
+            raise
     raise AttributeError(
         f"None of {names!r} found on {type(obj).__name__}; cannot perform action."
     )
@@ -182,7 +208,9 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
             A status string.
         """
         _safe_call(m, ["set_center"], lon, lat, zoom)
-        return f"Centred on ({lat}, {lon})" + (f" at zoom {zoom}." if zoom else ".")
+        return f"Centred on ({lat}, {lon})" + (
+            f" at zoom {zoom}." if zoom is not None else "."
+        )
 
     @geo_tool(
         category="map",

--- a/geoagent/tools/leafmap.py
+++ b/geoagent/tools/leafmap.py
@@ -1,0 +1,523 @@
+"""Tool adapters for ``leafmap.Map`` instances.
+
+The :func:`leafmap_tools` factory returns a list of GeoAgent-decorated tools
+bound to a single live ``leafmap.Map`` (or compatible mock) via closure. The
+map object never crosses the LLM boundary — only its methods are invoked
+under the hood.
+
+These tools target the ``leafmap.maplibregl.Map`` API surface, but degrade
+gracefully when methods are absent (e.g. older leafmap versions, or the
+:class:`MockLeafmap` test stub) by trying the closest equivalent method name.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import geo_tool
+
+
+def _safe_call(obj: Any, names: list[str], *args: Any, **kwargs: Any) -> Any:
+    """Call the first available method on ``obj`` from ``names``.
+
+    Args:
+        obj: Target object (a leafmap Map or similar).
+        names: Candidate method names, tried in order.
+        *args: Positional arguments forwarded to the chosen method.
+        **kwargs: Keyword arguments forwarded to the chosen method.
+
+    Returns:
+        The method's return value.
+
+    Raises:
+        AttributeError: If none of ``names`` exists on ``obj``.
+    """
+    for n in names:
+        if hasattr(obj, n):
+            return getattr(obj, n)(*args, **kwargs)
+    raise AttributeError(
+        f"None of {names!r} found on {type(obj).__name__}; cannot perform action."
+    )
+
+
+def leafmap_tools(m: Any) -> list[BaseTool]:
+    """Build the leafmap tool set bound to a live map instance.
+
+    Args:
+        m: A ``leafmap.Map`` (or ``leafmap.maplibregl.Map``) instance, or any
+            object exposing the same minimal API. Passing ``None`` returns an
+            empty list.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances. Each tool captures
+        ``m`` via closure; the LLM never sees the map object.
+    """
+    if m is None:
+        return []
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def list_layers() -> list[dict[str, Any]]:
+        """List the layers currently on the map.
+
+        Returns:
+            A list of dicts ``{"name": ..., "type": ...}`` for each layer.
+        """
+        layers = getattr(m, "layers", None) or []
+        out: list[dict[str, Any]] = []
+        for layer in layers:
+            if isinstance(layer, dict):
+                out.append(
+                    {
+                        "name": layer.get("name", "Unnamed"),
+                        "type": layer.get("type", "unknown"),
+                    }
+                )
+            else:
+                out.append(
+                    {
+                        "name": getattr(layer, "name", str(layer)),
+                        "type": type(layer).__name__,
+                    }
+                )
+        return out
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_layer(url: str, name: str, layer_type: str = "auto") -> str:
+        """Add a layer to the map by URL.
+
+        Args:
+            url: The data URL (HTTP, S3, file path).
+            name: Display name for the layer.
+            layer_type: One of ``"raster"``, ``"vector"``, ``"cog"``,
+                ``"pmtiles"``, ``"xyz"``, or ``"auto"``. ``"auto"`` infers
+                from the URL extension.
+
+        Returns:
+            A status string describing the action taken.
+        """
+        kind = layer_type.lower()
+        if kind == "auto":
+            lower = url.lower()
+            if any(lower.endswith(ext) for ext in (".geojson", ".json", ".shp")):
+                kind = "vector"
+            elif lower.endswith(".pmtiles"):
+                kind = "pmtiles"
+            elif lower.endswith(".tif") or lower.endswith(".tiff"):
+                kind = "cog"
+            else:
+                kind = "raster"
+        if kind in ("cog", "raster"):
+            _safe_call(m, ["add_cog_layer", "add_raster"], url, name=name)
+        elif kind == "vector":
+            _safe_call(m, ["add_vector", "add_geojson"], url, layer_name=name)
+        elif kind == "pmtiles":
+            _safe_call(m, ["add_pmtiles", "add_pmtiles_layer"], url, name=name)
+        elif kind == "xyz":
+            _safe_call(m, ["add_xyz_tile_layer", "add_tile_layer"], url, name=name)
+        else:
+            return f"Unknown layer_type {layer_type!r}."
+        return f"Added {kind} layer {name!r} from {url}."
+
+    @geo_tool(
+        category="map",
+        requires_confirmation=True,
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def remove_layer(name: str) -> str:
+        """Remove a layer from the map by display name.
+
+        Args:
+            name: The display name of the layer to remove.
+
+        Returns:
+            A status string indicating whether the layer was removed.
+        """
+        if hasattr(m, "remove_layer"):
+            removed = m.remove_layer(name)
+            if removed in (None, True):
+                return f"Removed layer {name!r}."
+            return f"Layer {name!r} not found."
+        layers = getattr(m, "layers", None)
+        if isinstance(layers, list):
+            before = len(layers)
+            m.layers = [
+                layer
+                for layer in layers
+                if (
+                    layer.get("name")
+                    if isinstance(layer, dict)
+                    else getattr(layer, "name", None)
+                )
+                != name
+            ]
+            if len(m.layers) < before:
+                return f"Removed layer {name!r}."
+        return f"Layer {name!r} not found."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def set_center(lat: float, lon: float, zoom: Optional[int] = None) -> str:
+        """Centre the map on a coordinate.
+
+        Args:
+            lat: Latitude in WGS84.
+            lon: Longitude in WGS84.
+            zoom: Optional new zoom level.
+
+        Returns:
+            A status string.
+        """
+        _safe_call(m, ["set_center"], lon, lat, zoom)
+        return f"Centred on ({lat}, {lon})" + (f" at zoom {zoom}." if zoom else ".")
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def set_zoom(zoom: int) -> str:
+        """Set the zoom level.
+
+        Args:
+            zoom: Zoom level (typically 0–22).
+
+        Returns:
+            A status string.
+        """
+        if hasattr(m, "set_zoom"):
+            m.set_zoom(zoom)
+        else:
+            m.zoom = zoom
+        return f"Zoom set to {zoom}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def zoom_in(steps: int = 1) -> str:
+        """Zoom in by a number of steps.
+
+        Args:
+            steps: Number of zoom levels to add. Default 1.
+
+        Returns:
+            A status string.
+        """
+        current = getattr(m, "zoom", 0) or 0
+        new_zoom = int(current) + int(steps)
+        if hasattr(m, "set_zoom"):
+            m.set_zoom(new_zoom)
+        else:
+            m.zoom = new_zoom
+        return f"Zoomed in to {new_zoom}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def zoom_out(steps: int = 1) -> str:
+        """Zoom out by a number of steps.
+
+        Args:
+            steps: Number of zoom levels to subtract. Default 1.
+
+        Returns:
+            A status string.
+        """
+        current = getattr(m, "zoom", 0) or 0
+        new_zoom = max(0, int(current) - int(steps))
+        if hasattr(m, "set_zoom"):
+            m.set_zoom(new_zoom)
+        else:
+            m.zoom = new_zoom
+        return f"Zoomed out to {new_zoom}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def zoom_to_bounds(west: float, south: float, east: float, north: float) -> str:
+        """Zoom to a bounding box.
+
+        Args:
+            west: Western longitude.
+            south: Southern latitude.
+            east: Eastern longitude.
+            north: Northern latitude.
+
+        Returns:
+            A status string.
+        """
+        bounds = [[west, south], [east, north]]
+        _safe_call(m, ["fit_bounds", "zoom_to_bounds"], bounds)
+        return f"Zoomed to bounds [{west}, {south}, {east}, {north}]."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def change_basemap(basemap: str) -> str:
+        """Change the basemap style.
+
+        Args:
+            basemap: A leafmap basemap identifier (e.g. ``"OpenStreetMap"``,
+                ``"CartoDB.Positron"``, ``"Esri.WorldImagery"``).
+
+        Returns:
+            A status string.
+        """
+        _safe_call(m, ["add_basemap", "set_basemap"], basemap)
+        return f"Basemap set to {basemap!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_vector_data(
+        path_or_url: str,
+        name: str,
+        style: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Add a vector dataset (GeoJSON, Shapefile, GeoPackage).
+
+        Args:
+            path_or_url: Source path or URL.
+            name: Display name.
+            style: Optional style dict (e.g. ``{"color": "red"}``).
+
+        Returns:
+            A status string.
+        """
+        _safe_call(
+            m,
+            ["add_vector", "add_geojson"],
+            path_or_url,
+            layer_name=name,
+            style=style or {},
+        )
+        return f"Added vector layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_raster_data(
+        path_or_url: str,
+        name: str,
+        colormap: str = "viridis",
+    ) -> str:
+        """Add a raster dataset (GeoTIFF, COG, NetCDF).
+
+        Args:
+            path_or_url: Source path or URL.
+            name: Display name.
+            colormap: Colormap name (default ``"viridis"``).
+
+        Returns:
+            A status string.
+        """
+        _safe_call(
+            m,
+            ["add_raster", "add_cog_layer"],
+            path_or_url,
+            layer_name=name,
+            colormap=colormap,
+        )
+        return f"Added raster layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_stac_layer(
+        collection: str,
+        item: Optional[str] = None,
+        assets: Optional[list[str]] = None,
+        name: Optional[str] = None,
+    ) -> str:
+        """Add a STAC layer to the map.
+
+        Args:
+            collection: STAC collection identifier.
+            item: STAC item identifier (optional).
+            assets: List of asset keys to render.
+            name: Display name (defaults to the collection or item id).
+
+        Returns:
+            A status string.
+        """
+        kwargs = {"collection": collection, "item": item, "assets": assets or []}
+        layer_name = name or item or collection
+        kwargs["name"] = layer_name
+        _safe_call(m, ["add_stac_layer"], **kwargs)
+        return f"Added STAC layer {layer_name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_cog_layer(
+        url: str,
+        name: str,
+        colormap: str = "viridis",
+    ) -> str:
+        """Add a Cloud Optimized GeoTIFF layer.
+
+        Args:
+            url: COG URL.
+            name: Display name.
+            colormap: Colormap name.
+
+        Returns:
+            A status string.
+        """
+        _safe_call(m, ["add_cog_layer"], url, name=name, colormap=colormap)
+        return f"Added COG layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_xyz_tile_layer(
+        url: str,
+        name: str,
+        attribution: str = "",
+    ) -> str:
+        """Add an XYZ tile layer.
+
+        Args:
+            url: XYZ tile URL template.
+            name: Display name.
+            attribution: Map attribution string.
+
+        Returns:
+            A status string.
+        """
+        _safe_call(
+            m,
+            ["add_xyz_tile_layer", "add_tile_layer"],
+            url,
+            name=name,
+            attribution=attribution,
+        )
+        return f"Added XYZ layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def add_pmtiles_layer(
+        url: str,
+        name: str,
+        style: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Add a PMTiles vector layer.
+
+        Args:
+            url: PMTiles URL.
+            name: Display name.
+            style: Optional MapLibre style dict.
+
+        Returns:
+            A status string.
+        """
+        kwargs: dict[str, Any] = {"name": name}
+        if style is not None:
+            kwargs["style"] = style
+        _safe_call(m, ["add_pmtiles", "add_pmtiles_layer"], url, **kwargs)
+        return f"Added PMTiles layer {name!r}."
+
+    @geo_tool(
+        category="map",
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def get_map_state() -> dict[str, Any]:
+        """Read the current map view (centre, zoom, bounds, basemap).
+
+        Returns:
+            A dict with ``"center"``, ``"zoom"``, ``"bounds"``, and
+            ``"basemap"`` keys, populated where available.
+        """
+        return {
+            "center": list(getattr(m, "center", []) or []),
+            "zoom": getattr(m, "zoom", None),
+            "bounds": getattr(m, "_bounds", None),
+            "basemap": getattr(m, "_style", None),
+            "layer_count": len(getattr(m, "layers", []) or []),
+        }
+
+    @geo_tool(
+        category="map",
+        requires_confirmation=True,
+        requires_packages=("leafmap",),
+        context_keys=("map_obj", "workdir"),
+    )
+    def save_map(path: str) -> str:
+        """Export the map to a standalone HTML file.
+
+        Args:
+            path: Destination file path (overwritten if it exists).
+
+        Returns:
+            The absolute path of the saved file.
+        """
+        from pathlib import Path
+
+        out = Path(path).expanduser().resolve()
+        if hasattr(m, "to_html"):
+            m.to_html(str(out))
+        elif hasattr(m, "save"):
+            m.save(str(out))
+        else:
+            raise AttributeError(
+                f"{type(m).__name__} has no to_html() or save() method."
+            )
+        return str(out)
+
+    return [
+        list_layers,
+        add_layer,
+        remove_layer,
+        set_center,
+        set_zoom,
+        zoom_in,
+        zoom_out,
+        zoom_to_bounds,
+        change_basemap,
+        add_vector_data,
+        add_raster_data,
+        add_stac_layer,
+        add_cog_layer,
+        add_xyz_tile_layer,
+        add_pmtiles_layer,
+        get_map_state,
+        save_map,
+    ]
+
+
+__all__ = ["leafmap_tools"]

--- a/geoagent/tools/nasa_earthdata.py
+++ b/geoagent/tools/nasa_earthdata.py
@@ -1,0 +1,168 @@
+"""Tool adapters for NASA Earthdata via the ``earthaccess`` library.
+
+Import-safe when ``earthaccess`` is not installed; :func:`earthdata_tools`
+returns an empty list in that case.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import geo_tool
+
+try:
+    import earthaccess  # type: ignore[import-not-found]
+
+    _EARTHACCESS_AVAILABLE = True
+except ImportError:
+    earthaccess = None  # type: ignore[assignment]
+    _EARTHACCESS_AVAILABLE = False
+
+
+def earthdata_tools() -> list[BaseTool]:
+    """Build the NASA Earthdata tool set.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances. Empty when
+        ``earthaccess`` is unavailable.
+    """
+    if not _EARTHACCESS_AVAILABLE:
+        return []
+
+    @geo_tool(
+        category="data",
+        requires_packages=("earthaccess",),
+    )
+    def search_granules(
+        short_name: str,
+        bbox: Optional[list[float]] = None,
+        temporal: Optional[list[str]] = None,
+        max_results: int = 25,
+    ) -> list[dict[str, Any]]:
+        """Search the NASA Earthdata CMR for granules.
+
+        Args:
+            short_name: Collection short name (e.g. ``"HLSL30"``).
+            bbox: Bounding box ``[west, south, east, north]`` in WGS84.
+            temporal: ``[start, end]`` ISO datetimes (e.g.
+                ``["2024-06-01", "2024-06-30"]``).
+            max_results: Maximum number of granules to return.
+
+        Returns:
+            A list of granule metadata dicts.
+        """
+        kwargs: dict[str, Any] = {"short_name": short_name, "count": max_results}
+        if bbox is not None:
+            kwargs["bounding_box"] = tuple(bbox)
+        if temporal is not None:
+            kwargs["temporal"] = tuple(temporal)
+        results = earthaccess.search_data(**kwargs)
+        out: list[dict[str, Any]] = []
+        for granule in results:
+            try:
+                out.append(
+                    {
+                        "id": str(granule.get("meta", {}).get("concept-id", "")),
+                        "title": str(granule.get("umm", {}).get("GranuleUR", "")),
+                        "links": [link for link in granule.data_links()],
+                    }
+                )
+            except Exception:
+                out.append({"granule": str(granule)})
+        return out
+
+    @geo_tool(
+        category="data",
+        requires_packages=("earthaccess",),
+    )
+    def list_collections(
+        keyword: str,
+        max_results: int = 25,
+    ) -> list[dict[str, Any]]:
+        """List NASA Earthdata collections matching a keyword.
+
+        Args:
+            keyword: Free-text search keyword.
+            max_results: Maximum number of collections to return.
+
+        Returns:
+            A list of collection metadata dicts.
+        """
+        results = earthaccess.search_datasets(keyword=keyword, count=max_results)
+        out: list[dict[str, Any]] = []
+        for dataset in results:
+            try:
+                umm = dataset.get("umm", {}) if isinstance(dataset, dict) else {}
+                out.append(
+                    {
+                        "short_name": umm.get("ShortName", ""),
+                        "version": umm.get("Version", ""),
+                        "title": umm.get("EntryTitle", ""),
+                    }
+                )
+            except Exception:
+                out.append({"dataset": str(dataset)})
+        return out
+
+    @geo_tool(
+        category="data",
+        requires_packages=("earthaccess",),
+    )
+    def get_granule_metadata(concept_id: str) -> dict[str, Any]:
+        """Fetch full metadata for a granule by CMR concept-id.
+
+        Args:
+            concept_id: CMR concept id (``G123-PROVIDER``).
+
+        Returns:
+            The granule metadata dict.
+        """
+        results = earthaccess.search_data(concept_id=concept_id, count=1)
+        if not results:
+            return {"concept_id": concept_id, "found": False}
+        granule = results[0]
+        return granule if isinstance(granule, dict) else {"granule": str(granule)}
+
+    @geo_tool(
+        category="io",
+        requires_confirmation=True,
+        requires_packages=("earthaccess",),
+        context_keys=("workdir",),
+    )
+    def download_granules(
+        concept_ids: list[str],
+        destination: str,
+    ) -> dict[str, Any]:
+        """Download granules from NASA Earthdata.
+
+        Args:
+            concept_ids: CMR concept ids to download.
+            destination: Local directory.
+
+        Returns:
+            A dict with ``"downloaded"`` (list of paths) and ``"errors"``.
+        """
+        granules = []
+        for concept_id in concept_ids:
+            results = earthaccess.search_data(concept_id=concept_id, count=1)
+            if results:
+                granules.extend(results)
+        if not granules:
+            return {"downloaded": [], "errors": ["No granules found."]}
+        try:
+            paths = earthaccess.download(granules, destination)
+            return {"downloaded": list(paths), "errors": []}
+        except Exception as exc:
+            return {"downloaded": [], "errors": [str(exc)]}
+
+    return [
+        search_granules,
+        list_collections,
+        get_granule_metadata,
+        download_granules,
+    ]
+
+
+__all__ = ["earthdata_tools"]

--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -1,0 +1,442 @@
+"""Tool adapters for QGIS via the ``QgisInterface`` (typically ``iface``).
+
+This module is **import-safe** outside a QGIS Python environment: the
+top-level imports do NOT pull in the ``qgis`` package, and the
+:func:`qgis_tools` factory returns an empty list when no ``iface`` is
+provided. Tool bodies that need QGIS classes (``QgsProject``,
+``QgsRectangle``, ``QgsVectorLayer``, ``QgsRasterLayer``) import them
+lazily so the module can still be imported in CI without QGIS.
+
+Typical usage from inside a QGIS plugin's Python console::
+
+    from qgis.utils import iface
+    from geoagent import for_qgis
+    agent = for_qgis(iface)
+    agent.chat("Zoom to the active layer.")
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import geo_tool
+
+
+def _resolve_layer(project: Any, layer_name: str) -> Any:
+    """Resolve a layer by name from a project.
+
+    Args:
+        project: A ``QgsProject`` (or :class:`MockQGISProject`) instance.
+        layer_name: Layer name to look up.
+
+    Returns:
+        The first matching layer.
+
+    Raises:
+        LookupError: If no layer with that name exists in the project.
+    """
+    layers = project.mapLayersByName(layer_name)
+    if not layers:
+        raise LookupError(f"No layer named {layer_name!r} in the project.")
+    return layers[0]
+
+
+def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[BaseTool]:
+    """Build the QGIS tool set bound to a live ``QgisInterface``.
+
+    Args:
+        iface: The QGIS ``QgisInterface`` (``qgis.utils.iface``) or a mock.
+            Passing ``None`` returns an empty list, so callers may safely do
+            ``qgis_tools(getattr(some_ctx, 'qgis_iface', None))`` outside
+            QGIS.
+        project: Optional ``QgsProject`` instance. If omitted, the tools fall
+            back to ``QgsProject.instance()``.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances. Empty when ``iface`` is
+        ``None``.
+    """
+    if iface is None:
+        return []
+
+    def _project() -> Any:
+        if project is not None:
+            return project
+        try:
+            from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+            return QgsProject.instance()
+        except Exception as exc:  # pragma: no cover - QGIS-only path
+            raise RuntimeError(
+                "QGIS is not available; cannot resolve QgsProject."
+            ) from exc
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface", "qgis_project"),
+    )
+    def list_project_layers() -> list[dict[str, Any]]:
+        """List all layers in the active QGIS project.
+
+        Returns:
+            A list of dicts ``{"name": ..., "type": ..., "source": ...}``.
+        """
+        out: list[dict[str, Any]] = []
+        for layer in _project().mapLayers().values():
+            out.append(
+                {
+                    "name": layer.name(),
+                    "type": str(layer.type()),
+                    "source": layer.source(),
+                }
+            )
+        return out
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def get_active_layer() -> dict[str, Any]:
+        """Return metadata for the currently active layer.
+
+        Returns:
+            A dict with ``name``, ``type``, and ``source`` keys, or a single
+            ``{"active_layer": None}`` if no layer is active.
+        """
+        layer = iface.activeLayer()
+        if layer is None:
+            return {"active_layer": None}
+        return {
+            "name": layer.name(),
+            "type": str(layer.type()),
+            "source": layer.source(),
+        }
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def zoom_in() -> str:
+        """Zoom the QGIS map canvas in by one step.
+
+        Returns:
+            A status string.
+        """
+        iface.mapCanvas().zoomIn()
+        return "Zoomed in."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def zoom_out() -> str:
+        """Zoom the QGIS map canvas out by one step.
+
+        Returns:
+            A status string.
+        """
+        iface.mapCanvas().zoomOut()
+        return "Zoomed out."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface", "qgis_project"),
+    )
+    def zoom_to_layer(layer_name: str) -> str:
+        """Zoom the canvas to the extent of a named layer.
+
+        Args:
+            layer_name: Display name of the layer.
+
+        Returns:
+            A status string.
+        """
+        layer = _resolve_layer(_project(), layer_name)
+        iface.setActiveLayer(layer)
+        if hasattr(iface, "zoomToActiveLayer"):
+            iface.zoomToActiveLayer()
+        else:
+            extent = layer.extent() if hasattr(layer, "extent") else None
+            if extent is not None:
+                iface.mapCanvas().setExtent(extent)
+                iface.mapCanvas().refresh()
+        return f"Zoomed to layer {layer_name!r}."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def zoom_to_extent(west: float, south: float, east: float, north: float) -> str:
+        """Zoom the canvas to a geographic extent (in the project CRS).
+
+        Args:
+            west: Western coordinate.
+            south: Southern coordinate.
+            east: Eastern coordinate.
+            north: Northern coordinate.
+
+        Returns:
+            A status string.
+        """
+        try:
+            from qgis.core import QgsRectangle  # type: ignore[import-not-found]
+
+            rect = QgsRectangle(west, south, east, north)
+        except Exception:
+            rect = (west, south, east, north)
+        iface.mapCanvas().setExtent(rect)
+        iface.mapCanvas().refresh()
+        return f"Zoomed to extent [{west}, {south}, {east}, {north}]."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def add_vector_layer(
+        path_or_uri: str,
+        name: str,
+        provider: str = "ogr",
+    ) -> str:
+        """Add a vector layer to the project.
+
+        Args:
+            path_or_uri: Path or provider URI for the data source.
+            name: Display name.
+            provider: QGIS data provider key (default ``"ogr"``).
+
+        Returns:
+            A status string.
+        """
+        layer = iface.addVectorLayer(path_or_uri, name, provider)
+        if layer is None or (hasattr(layer, "isValid") and not layer.isValid()):
+            return f"Failed to load vector layer from {path_or_uri!r}."
+        return f"Added vector layer {name!r}."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def add_raster_layer(path_or_uri: str, name: str) -> str:
+        """Add a raster layer to the project.
+
+        Args:
+            path_or_uri: Path or provider URI for the raster.
+            name: Display name.
+
+        Returns:
+            A status string.
+        """
+        layer = iface.addRasterLayer(path_or_uri, name)
+        if layer is None or (hasattr(layer, "isValid") and not layer.isValid()):
+            return f"Failed to load raster layer from {path_or_uri!r}."
+        return f"Added raster layer {name!r}."
+
+    @geo_tool(
+        category="qgis",
+        requires_confirmation=True,
+        requires_packages=("qgis",),
+        context_keys=("qgis_project",),
+    )
+    def remove_layer(layer_name: str) -> str:
+        """Remove a layer from the project.
+
+        Args:
+            layer_name: Display name of the layer to remove.
+
+        Returns:
+            A status string.
+        """
+        proj = _project()
+        layers = proj.mapLayersByName(layer_name)
+        if not layers:
+            return f"Layer {layer_name!r} not found."
+        for layer in layers:
+            try:
+                proj.removeMapLayer(layer.id())
+            except Exception:
+                proj.removeMapLayer(layer)
+        return f"Removed layer {layer_name!r}."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_project",),
+    )
+    def set_layer_visibility(layer_name: str, visible: bool) -> str:
+        """Show or hide a layer in the layer panel.
+
+        Args:
+            layer_name: Display name of the layer.
+            visible: ``True`` to show, ``False`` to hide.
+
+        Returns:
+            A status string.
+        """
+        proj = _project()
+        layer = _resolve_layer(proj, layer_name)
+        # Try the layer-tree-based path first; fall back to a simple attribute.
+        try:
+            tree_layer = proj.layerTreeRoot().findLayer(layer.id())  # type: ignore[attr-defined]
+            tree_layer.setItemVisibilityChecked(bool(visible))
+        except Exception:
+            try:
+                layer.visible = bool(visible)
+            except Exception as exc:
+                return f"Could not set visibility on {layer_name!r}: {exc}"
+        return f"Layer {layer_name!r} visibility set to {visible}."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_project",),
+    )
+    def inspect_layer_fields(layer_name: str) -> list[dict[str, Any]]:
+        """List fields and types for a vector layer.
+
+        Args:
+            layer_name: Display name of the layer.
+
+        Returns:
+            A list of ``{"name": ..., "type": ...}`` per field.
+        """
+        layer = _resolve_layer(_project(), layer_name)
+        out: list[dict[str, Any]] = []
+        for field in layer.fields():
+            if isinstance(field, dict):
+                out.append(
+                    {"name": field.get("name", ""), "type": field.get("type", "")}
+                )
+            else:
+                out.append(
+                    {
+                        "name": getattr(field, "name", lambda: "")(),
+                        "type": str(
+                            getattr(field, "typeName", lambda: type(field).__name__)()
+                        ),
+                    }
+                )
+        return out
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface", "qgis_project"),
+    )
+    def get_selected_features(
+        layer_name: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """Return selected features from a layer (or the active layer).
+
+        Args:
+            layer_name: Display name of the layer; if omitted, uses the
+                active layer.
+
+        Returns:
+            A list of feature dicts (mock-friendly; the QGIS path returns a
+            simple ``{"id": ..., "attributes": ...}``).
+        """
+        if layer_name is None:
+            layer = iface.activeLayer()
+            if layer is None:
+                return []
+        else:
+            layer = _resolve_layer(_project(), layer_name)
+        features = layer.selectedFeatures()
+        out: list[dict[str, Any]] = []
+        for feature in features:
+            if isinstance(feature, dict):
+                out.append(feature)
+            else:
+                attrs = getattr(feature, "attributes", lambda: [])()
+                fid = getattr(feature, "id", lambda: None)()
+                out.append({"id": fid, "attributes": list(attrs)})
+        return out
+
+    @geo_tool(
+        category="qgis",
+        requires_confirmation=True,
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def run_processing_algorithm(
+        algorithm_id: str, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Run a QGIS processing algorithm.
+
+        Args:
+            algorithm_id: Algorithm identifier (e.g. ``"native:buffer"``).
+            parameters: Algorithm parameters as a dict.
+
+        Returns:
+            The algorithm's result dictionary.
+        """
+        try:
+            import processing  # type: ignore[import-not-found]
+        except Exception as exc:  # pragma: no cover - QGIS-only path
+            raise RuntimeError("QGIS Processing framework is not available.") from exc
+        return processing.run(algorithm_id, parameters)
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def open_attribute_table(layer_name: str) -> str:
+        """Open the attribute table for a layer.
+
+        Args:
+            layer_name: Display name of the layer.
+
+        Returns:
+            A status string.
+        """
+        layer = _resolve_layer(_project(), layer_name)
+        iface.setActiveLayer(layer)
+        if hasattr(iface, "showAttributeTable"):
+            iface.showAttributeTable(layer)  # type: ignore[attr-defined]
+        return f"Attribute table requested for {layer_name!r}."
+
+    @geo_tool(
+        category="qgis",
+        requires_packages=("qgis",),
+        context_keys=("qgis_iface",),
+    )
+    def refresh_canvas() -> str:
+        """Refresh the QGIS map canvas.
+
+        Returns:
+            A status string.
+        """
+        iface.mapCanvas().refresh()
+        return "Canvas refreshed."
+
+    return [
+        list_project_layers,
+        get_active_layer,
+        zoom_in,
+        zoom_out,
+        zoom_to_layer,
+        zoom_to_extent,
+        add_vector_layer,
+        add_raster_layer,
+        remove_layer,
+        set_layer_visibility,
+        inspect_layer_fields,
+        get_selected_features,
+        run_processing_algorithm,
+        open_attribute_table,
+        refresh_canvas,
+    ]
+
+
+__all__ = ["qgis_tools"]

--- a/geoagent/tools/stac.py
+++ b/geoagent/tools/stac.py
@@ -11,29 +11,9 @@ unchanged.
 
 from __future__ import annotations
 
-from typing import Any
-
 from langchain_core.tools import BaseTool
 
-from geoagent.core.decorators import GEO_META_KEY
-
-
-def _stamp(tool: BaseTool, **geo_meta: Any) -> BaseTool:
-    """Stamp GeoAgent metadata onto an already-built LangChain tool.
-
-    Args:
-        tool: A LangChain ``BaseTool``.
-        **geo_meta: Keys to merge into ``tool.metadata["geo"]``.
-
-    Returns:
-        The same tool, with metadata mutated.
-    """
-    meta = dict(tool.metadata or {})
-    geo = dict(meta.get(GEO_META_KEY, {}))
-    geo.update(geo_meta)
-    meta[GEO_META_KEY] = geo
-    tool.metadata = meta
-    return tool
+from geoagent.core.decorators import stamp_geo_meta
 
 
 def stac_tools() -> list[BaseTool]:
@@ -49,13 +29,13 @@ def stac_tools() -> list[BaseTool]:
     except ImportError:
         return []
 
-    _stamp(
+    stamp_geo_meta(
         search_stac,
         category="data",
         requires_confirmation=False,
         requires_packages=["pystac_client"],
     )
-    _stamp(
+    stamp_geo_meta(
         get_stac_collections,
         category="data",
         requires_confirmation=False,

--- a/geoagent/tools/stac.py
+++ b/geoagent/tools/stac.py
@@ -1,0 +1,68 @@
+"""STAC search tool, re-exported with GeoAgent metadata.
+
+This is a thin wrapper around the v0.x ``geoagent.core.tools.stac`` module
+that stamps :func:`geoagent.core.decorators.geo_tool` metadata onto the
+existing LangChain tools so they participate in the new registry, safety,
+and category-based filtering machinery.
+
+The underlying implementation (pystac-client + the catalog registry) is
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import GEO_META_KEY
+
+
+def _stamp(tool: BaseTool, **geo_meta: Any) -> BaseTool:
+    """Stamp GeoAgent metadata onto an already-built LangChain tool.
+
+    Args:
+        tool: A LangChain ``BaseTool``.
+        **geo_meta: Keys to merge into ``tool.metadata["geo"]``.
+
+    Returns:
+        The same tool, with metadata mutated.
+    """
+    meta = dict(tool.metadata or {})
+    geo = dict(meta.get(GEO_META_KEY, {}))
+    geo.update(geo_meta)
+    meta[GEO_META_KEY] = geo
+    tool.metadata = meta
+    return tool
+
+
+def stac_tools() -> list[BaseTool]:
+    """Build the STAC tool set.
+
+    Returns:
+        A list of LangChain ``BaseTool`` instances exposing ``search_stac``
+        and ``get_stac_collections``. Empty when ``pystac_client`` is
+        unavailable.
+    """
+    try:
+        from geoagent.core.tools.stac import search_stac, get_stac_collections
+    except ImportError:
+        return []
+
+    _stamp(
+        search_stac,
+        category="data",
+        requires_confirmation=False,
+        requires_packages=["pystac_client"],
+    )
+    _stamp(
+        get_stac_collections,
+        category="data",
+        requires_confirmation=False,
+        requires_packages=["pystac_client"],
+    )
+
+    return [search_stac, get_stac_collections]
+
+
+__all__ = ["stac_tools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 
 [project.entry-points."console_scripts"]
-geoagent = "geoagent.integrations.cli:main"
+geoagent = "geoagent.cli:main"
 
 [project.optional-dependencies]
 openai = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "GeoAgent"
-version = "0.2.0"
-description = "An AI agent for geospatial data analysis and visualization"
+version = "1.0.0"
+description = "A centralized AI agent framework for Open Geospatial Python packages and QGIS plugins"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = [
     "GeoAgent",
     "geospatial",
@@ -12,6 +12,10 @@ keywords = [
     "STAC",
     "remote sensing",
     "earth observation",
+    "QGIS",
+    "leafmap",
+    "anymap",
+    "deepagents",
 ]
 license = {text = "MIT License"}
 authors = [
@@ -22,17 +26,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
-    "langgraph>=0.2",
-    "langchain>=0.3",
-    "langchain-core>=0.3",
-    "langchain-openai>=0.2",
+    "deepagents>=0.5.3",
     "leafmap>=0.43",
     "pystac-client>=0.8",
     "planetary-computer>=1.0",
@@ -50,24 +50,59 @@ dependencies = [
 ]
 
 [project.entry-points."console_scripts"]
-geoagent = "geoagent.cli:main"
+geoagent = "geoagent.integrations.cli:main"
 
 [project.optional-dependencies]
-llm = [
-    "langchain-anthropic>=0.2",
-    "langchain-google-genai>=2.0",
+openai = [
+    "langchain-openai>=1.0",
+]
+
+anthropic = [
+    "langchain-anthropic>=1.4",
+]
+
+google = [
+    "langchain-google-genai>=4.2",
 ]
 
 ollama = [
-    "langchain-ollama>=0.2",
+    "langchain-ollama>=1.0",
+]
+
+llm = [
+    "GeoAgent[openai,anthropic,google,ollama]",
+]
+
+anymap = [
+    "anymap",
+]
+
+geoai = [
+    "geoai",
+]
+
+earthengine = [
+    "earthengine-api>=1.0",
+]
+
+nasa_earthdata = [
+    "earthaccess>=0.10",
+]
+
+stac = [
+    "pystac-client>=0.8",
+    "planetary-computer>=1.0",
 ]
 
 ui = [
     "solara>=1.35",
 ]
 
+# QGIS is environment-installed (system package), not pip; this extra is a marker.
+qgis = []
+
 all = [
-    "GeoAgent[llm,ollama,ui]",
+    "GeoAgent[llm,anymap,geoai,earthengine,nasa_earthdata,ui]",
 ]
 
 dev = [
@@ -80,13 +115,13 @@ dev = [
 [tool]
 [tool.setuptools.packages.find]
 include = ["geoagent*"]
-exclude = ["docs*", "tests*", "notebooks*"]
+exclude = ["docs*", "tests*", "notebooks*", "examples*"]
 
 [tool.distutils.bdist_wheel]
 universal = true
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "1.0.0"
 commit = true
 tag = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
+deepagents>=0.5.3
 duckdb>=1.1
 geopandas>=1.0
-langchain>=0.3
-langchain-core>=0.3
-langchain-openai>=0.2
-langgraph>=0.2
+geopy>=2.4
 leafmap>=0.43
 numpy>=1.26
 pandas>=2.1
+planetary-computer>=1.0
 pydantic>=2.0
+pyproj>=3.6
 pystac-client>=0.8
 rasterio>=1.3
 rioxarray>=0.17

--- a/tests/test_anymap_tools.py
+++ b/tests/test_anymap_tools.py
@@ -1,0 +1,42 @@
+"""Tests for the anymap tool factory."""
+
+from __future__ import annotations
+
+from geoagent.core.decorators import needs_confirmation
+from geoagent.testing import MockAnymap
+from geoagent.tools.anymap import anymap_tools
+
+
+def test_factory_returns_tools() -> None:
+    m = MockAnymap()
+    tools = anymap_tools(m)
+    names = {t.name for t in tools}
+    assert {"list_layers", "add_layer", "remove_layer", "save_map"}.issubset(names)
+
+
+def test_factory_returns_empty_for_none() -> None:
+    assert anymap_tools(None) == []
+
+
+def test_remove_and_save_require_confirmation() -> None:
+    tools = {t.name: t for t in anymap_tools(MockAnymap())}
+    assert needs_confirmation(tools["remove_layer"]) is True
+    assert needs_confirmation(tools["save_map"]) is True
+
+
+def test_add_layer_mutates_map() -> None:
+    m = MockAnymap()
+    tools = {t.name: t for t in anymap_tools(m)}
+    tools["add_layer"].invoke(
+        {"url": "https://example.com/grid.geojson", "name": "Grid"}
+    )
+    assert any(layer.get("name") == "Grid" for layer in m.layers)
+
+
+def test_zoom_to_bounds() -> None:
+    m = MockAnymap()
+    tools = {t.name: t for t in anymap_tools(m)}
+    tools["zoom_to_bounds"].invoke(
+        {"west": 0.0, "south": 0.0, "east": 10.0, "north": 10.0}
+    )
+    assert m._bounds == [[0.0, 0.0], [10.0, 10.0]]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,32 @@
+"""Tests for the GeoAgentContext dataclass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from geoagent.core.context import GeoAgentContext
+
+
+def test_default_context_has_workdir_set_to_cwd() -> None:
+    ctx = GeoAgentContext()
+    assert ctx.map_obj is None
+    assert ctx.qgis_iface is None
+    assert ctx.qgis_project is None
+    assert isinstance(ctx.workdir, Path)
+    assert ctx.workdir.exists()
+    assert ctx.user_preferences == {}
+
+
+def test_with_overrides_returns_new_instance() -> None:
+    ctx = GeoAgentContext()
+    ctx2 = ctx.with_overrides(current_layer="NDVI")
+    assert ctx is not ctx2
+    assert ctx2.current_layer == "NDVI"
+    assert ctx.current_layer is None
+
+
+def test_user_preferences_dict_is_independent_per_instance() -> None:
+    a = GeoAgentContext()
+    b = GeoAgentContext()
+    a.user_preferences["theme"] = "dark"
+    assert b.user_preferences == {}

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,120 @@
+"""Tests for create_geo_agent + for_leafmap / for_anymap / for_qgis.
+
+These tests construct the deepagents-compiled agents with mocks. They do
+not exercise an LLM — they verify that the factory wires up the right
+tools and ``interrupt_on`` configuration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+from geoagent.core.context import GeoAgentContext
+from geoagent.core.factory import (
+    create_geo_agent,
+    for_anymap,
+    for_leafmap,
+    for_qgis,
+)
+from geoagent.testing import MockAnymap, MockLeafmap, MockQGISIface, MockQGISProject
+
+deepagents = pytest.importorskip("deepagents")
+
+
+def _fake_llm() -> FakeListChatModel:
+    """Return a minimal LangChain BaseChatModel for factory tests.
+
+    deepagents requires the model arg to be either a provider:model string or
+    a real ``BaseChatModel`` instance. We don't actually invoke the agent
+    here — we only verify that the factory can construct it.
+    """
+    return FakeListChatModel(responses=["ok"])
+
+
+def test_for_leafmap_builds_agent() -> None:
+    m = MockLeafmap()
+    agent = for_leafmap(m, llm=_fake_llm(), include_stac=False)
+    assert agent is not None
+    # Compiled deepagents graphs expose `.invoke` and `.stream`.
+    assert hasattr(agent, "invoke") or hasattr(agent, "ainvoke")
+
+
+def test_for_anymap_builds_agent() -> None:
+    m = MockAnymap()
+    agent = for_anymap(m, llm=_fake_llm(), include_stac=False)
+    assert agent is not None
+
+
+def test_for_qgis_builds_agent_with_iface() -> None:
+    iface = MockQGISIface()
+    project = MockQGISProject()
+    agent = for_qgis(iface, project, llm=_fake_llm(), include_stac=False)
+    assert agent is not None
+
+
+def test_for_qgis_builds_agent_with_no_iface() -> None:
+    # Should not raise; tool list will simply lack QGIS-specific tools.
+    agent = for_qgis(None, llm=_fake_llm(), include_stac=False)
+    assert agent is not None
+
+
+def test_create_geo_agent_accepts_explicit_tools_and_context() -> None:
+    from geoagent.tools.leafmap import leafmap_tools
+
+    m = MockLeafmap()
+    tools = leafmap_tools(m)
+    context = GeoAgentContext(map_obj=m, current_layer="NDVI")
+    agent = create_geo_agent(tools=tools, context=context, llm=_fake_llm())
+    assert agent is not None
+
+
+def test_factory_assembles_interrupt_on_for_confirm_tools(monkeypatch) -> None:
+    """The factory must populate `interrupt_on` from tool metadata."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    import geoagent.core.factory as factory_mod
+
+    monkeypatch.setattr(
+        factory_mod, "_require_deepagents", lambda: fake_create_deep_agent
+    )
+
+    from geoagent.tools.leafmap import leafmap_tools
+
+    m = MockLeafmap()
+    create_geo_agent(tools=leafmap_tools(m), llm=_fake_llm())
+
+    assert "interrupt_on" in captured
+    interrupt_on = captured["interrupt_on"]
+    assert interrupt_on is not None
+    assert "remove_layer" in interrupt_on
+    assert "save_map" in interrupt_on
+    # safe tools must NOT be in interrupt_on
+    assert "list_layers" not in interrupt_on
+    assert "zoom_in" not in interrupt_on
+
+
+def test_factory_passes_context_schema(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    import geoagent.core.factory as factory_mod
+
+    monkeypatch.setattr(
+        factory_mod, "_require_deepagents", lambda: fake_create_deep_agent
+    )
+
+    create_geo_agent(
+        tools=[],
+        context=GeoAgentContext(current_layer="NDVI"),
+        llm=_fake_llm(),
+    )
+    assert captured["context_schema"] is GeoAgentContext

--- a/tests/test_geo_tool.py
+++ b/tests/test_geo_tool.py
@@ -1,0 +1,104 @@
+"""Tests for the @geo_tool decorator."""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+
+from geoagent.core.decorators import (
+    GEO_META_KEY,
+    geo_tool,
+    get_category,
+    get_geo_meta,
+    get_required_packages,
+    needs_confirmation,
+)
+
+
+def test_geo_tool_produces_basetool() -> None:
+    @geo_tool(category="data")
+    def my_tool(x: int) -> int:
+        """Square a number."""
+        return x * x
+
+    assert isinstance(my_tool, BaseTool)
+    assert my_tool.name == "my_tool"
+    assert my_tool.description.strip().startswith("Square a number.")
+
+
+def test_geo_tool_metadata_stamped() -> None:
+    @geo_tool(
+        category="map",
+        requires_confirmation=True,
+        requires_packages=("leafmap",),
+        context_keys=("map_obj",),
+    )
+    def remove_layer(name: str) -> str:
+        """Remove a layer."""
+        return f"Removed {name}"
+
+    meta = get_geo_meta(remove_layer)
+    assert meta["category"] == "map"
+    assert meta["requires_confirmation"] is True
+    assert meta["requires_packages"] == ["leafmap"]
+    assert meta["context_keys"] == ["map_obj"]
+
+
+def test_needs_confirmation_helper() -> None:
+    @geo_tool(category="data")
+    def safe_tool() -> str:
+        """A safe tool."""
+        return "ok"
+
+    @geo_tool(category="io", requires_confirmation=True)
+    def dangerous_tool() -> str:
+        """A dangerous tool."""
+        return "danger"
+
+    assert needs_confirmation(safe_tool) is False
+    assert needs_confirmation(dangerous_tool) is True
+
+
+def test_get_category_and_packages() -> None:
+    @geo_tool(category="qgis", requires_packages=("qgis", "PyQt5"))
+    def my_qgis_tool() -> str:
+        """A QGIS tool."""
+        return "qgis"
+
+    assert get_category(my_qgis_tool) == "qgis"
+    assert get_required_packages(my_qgis_tool) == ["qgis", "PyQt5"]
+
+
+def test_geo_tool_with_explicit_name_and_description() -> None:
+    @geo_tool(
+        category="data",
+        name="renamed_tool",
+        description="Override description.",
+    )
+    def original_name() -> str:
+        """Original docstring."""
+        return "x"
+
+    assert original_name.name == "renamed_tool"
+    assert original_name.description == "Override description."
+
+
+def test_metadata_uses_namespaced_key() -> None:
+    @geo_tool(category="data")
+    def my_tool() -> str:
+        """Doc."""
+        return "x"
+
+    assert GEO_META_KEY in my_tool.metadata
+    assert "category" in my_tool.metadata[GEO_META_KEY]
+
+
+def test_get_geo_meta_returns_empty_for_plain_tools() -> None:
+    from langchain_core.tools import tool
+
+    @tool
+    def plain(x: int) -> int:
+        """Plain LangChain tool."""
+        return x
+
+    assert get_geo_meta(plain) == {}
+    assert needs_confirmation(plain) is False

--- a/tests/test_leafmap_tools.py
+++ b/tests/test_leafmap_tools.py
@@ -1,0 +1,124 @@
+"""Tests for the leafmap tool factory.
+
+These tests use :class:`MockLeafmap` so they run on systems without leafmap
+installed.
+"""
+
+from __future__ import annotations
+
+from geoagent.core.decorators import needs_confirmation
+from geoagent.testing import MockLeafmap
+from geoagent.tools.leafmap import leafmap_tools
+
+
+def test_factory_returns_full_tool_list() -> None:
+    m = MockLeafmap()
+    tools = leafmap_tools(m)
+    names = {t.name for t in tools}
+    expected = {
+        "list_layers",
+        "add_layer",
+        "remove_layer",
+        "set_center",
+        "set_zoom",
+        "zoom_in",
+        "zoom_out",
+        "zoom_to_bounds",
+        "change_basemap",
+        "add_vector_data",
+        "add_raster_data",
+        "add_stac_layer",
+        "add_cog_layer",
+        "add_xyz_tile_layer",
+        "add_pmtiles_layer",
+        "get_map_state",
+        "save_map",
+    }
+    assert expected.issubset(names)
+
+
+def test_factory_returns_empty_for_none() -> None:
+    assert leafmap_tools(None) == []
+
+
+def test_remove_and_save_require_confirmation() -> None:
+    tools = {t.name: t for t in leafmap_tools(MockLeafmap())}
+    assert needs_confirmation(tools["remove_layer"]) is True
+    assert needs_confirmation(tools["save_map"]) is True
+    assert needs_confirmation(tools["list_layers"]) is False
+    assert needs_confirmation(tools["zoom_in"]) is False
+
+
+def test_add_layer_mutates_map() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+
+    tools["add_layer"].invoke(
+        {"url": "https://example.com/data.tif", "name": "DEM", "layer_type": "cog"}
+    )
+    assert any(layer.get("name") == "DEM" for layer in m.layers)
+
+
+def test_remove_layer_mutates_map() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["add_layer"].invoke(
+        {"url": "https://example.com/buildings.geojson", "name": "Buildings"}
+    )
+    assert len(m.layers) == 1
+    tools["remove_layer"].invoke({"name": "Buildings"})
+    assert len(m.layers) == 0
+
+
+def test_set_center_and_zoom_in() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["set_center"].invoke({"lat": 37.7, "lon": -122.4, "zoom": 10})
+    assert m.center == [-122.4, 37.7]
+    assert m.zoom == 10
+    tools["zoom_in"].invoke({"steps": 2})
+    assert m.zoom == 12
+
+
+def test_zoom_to_bounds() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["zoom_to_bounds"].invoke(
+        {"west": -125.0, "south": 24.0, "east": -66.0, "north": 49.0}
+    )
+    assert m._bounds == [[-125.0, 24.0], [-66.0, 49.0]]
+
+
+def test_change_basemap() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["change_basemap"].invoke({"basemap": "CartoDB.Positron"})
+    assert m._style == "CartoDB.Positron"
+
+
+def test_get_map_state() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["set_center"].invoke({"lat": 35.0, "lon": -83.9, "zoom": 8})
+    state = tools["get_map_state"].invoke({})
+    assert state["zoom"] == 8
+    assert state["center"] == [-83.9, 35.0]
+
+
+def test_save_map_writes_file(tmp_path) -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    out = tmp_path / "map.html"
+    result = tools["save_map"].invoke({"path": str(out)})
+    assert out.exists()
+    assert str(out.resolve()) == result
+
+
+def test_list_layers_returns_dicts() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["add_layer"].invoke(
+        {"url": "https://example.com/buildings.geojson", "name": "Buildings"}
+    )
+    layers = tools["list_layers"].invoke({})
+    assert layers == [{"name": "Buildings", "type": "geojson"}]

--- a/tests/test_qgis_import_safe.py
+++ b/tests/test_qgis_import_safe.py
@@ -1,0 +1,35 @@
+"""Verify ``geoagent.tools.qgis`` is import-safe when QGIS is missing.
+
+The module-level imports of ``geoagent.tools.qgis`` must NOT pull in the
+``qgis`` package; only tool *bodies* may do that lazily. This test confirms
+that on a fresh import, no ``qgis`` module is loaded into ``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def _reimport(name: str):
+    """Force a fresh import of ``name``."""
+    sys.modules.pop(name, None)
+    return importlib.import_module(name)
+
+
+def test_module_import_does_not_pull_qgis() -> None:
+    if "qgis" in sys.modules:
+        pytest.skip("qgis is already imported in this environment.")
+    module = _reimport("geoagent.tools.qgis")
+    assert hasattr(module, "qgis_tools")
+    assert "qgis" not in sys.modules
+    assert "qgis.core" not in sys.modules
+
+
+def test_qgis_tools_with_none_iface_returns_empty_list() -> None:
+    from geoagent.tools.qgis import qgis_tools
+
+    assert qgis_tools(None) == []
+    assert qgis_tools(None, None) == []

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -1,0 +1,150 @@
+"""Tests for the QGIS tool factory.
+
+These tests use :class:`MockQGISIface` and :class:`MockQGISProject` so they
+run without QGIS installed. They also exercise the import-safe contract:
+``import geoagent.tools.qgis`` must succeed when ``qgis`` is not on the
+import path.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from geoagent.core.decorators import needs_confirmation
+from geoagent.testing import MockQGISIface, MockQGISLayer, MockQGISProject
+from geoagent.tools.qgis import qgis_tools
+
+
+def test_qgis_module_imports_without_qgis() -> None:
+    # The module is already imported; confirm `qgis` was not pulled in.
+    # (If it was, this test would still pass — we just want to ensure import
+    # didn't fail when the user's environment has no qgis package.)
+    assert "geoagent.tools.qgis" in sys.modules
+
+
+def test_qgis_tools_returns_empty_for_none() -> None:
+    assert qgis_tools(None) == []
+
+
+def test_factory_returns_tools_for_iface() -> None:
+    iface = MockQGISIface()
+    project = MockQGISProject()
+    tools = qgis_tools(iface, project)
+    names = {t.name for t in tools}
+    expected = {
+        "list_project_layers",
+        "get_active_layer",
+        "zoom_in",
+        "zoom_out",
+        "zoom_to_layer",
+        "zoom_to_extent",
+        "add_vector_layer",
+        "add_raster_layer",
+        "remove_layer",
+        "set_layer_visibility",
+        "inspect_layer_fields",
+        "get_selected_features",
+        "run_processing_algorithm",
+        "open_attribute_table",
+        "refresh_canvas",
+    }
+    assert expected.issubset(names)
+
+
+def test_remove_layer_and_run_processing_require_confirmation() -> None:
+    iface = MockQGISIface()
+    project = MockQGISProject()
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    assert needs_confirmation(tools["remove_layer"]) is True
+    assert needs_confirmation(tools["run_processing_algorithm"]) is True
+    assert needs_confirmation(tools["zoom_in"]) is False
+    assert needs_confirmation(tools["list_project_layers"]) is False
+
+
+def test_add_vector_layer_invokes_iface() -> None:
+    project = MockQGISProject()
+    iface = MockQGISIface(project=project)
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    tools["add_vector_layer"].invoke(
+        {"path_or_uri": "/tmp/x.shp", "name": "Roads", "provider": "ogr"}
+    )
+    assert "Roads" in project.mapLayers()
+
+
+def test_remove_layer_drops_from_project() -> None:
+    project = MockQGISProject()
+    iface = MockQGISIface(project=project)
+    project.addMapLayer(MockQGISLayer("Buildings", "/tmp/b.shp"))
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    out = tools["remove_layer"].invoke({"layer_name": "Buildings"})
+    assert "Buildings" not in project.mapLayers()
+    assert "Removed" in out
+
+
+def test_zoom_in_invokes_canvas() -> None:
+    iface = MockQGISIface()
+    project = MockQGISProject()
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    initial_scale = iface.mapCanvas().scale_value
+    tools["zoom_in"].invoke({})
+    assert iface.mapCanvas().scale_value == initial_scale / 2
+
+
+def test_list_project_layers() -> None:
+    project = MockQGISProject()
+    project.addMapLayer(MockQGISLayer("A", "a.shp", "vector"))
+    project.addMapLayer(MockQGISLayer("B", "b.tif", "raster"))
+    iface = MockQGISIface(project=project)
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    layers = tools["list_project_layers"].invoke({})
+    names = {layer["name"] for layer in layers}
+    assert names == {"A", "B"}
+
+
+def test_get_active_layer_returns_none_when_unset() -> None:
+    iface = MockQGISIface()
+    project = MockQGISProject()
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    out = tools["get_active_layer"].invoke({})
+    assert out == {"active_layer": None}
+
+
+def test_get_active_layer_returns_metadata() -> None:
+    project = MockQGISProject()
+    iface = MockQGISIface(project=project)
+    layer = MockQGISLayer("Active", "a.shp", "vector")
+    project.addMapLayer(layer)
+    iface.setActiveLayer(layer)
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    out = tools["get_active_layer"].invoke({})
+    assert out["name"] == "Active"
+    assert out["source"] == "a.shp"
+
+
+def test_zoom_to_layer_resolves_layer() -> None:
+    project = MockQGISProject()
+    iface = MockQGISIface(project=project)
+    layer = MockQGISLayer("Target", "t.shp")
+    project.addMapLayer(layer)
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    tools["zoom_to_layer"].invoke({"layer_name": "Target"})
+    assert iface.activeLayer() is layer
+
+
+def test_zoom_to_layer_raises_when_missing() -> None:
+    project = MockQGISProject()
+    iface = MockQGISIface(project=project)
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    with pytest.raises(LookupError):
+        tools["zoom_to_layer"].invoke({"layer_name": "NotThere"})
+
+
+def test_refresh_canvas_increments_counter() -> None:
+    iface = MockQGISIface()
+    project = MockQGISProject()
+    tools = {t.name: t for t in qgis_tools(iface, project)}
+    before = iface.mapCanvas().refresh_count
+    tools["refresh_canvas"].invoke({})
+    assert iface.mapCanvas().refresh_count == before + 1

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,76 @@
+"""Tests for the tool registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from geoagent.core import registry
+from geoagent.core.decorators import geo_tool
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry.clear()
+    registry._PKG_CACHE.clear()
+    yield
+    registry.clear()
+    registry._PKG_CACHE.clear()
+
+
+def _make_tool(name: str, **meta_kwargs):
+    @geo_tool(category=meta_kwargs.pop("category", "data"), **meta_kwargs)
+    def fn() -> str:
+        """Tool docstring."""
+        return name
+
+    fn.name = name  # rename for clean comparisons
+    return fn
+
+
+def test_register_and_all_tools() -> None:
+    tool = _make_tool("alpha")
+    registry.register(tool)
+    assert registry.all_tools() == [tool]
+
+
+def test_register_many() -> None:
+    a = _make_tool("a")
+    b = _make_tool("b")
+    registry.register_many([a, b])
+    assert {t.name for t in registry.all_tools()} == {"a", "b"}
+
+
+def test_unregister() -> None:
+    tool = _make_tool("alpha")
+    registry.register(tool)
+    registry.unregister("alpha")
+    assert registry.all_tools() == []
+
+
+def test_get_tools_filters_by_category() -> None:
+    map_tool = _make_tool("map_tool", category="map")
+    data_tool = _make_tool("data_tool", category="data")
+    registry.register_many([map_tool, data_tool])
+
+    out = registry.get_tools(categories={"map"})
+    assert {t.name for t in out} == {"map_tool"}
+
+
+def test_get_tools_filters_by_package_availability() -> None:
+    available = _make_tool("ok", requires_packages=("os",))
+    unavailable = _make_tool(
+        "bad", requires_packages=("definitely_not_a_real_pkg_xyz",)
+    )
+    registry.register_many([available, unavailable])
+
+    out = registry.get_tools(available_only=True)
+    assert {t.name for t in out} == {"ok"}
+
+
+def test_get_tools_disable_availability_filter() -> None:
+    available = _make_tool("ok", requires_packages=("os",))
+    unavailable = _make_tool("bad", requires_packages=("nope_pkg_xyz",))
+    registry.register_many([available, unavailable])
+
+    out = registry.get_tools(available_only=False)
+    assert {t.name for t in out} == {"ok", "bad"}

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,60 @@
+"""Tests for the safety / interrupt_on plumbing."""
+
+from __future__ import annotations
+
+from geoagent.core.decorators import geo_tool
+from geoagent.core.safety import (
+    auto_approve_all,
+    auto_approve_safe_only,
+    build_interrupt_on,
+    make_confirm_request,
+    ConfirmRequest,
+)
+
+
+@geo_tool(category="data")
+def safe() -> str:
+    """A safe tool."""
+    return "ok"
+
+
+@geo_tool(category="io", requires_confirmation=True)
+def dangerous() -> str:
+    """A dangerous tool."""
+    return "danger"
+
+
+@geo_tool(category="map", requires_confirmation=True)
+def remove_layer(name: str) -> str:
+    """Remove a layer."""
+    return f"removed {name}"
+
+
+def test_build_interrupt_on_only_flags_confirm_required() -> None:
+    cfg = build_interrupt_on([safe, dangerous, remove_layer])
+    assert set(cfg.keys()) == {"dangerous", "remove_layer"}
+    assert all(value is True for value in cfg.values())
+
+
+def test_build_interrupt_on_returns_empty_when_all_safe() -> None:
+    cfg = build_interrupt_on([safe])
+    assert cfg == {}
+
+
+def test_make_confirm_request_populates_fields() -> None:
+    request = make_confirm_request(remove_layer, {"name": "NDVI"})
+    assert isinstance(request, ConfirmRequest)
+    assert request.tool_name == "remove_layer"
+    assert request.args == {"name": "NDVI"}
+    assert request.category == "map"
+    assert request.metadata["requires_confirmation"] is True
+
+
+def test_auto_approve_safe_only_rejects_everything() -> None:
+    request = make_confirm_request(remove_layer, {"name": "NDVI"})
+    assert auto_approve_safe_only(request) is False
+
+
+def test_auto_approve_all_approves_everything() -> None:
+    request = make_confirm_request(remove_layer, {"name": "NDVI"})
+    assert auto_approve_all(request) is True


### PR DESCRIPTION
## Summary

Phase 1 of the v1.0 rewrite: introduce the centralized AI agent framework foundation on top of [DeepAgents](https://github.com/langchain-ai/deepagents), without touching the legacy 4-agent LangGraph pipeline. Existing notebooks and \`from geoagent import GeoAgent; agent.chat(...)\` still work unchanged.

The end goal is for GeoAgent to become the shared AI layer for the broader Open Geospatial ecosystem (leafmap, anymap, geoai, QGIS plugins) — downstream packages contribute tools and adapters, not duplicate agent logic. Phase 2 will rebuild \`GeoAgent.chat()\` on top of the new factory and delete the legacy pipeline.

### Highlights

- **Core abstractions** (\`geoagent/core/\`):
  - \`@geo_tool\` decorator wraps LangChain \`@tool\` with category, confirmation, package-availability, and context metadata
  - \`GeoAgentContext\` dataclass for runtime context (map widget, QGIS iface/project, workdir, current layer, user preferences)
  - Capability-tagged tool registry with package-availability gating
  - \`ConfirmCallback\` bridge + \`build_interrupt_on()\` for deepagents human-in-the-loop
  - \`create_geo_agent(...)\` factory + \`for_leafmap(m)\`, \`for_anymap(m)\`, \`for_qgis(iface)\` convenience helpers
- **Tool adapters** (\`geoagent/tools/\`):
  - 17 leafmap tools, 13 anymap tools, 15 QGIS tools, plus geoai / Earth Engine / NASA Earthdata factories
  - QGIS adapter is **import-safe outside QGIS** (no top-level \`import qgis\`; tool bodies import lazily; \`qgis_tools(None)\` returns \`[]\`)
  - All tools route confirmation-required actions (remove, save, export, run-processing, download, EE submit_task) through \`interrupt_on\`
- **Testing helpers** (\`geoagent/testing/\`): MockLeafmap, MockAnymap, MockQGISIface, MockQGISProject, MockQGISLayer, MockQGISCanvas
- **pyproject.toml**: bump to 1.0.0, requires-python \`>=3.11\`, replace LangChain 0.3 stack with \`deepagents>=0.5.3\` (transitively pulls LangChain 1.x), restructure provider extras into separate opt-ins

### Test results

- 68 new tests passing
- 9 existing legacy tests still passing (no behaviour change to current \`GeoAgent\` class)
- pre-commit clean

## Test plan

- [x] \`pytest tests/ -q\` — 68 passed
- [x] Legacy \`tests/test_geoagent.py\` still passes (9/9)
- [x] \`pre-commit run --all-files\` clean
- [x] \`import geoagent.tools.qgis\` succeeds with no \`qgis\` package on the import path
- [x] \`for_qgis(None)\` returns an agent with zero QGIS tools
- [x] \`for_leafmap(MockLeafmap())\` builds a deepagents graph
- [x] \`@geo_tool\` decorator round-trips metadata and produces a \`BaseTool\`
- [x] \`build_interrupt_on()\` only flags tools with \`requires_confirmation=True\`