### PR TITLE
docs: refresh examples for v1.0 deepagents response shape

### DIFF
--- a/docs/examples/contextual_qa.ipynb
+++ b/docs/examples/contextual_qa.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Contextual Q&A with GeoAgent\n",
     "\n",
-    "GeoAgent can answer general questions using its built-in LLM — from earth science topics and natural disaster impacts to programming questions and everyday queries.\n",
+    "GeoAgent can answer general questions using its built-in LLM \u2014 from earth science topics and natural disaster impacts to programming questions and everyday queries.\n",
     "\n",
     "When a query asks for *information or explanation* rather than *data retrieval or visualization*, it is automatically routed to the **ContextAgent** for a direct LLM answer."
    ]
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"What is NDVI and how is it calculated?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print(f\"Success: {result.success}\")\n",
     "print()\n",
     "if result.answer_text:\n",
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"How do synthetic aperture radar (SAR) satellites work?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Explain the difference between Landsat and Sentinel-2 satellites\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -86,7 +86,7 @@
    "source": [
     "## 2. Natural Disaster Impact Questions\n",
     "\n",
-    "Ask about the impact of specific natural disasters — hurricanes, wildfires, floods, and more."
+    "Ask about the impact of specific natural disasters \u2014 hurricanes, wildfires, floods, and more."
    ]
   },
   {
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"How was NYC impacted by Hurricane Sandy?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -109,7 +109,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"What was the impact of Hurricane Florence 2018 in North Carolina?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -124,7 +124,7 @@
     "result = agent.chat(\n",
     "    \"How did vegetation recover after flooding in Missouri River valley 2023?\"\n",
     ")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -146,7 +146,7 @@
     "result = agent.chat(\n",
     "    \"What are the long-term climate trends affecting Pacific Northwest forests?\"\n",
     ")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -159,9 +159,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\n",
-    "    \"Explain the correlation between El Niño events and wildfire patterns\"\n",
+    "    \"Explain the correlation between El Ni\u00f1o events and wildfire patterns\"\n",
     ")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -176,7 +176,7 @@
     "result = agent.chat(\n",
     "    \"What is urban heat island effect and which cities are most affected?\"\n",
     ")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -188,7 +188,7 @@
    "source": [
     "## 4. General Questions\n",
     "\n",
-    "GeoAgent can also handle general-purpose questions — it's not limited to earth science."
+    "GeoAgent can also handle general-purpose questions \u2014 it's not limited to earth science."
    ]
   },
   {
@@ -198,7 +198,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"What is the STAC specification and why is it important?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -211,7 +211,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"What are Cloud Optimized GeoTIFFs and why are they useful?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -224,7 +224,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"What is the difference between raster and vector data in GIS?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -237,7 +237,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"What Python libraries are commonly used for geospatial analysis?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -247,7 +247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Mixed Queries — Data + Explanation\n",
+    "## 5. Mixed Queries \u2014 Data + Explanation\n",
     "\n",
     "Some queries combine data visualization with contextual information. GeoAgent handles both in one response."
    ]
@@ -262,8 +262,8 @@
     "result = agent.chat(\n",
     "    \"Show me Sentinel-2 imagery of the Amazon rainforest in August 2024\"\n",
     ")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
-    "print(f\"Items: {result.data.total_items if result.data else 0}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
+    "print(f\"Items: {len((result.data or {}).get('items', []))}\")\n",
     "print(f\"Has answer_text: {result.answer_text is not None}\")\n",
     "result.map"
    ]
@@ -276,7 +276,7 @@
    "source": [
     "# This should trigger explanation\n",
     "result = agent.chat(\"What causes deforestation in the Amazon rainforest?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print(f\"Has answer_text: {result.answer_text is not None}\")\n",
     "print()\n",
     "if result.answer_text:\n",
@@ -295,12 +295,12 @@
     "\n",
     "| Intent | Routing | Example |\n",
     "|---|---|---|\n",
-    "| `search` | Data pipeline → STAC search | \"Find Sentinel-2 images of Tokyo\" |\n",
-    "| `analyze` | Data pipeline → analysis | \"Compute NDVI for California\" |\n",
-    "| `visualize` | Data pipeline → map | \"Show land cover for Denver\" |\n",
-    "| `compare` | Data pipeline → comparison | \"Compare forest cover 2020 vs 2024\" |\n",
-    "| `explain` | **ContextAgent** → LLM answer | \"What is NDVI?\" |\n",
-    "| `monitor` | **ContextAgent** → LLM answer | \"Track deforestation trends\" |\n",
+    "| `search` | Data pipeline \u2192 STAC search | \"Find Sentinel-2 images of Tokyo\" |\n",
+    "| `analyze` | Data pipeline \u2192 analysis | \"Compute NDVI for California\" |\n",
+    "| `visualize` | Data pipeline \u2192 map | \"Show land cover for Denver\" |\n",
+    "| `compare` | Data pipeline \u2192 comparison | \"Compare forest cover 2020 vs 2024\" |\n",
+    "| `explain` | **ContextAgent** \u2192 LLM answer | \"What is NDVI?\" |\n",
+    "| `monitor` | **ContextAgent** \u2192 LLM answer | \"Track deforestation trends\" |\n",
     "\n",
     "The `explain` and `monitor` intents route directly to the ContextAgent, which uses the LLM to provide informative answers."
    ]

--- a/docs/examples/custom_tools.ipynb
+++ b/docs/examples/custom_tools.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Extending GeoAgent with your own tools\n",
+    "\n",
+    "GeoAgent is a thin coordinator over deepagents subagents. Bringing your own geospatial tooling is a matter of decorating a Python function with `@geo_tool` (or stamping metadata on an existing LangChain tool with `stamp_geo_meta`) and passing it to `GeoAgent(tools=[...])`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## `@geo_tool` arguments\n",
+    "\n",
+    "- `category` — one of `\"map\"`, `\"qgis\"`, `\"data\"`, `\"ai\"`, `\"io\"`. Used by the registry to filter and by the safety bridge to label confirm requests.\n",
+    "- `name` — optional override for the tool name (defaults to the function name).\n",
+    "- `description` — optional override (defaults to the function's docstring).\n",
+    "- `requires_confirmation` — when `True`, the factory wires this tool into deepagents' `interrupt_on` so it pauses for user approval (see [hitl_confirm.ipynb](hitl_confirm.ipynb)).\n",
+    "- `requires_packages` — packages whose absence makes the registry silently skip this tool (e.g. `(\"qgis\",)`).\n",
+    "- `context_keys` — `GeoAgentContext` fields the tool reads at runtime. Informational; live runtime objects flow via closure, not via this list.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Define a custom data tool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import GeoAgent, geo_tool\n",
+    "\n",
+    "\n",
+    "@geo_tool(\n",
+    "    category=\"data\",\n",
+    "    description=(\n",
+    "        \"Count features in a remote GeoJSON / Shapefile / GeoParquet URL.\"\n",
+    "        \" Returns the feature count and the source CRS.\"\n",
+    "    ),\n",
+    "    requires_packages=[\"geopandas\"],\n",
+    ")\n",
+    "def count_features_in_url(url: str) -> dict:\n",
+    "    \"\"\"Open a vector dataset by URL with geopandas and count features.\n",
+    "\n",
+    "    Args:\n",
+    "        url: A URL geopandas can open (GeoJSON, Shapefile, GeoParquet, ...).\n",
+    "\n",
+    "    Returns:\n",
+    "        Dict with ``count`` (int) and ``crs`` (string).\n",
+    "    \"\"\"\n",
+    "    import geopandas as gpd\n",
+    "\n",
+    "    gdf = gpd.read_file(url)\n",
+    "    return {\"count\": int(len(gdf)), \"crs\": str(gdf.crs)}\n",
+    "\n",
+    "\n",
+    "count_features_in_url.metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Use the tool from a chat\n",
+    "\n",
+    "Pass the decorated tool via `tools=[...]`. The agent inspects the tool's description (the `@geo_tool` decorator promotes the docstring) to decide when to call it.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = GeoAgent(tools=[count_features_in_url])\n",
+    "result = agent.chat(\n",
+    "    \"How many features are in https://raw.githubusercontent.com/python-visualization/folium-example-data/main/us_states.json?\"\n",
+    ")\n",
+    "print(\"success:\", result.success)\n",
+    "print(\"executed:\", result.executed_tools)\n",
+    "print(\"answer:\", (result.answer_text or \"\")[:400])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Retrofitting an existing LangChain tool with `stamp_geo_meta`\n",
+    "\n",
+    "If you already have a tool built with the plain `@langchain_core.tools.tool` decorator (or imported from another package), you can enroll it in the GeoAgent registry without redecorating: `stamp_geo_meta` merges metadata into the tool in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.tools import tool as lc_tool\n",
+    "from geoagent import stamp_geo_meta, get_geo_meta\n",
+    "\n",
+    "\n",
+    "@lc_tool\n",
+    "def list_supported_crs() -> list[str]:\n",
+    "    \"\"\"Return a small set of common geographic / projected CRS strings.\"\"\"\n",
+    "    return [\"EPSG:4326\", \"EPSG:3857\", \"EPSG:32633\"]\n",
+    "\n",
+    "\n",
+    "stamp_geo_meta(\n",
+    "    list_supported_crs,\n",
+    "    category=\"io\",\n",
+    "    requires_confirmation=False,\n",
+    "    requires_packages=[],\n",
+    ")\n",
+    "get_geo_meta(list_supported_crs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Confirmation-required custom tools\n",
+    "\n",
+    "Setting `requires_confirmation=True` flips the tool into the HITL path. The default `auto_approve_safe_only` callback rejects everything, so a fresh `GeoAgent(tools=[...])` will *plan* the call but cancel it. See [hitl_confirm.ipynb](hitl_confirm.ipynb) for the approval flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@geo_tool(\n",
+    "    category=\"data\",\n",
+    "    description=\"Pretend to clear a local raster cache.\",\n",
+    "    requires_confirmation=True,\n",
+    ")\n",
+    "def clear_cache() -> str:\n",
+    "    \"\"\"Pretend to clear the cache (no-op for the demo).\"\"\"\n",
+    "    return \"cache cleared\"\n",
+    "\n",
+    "\n",
+    "agent = GeoAgent(tools=[clear_cache])\n",
+    "result = agent.chat(\"Clear the local raster cache.\")\n",
+    "print(\"executed:\", result.executed_tools)\n",
+    "print(\"cancelled:\", result.cancelled_tools)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/earth_science_queries.ipynb
+++ b/docs/examples/earth_science_queries.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each query routes through GeoAgent's deepagents pipeline: the planner picks an appropriate dataset, the **data subagent** runs `search_stac` against the matching STAC catalog (Planetary Computer, Earth Search, NASA VEDA, etc.), and the **mapping subagent** renders the result. Inspect `result.executed_tools` to confirm which tools fired for each prompt.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -47,11 +54,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me thermal anomalies in Australia in January 2024\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -62,9 +67,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me burned area mapping for Montana wildfire regions in 2023\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -93,11 +96,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me surface water in Bangladesh\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -126,11 +127,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me snow cover in Quebec in January 2024\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -159,11 +158,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me sea surface temperature near Madagascar\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -174,9 +171,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me land surface temperature for Phoenix Arizona in July 2024\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -205,11 +200,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me vegetation indices for Ukraine in June 2024\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -238,11 +231,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me cropland data for Florida\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -271,11 +262,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me radar imagery of Houston Texas during August 2017\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -304,11 +293,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me LIDAR height data for Denver Colorado\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -337,11 +324,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me HLS Landsat imagery for Greece in June 2024\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -370,9 +355,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me elevation profile for the Grand Canyon\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -383,9 +366,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me ALOS World DEM for Berlanga Spain\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -405,11 +386,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me net production for San Jose California\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -438,11 +417,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show me nadir BRDF reflectance for Mexico\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },

--- a/docs/examples/event_monitoring.ipynb
+++ b/docs/examples/event_monitoring.ipynb
@@ -50,10 +50,12 @@
     "    \"Show me radar imagery of Houston Texas during Hurricane Harvey August 2017\"\n",
     ")\n",
     "print(f\"Success: {result.success}\")\n",
-    "print(f\"Plan: intent={result.plan.intent}, dataset={result.plan.dataset}\")\n",
-    "print(f\"Items: {result.data.total_items if result.data else 0}\")\n",
-    "if result.data and result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "print(\n",
+    "    f\"Plan: intent={(result.plan or {}).get('intent')}, dataset={(result.plan or {}).get('dataset')}\"\n",
+    ")\n",
+    "print(f\"Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if result.data and (result.data or {}).get(\"items\", []):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -83,8 +85,10 @@
    "source": [
     "result = agent.chat(\"Show wildfire activity in Southern California in January 2025\")\n",
     "print(f\"Success: {result.success}\")\n",
-    "print(f\"Plan: intent={result.plan.intent}, dataset={result.plan.dataset}\")\n",
-    "print(f\"Items: {result.data.total_items if result.data else 0}\")\n",
+    "print(\n",
+    "    f\"Plan: intent={(result.plan or {}).get('intent')}, dataset={(result.plan or {}).get('dataset')}\"\n",
+    ")\n",
+    "print(f\"Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -96,7 +100,7 @@
    "source": [
     "result = agent.chat(\"Show me burned area mapping for Montana wildfire regions 2023\")\n",
     "print(f\"Success: {result.success}\")\n",
-    "print(f\"Items: {result.data.total_items if result.data else 0}\")\n",
+    "print(f\"Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -126,8 +130,10 @@
    "source": [
     "result = agent.chat(\"Show me flood extent in Pakistan during August 2022\")\n",
     "print(f\"Success: {result.success}\")\n",
-    "print(f\"Plan: intent={result.plan.intent}, dataset={result.plan.dataset}\")\n",
-    "print(f\"Items: {result.data.total_items if result.data else 0}\")\n",
+    "print(\n",
+    "    f\"Plan: intent={(result.plan or {}).get('intent')}, dataset={(result.plan or {}).get('dataset')}\"\n",
+    ")\n",
+    "print(f\"Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -159,8 +165,10 @@
     "    \"Show me high resolution satellite imagery of Dubai urban expansion in 2020\"\n",
     ")\n",
     "print(f\"Success: {result.success}\")\n",
-    "print(f\"Plan: intent={result.plan.intent}, dataset={result.plan.dataset}\")\n",
-    "print(f\"Items: {result.data.total_items if result.data else 0}\")\n",
+    "print(\n",
+    "    f\"Plan: intent={(result.plan or {}).get('intent')}, dataset={(result.plan or {}).get('dataset')}\"\n",
+    ")\n",
+    "print(f\"Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -189,7 +197,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"How was NYC impacted by Hurricane Sandy?\")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"
@@ -204,7 +212,7 @@
     "result = agent.chat(\n",
     "    \"What satellites are most useful for monitoring volcanic eruptions?\"\n",
     ")\n",
-    "print(f\"Intent: {result.plan.intent}\")\n",
+    "print(f\"Intent: {(result.plan or {}).get('intent')}\")\n",
     "print()\n",
     "if result.answer_text:\n",
     "    print(result.answer_text)"

--- a/docs/examples/hitl_confirm.ipynb
+++ b/docs/examples/hitl_confirm.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "GeoAgent classifies tools as either *safe* (read-only, navigation, preview) or *confirmation-required* (destructive, expensive, externally-visible). When a confirmation-required tool is about to fire, the deepagents graph pauses and emits an `__interrupt__`. `GeoAgent.chat()` routes that interrupt through a `ConfirmCallback` you supply at construction.\n",
     "\n",
-    "This notebook walks through the three built-in callbacks plus a custom one.\n"
+    "This notebook walks through the two built-in callbacks plus a custom one.\n"
    ]
   },
   {
@@ -133,7 +133,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "## `auto_approve_all` — only safe in fully sandboxed sessions\n",
+    "## `auto_approve_all` \u2014 only safe in fully sandboxed sessions\n",
     "\n",
     "`auto_approve_all` is provided for tests and trusted automation. Every confirmation request returns `True`, so destructive tools fire without human review. Do not use this as a default in interactive applications."
    ]

--- a/docs/examples/hitl_confirm.ipynb
+++ b/docs/examples/hitl_confirm.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Human-in-the-loop tool confirmation\n",
+    "\n",
+    "GeoAgent classifies tools as either *safe* (read-only, navigation, preview) or *confirmation-required* (destructive, expensive, externally-visible). When a confirmation-required tool is about to fire, the deepagents graph pauses and emits an `__interrupt__`. `GeoAgent.chat()` routes that interrupt through a `ConfirmCallback` you supply at construction.\n",
+    "\n",
+    "This notebook walks through the three built-in callbacks plus a custom one.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import (\n",
+    "    GeoAgent,\n",
+    "    ConfirmCallback,\n",
+    "    ConfirmRequest,\n",
+    "    auto_approve_all,\n",
+    "    auto_approve_safe_only,\n",
+    "    geo_tool,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Define a confirmation-required tool\n",
+    "\n",
+    "We define a tiny toy tool so the demo does not depend on QGIS, Earth Engine, or a live map. Setting `requires_confirmation=True` flips it into the interrupt path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@geo_tool(\n",
+    "    category=\"data\",\n",
+    "    description=\"Pretend to delete a dataset by name.\",\n",
+    "    requires_confirmation=True,\n",
+    ")\n",
+    "def delete_dataset(name: str) -> str:\n",
+    "    \"\"\"Pretend to delete the named dataset (no-op for the demo).\"\"\"\n",
+    "    return f\"deleted dataset: {name}\"\n",
+    "\n",
+    "\n",
+    "delete_dataset.metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Default callback rejects everything\n",
+    "\n",
+    "When no `confirm=` is supplied, `GeoAgent` uses `auto_approve_safe_only`, which **rejects** every confirmation-required call. Safe tools still run, but the destructive `delete_dataset` cannot fire silently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = GeoAgent(tools=[delete_dataset])\n",
+    "result = agent.chat(\"Delete the dataset named lulc-2024.\")\n",
+    "print(\"success:\", result.success)\n",
+    "print(\"executed:\", result.executed_tools)\n",
+    "print(\"cancelled:\", result.cancelled_tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## A custom callback that prints the request and approves\n",
+    "\n",
+    "A `ConfirmCallback` is just `Callable[[ConfirmRequest], bool]`. The request includes the proposed tool name, the args, the description (lifted from the `@geo_tool` docstring), the category, and the full GeoAgent metadata dict.\n",
+    "\n",
+    "Notebooks cannot reliably block on `input()`, so this demo callback prints the request and returns `True`. Replace the body with `input('approve? ') == 'y'` in a CLI session to gate on real user input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interactive_confirm(req: ConfirmRequest) -> bool:\n",
+    "    print(\"Confirm request:\")\n",
+    "    print(f\"  tool: {req.tool_name}\")\n",
+    "    print(f\"  args: {req.args}\")\n",
+    "    print(f\"  description: {req.description}\")\n",
+    "    print(f\"  category: {req.category}\")\n",
+    "    print(f\"  metadata: {req.metadata}\")\n",
+    "    return True\n",
+    "\n",
+    "\n",
+    "agent = GeoAgent(tools=[delete_dataset], confirm=interactive_confirm)\n",
+    "result = agent.chat(\"Delete the dataset named lulc-2024.\")\n",
+    "print(\"---\")\n",
+    "print(\"executed:\", result.executed_tools)\n",
+    "print(\"cancelled:\", result.cancelled_tools)\n",
+    "print(\"answer:\", result.answer_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## `auto_approve_all` — only safe in fully sandboxed sessions\n",
+    "\n",
+    "`auto_approve_all` is provided for tests and trusted automation. Every confirmation request returns `True`, so destructive tools fire without human review. Do not use this as a default in interactive applications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = GeoAgent(tools=[delete_dataset], confirm=auto_approve_all)\n",
+    "result = agent.chat(\"Delete the dataset named lulc-2024.\")\n",
+    "print(\"executed:\", result.executed_tools)\n",
+    "print(\"cancelled:\", result.cancelled_tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## How it wires together\n",
+    "\n",
+    "1. `@geo_tool(requires_confirmation=True)` stamps GeoAgent metadata onto the   `BaseTool`.\n",
+    "2. The factory at construction time builds a deepagents `interrupt_on` from   every confirmation-required tool's name.\n",
+    "3. When the agent proposes one of those tools, the graph emits   `__interrupt__` with `action_requests`.\n",
+    "4. `GeoAgent.chat()` routes each pending request through your   `ConfirmCallback`, then resumes the graph with   `Command(resume={'decisions': [...]})`.\n",
+    "5. Approved tools run; rejected tools land in `result.cancelled_tools` and   their stub `ToolMessage`s are excluded from `result.executed_tools`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/intro.ipynb
+++ b/docs/examples/intro.ipynb
@@ -10,6 +10,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How GeoAgent v1.0 works under the hood\n",
+    "\n",
+    "`GeoAgent` is a thin facade over a [DeepAgents](https://github.com/langchain-ai/deepagents) coordinator. Each call to `agent.chat(...)` runs through a planner subagent that decomposes the query and dispatches to specialised subagents:\n",
+    "\n",
+    "- **planner** — picks the intent, dataset, and analysis type.\n",
+    "- **data** — STAC + DuckDB tools for catalog discovery.\n",
+    "- **analysis** — raster / vector tools (NDVI, zonal stats, etc.).\n",
+    "- **context** — LLM-only Q&A for explanatory queries.\n",
+    "- **mapping** (active when a `target_map` is supplied) — drives a leafmap / anymap widget.\n",
+    "\n",
+    "Inspect what the agent did via `result.executed_tools`, `result.cancelled_tools`, `result.answer_text`, and `result.execution_time`. The legacy typed objects (`result.data.total_items`, `result.analysis.result_data`, ...) are no longer emitted in v1.0 — `plan` / `data` / `analysis` are opaque dicts that subagents fill in only when they explicitly write to the graph state.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -65,6 +82,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def summarize(result):\n",
+    "    \"\"\"Compact introspection of a v1.0 GeoAgentResponse.\"\"\"\n",
+    "    items = (result.data or {}).get(\"items\", []) if result.data else []\n",
+    "    print(\n",
+    "        f\"success={result.success} | tools={result.executed_tools} \"\n",
+    "        f\"| items={len(items)} | time={result.execution_time:.1f}s\"\n",
+    "    )\n",
+    "    if result.answer_text:\n",
+    "        first_line = result.answer_text.strip().splitlines()[0]\n",
+    "        print(f\"answer: {first_line[:160]}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -83,7 +118,7 @@
    "source": [
     "result = agent.chat(\"Show Sentinel-2 imagery of San Francisco in July 2025\")\n",
     "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items} | Time: {result.execution_time:.1f}s\"\n",
+    "    f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))} | Time: {result.execution_time:.1f}s\"\n",
     ")\n",
     "result.map"
    ]
@@ -113,9 +148,9 @@
     "result = agent.chat(\n",
     "    \"Find Sentinel-2 images of Tokyo with less than 10% cloud cover in March 2024\"\n",
     ")\n",
-    "print(f\"Success: {result.success} | Items: {result.data.total_items}\")\n",
-    "if result.data.items:\n",
-    "    for item in result.data.items[:3]:\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
+    "if (result.data or {}).get(\"items\"):\n",
+    "    for item in ((result.data or {}).get(\"items\", []))[:3]:\n",
     "        cc = item[\"properties\"].get(\"eo:cloud_cover\", \"N/A\")\n",
     "        print(f\"  {item['id']}: cloud cover {cc}%\")\n",
     "result.map"
@@ -141,7 +176,7 @@
     "result = agent.chat(\"Compute NDVI for Knoxville Tennessee in July 2024\")\n",
     "print(f\"Success: {result.success} | Time: {result.execution_time:.1f}s\")\n",
     "if result.analysis:\n",
-    "    stats = result.analysis.result_data.get(\"ndvi_stats\", {})\n",
+    "    stats = ((result.analysis or {}).get(\"result_data\") or {}).get(\"ndvi_stats\", {})\n",
     "    if stats:\n",
     "        print(f\"NDVI mean: {stats['mean']:.3f}\")\n",
     "        print(f\"NDVI range: [{stats['min']:.3f}, {stats['max']:.3f}]\")\n",
@@ -172,11 +207,9 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show NDVI for the Amazon rainforest in August 2024\")\n",
-    "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items if result.data else 0}\"\n",
-    ")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "if result.analysis:\n",
-    "    stats = result.analysis.result_data.get(\"ndvi_stats\", {})\n",
+    "    stats = ((result.analysis or {}).get(\"result_data\") or {}).get(\"ndvi_stats\", {})\n",
     "    if stats and stats.get(\"mean\"):\n",
     "        print(f\"NDVI mean: {stats['mean']:.3f}\")\n",
     "result.map"
@@ -201,10 +234,10 @@
    "source": [
     "result = agent.chat(\"Show land cover for Denver Colorado\")\n",
     "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items} | Time: {result.execution_time:.1f}s\"\n",
+    "    f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))} | Time: {result.execution_time:.1f}s\"\n",
     ")\n",
-    "if result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "if (result.data or {}).get(\"items\"):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -231,7 +264,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show land cover for New York City\")\n",
-    "print(f\"Success: {result.success} | Items: {result.data.total_items}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -254,10 +287,10 @@
    "source": [
     "result = agent.chat(\"Show DEM for Grand Canyon\")\n",
     "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items} | Time: {result.execution_time:.1f}s\"\n",
+    "    f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))} | Time: {result.execution_time:.1f}s\"\n",
     ")\n",
-    "if result.data.items:\n",
-    "    print(f\"Collection: {result.data.items[0].get('collection')}\")\n",
+    "if (result.data or {}).get(\"items\"):\n",
+    "    print(f\"Collection: {(result.data or {}).get('items', [])[0].get('collection')}\")\n",
     "result.map"
    ]
   },
@@ -284,7 +317,7 @@
    "outputs": [],
    "source": [
     "result = agent.chat(\"Show elevation map of Mount Rainier\")\n",
-    "print(f\"Success: {result.success} | Items: {result.data.total_items}\")\n",
+    "print(f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\")\n",
     "result.map"
    ]
   },
@@ -307,10 +340,10 @@
    "source": [
     "result = agent.chat(\"Find Landsat images of Denver in June 2024\")\n",
     "print(\n",
-    "    f\"Success: {result.success} | Items: {result.data.total_items} | Time: {result.execution_time:.1f}s\"\n",
+    "    f\"Success: {result.success} | Items: {len((result.data or {}).get('items', []))} | Time: {result.execution_time:.1f}s\"\n",
     ")\n",
-    "if result.data.items:\n",
-    "    for item in result.data.items[:3]:\n",
+    "if (result.data or {}).get(\"items\"):\n",
+    "    for item in ((result.data or {}).get(\"items\", []))[:3]:\n",
     "        cc = item[\"properties\"].get(\"eo:cloud_cover\", \"N/A\")\n",
     "        print(f\"  {item['id']}: cloud cover {cc}%\")\n",
     "result.map"
@@ -344,7 +377,9 @@
    "source": [
     "# African location\n",
     "result = agent.chat(\"Show Sentinel-2 imagery of Lagos Nigeria in January 2024\")\n",
-    "print(f\"Lagos - Success: {result.success} | Items: {result.data.total_items}\")\n",
+    "print(\n",
+    "    f\"Lagos - Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\"\n",
+    ")\n",
     "result.map"
    ]
   },
@@ -356,7 +391,9 @@
    "source": [
     "# European location\n",
     "result = agent.chat(\"Show land cover for Paris France\")\n",
-    "print(f\"Paris - Success: {result.success} | Items: {result.data.total_items}\")\n",
+    "print(\n",
+    "    f\"Paris - Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\"\n",
+    ")\n",
     "result.map"
    ]
   },
@@ -368,7 +405,9 @@
    "source": [
     "# Asian location\n",
     "result = agent.chat(\"Show DEM for Mount Fuji\")\n",
-    "print(f\"Mount Fuji - Success: {result.success} | Items: {result.data.total_items}\")\n",
+    "print(\n",
+    "    f\"Mount Fuji - Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\"\n",
+    ")\n",
     "result.map"
    ]
   },
@@ -390,7 +429,7 @@
     "# Winter\n",
     "result = agent.chat(\"Show Sentinel-2 imagery of Chicago in December 2023\")\n",
     "print(\n",
-    "    f\"Chicago Dec 2023 - Success: {result.success} | Items: {result.data.total_items}\"\n",
+    "    f\"Chicago Dec 2023 - Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\"\n",
     ")\n",
     "result.map"
    ]
@@ -404,7 +443,7 @@
     "# Summer\n",
     "result = agent.chat(\"Show Sentinel-2 imagery of Chicago in July 2024\")\n",
     "print(\n",
-    "    f\"Chicago Jul 2024 - Success: {result.success} | Items: {result.data.total_items}\"\n",
+    "    f\"Chicago Jul 2024 - Success: {result.success} | Items: {len((result.data or {}).get('items', []))}\"\n",
     ")\n",
     "result.map"
    ]
@@ -429,12 +468,13 @@
     "data = agent.search(\n",
     "    \"Find Sentinel-2 images of Seattle in August 2024 with low cloud cover\"\n",
     ")\n",
-    "print(f\"Found {data.total_items} items\")\n",
-    "print(f\"Search params: {data.search_query}\")\n",
-    "for item in data.items[:5]:\n",
-    "    cc = item[\"properties\"].get(\"eo:cloud_cover\", \"N/A\")\n",
-    "    dt = item[\"properties\"].get(\"datetime\", \"\")\n",
-    "    print(f\"  {item['id']}: {dt[:10]} cloud={cc}%\")"
+    "print(\n",
+    "    f\"success={data.success} | tools={data.executed_tools} \"\n",
+    "    f\"| time={data.execution_time:.1f}s\"\n",
+    ")\n",
+    "if data.answer_text:\n",
+    "    print(\"---\")\n",
+    "    print(data.answer_text[:600])"
    ]
   },
   {

--- a/docs/examples/live_mapping.ipynb
+++ b/docs/examples/live_mapping.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Live mapping with `for_leafmap`\n",
+    "\n",
+    "When you bind a live `leafmap.maplibregl.Map` to a GeoAgent, the **mapping subagent** is added to the active subagent list and its tools (add layer, remove layer, set basemap, fly to, save) are wired to the very `Map` widget you passed in. Subsequent natural-language chats mutate that `Map` in place, so re-displaying the same widget shows the agent's work.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Why `for_leafmap(m)` and not `chat(target_map=m)`?\n",
+    "\n",
+    "Both paths bind the agent to a map, but they have different state semantics:\n",
+    "\n",
+    "- `for_leafmap(m)` — builds the agent once with `map_obj=m` already in the context. The deepagents graph and its `MemorySaver` thread persist across many chats, so the agent can reason about what it did before.\n",
+    "- `agent.chat(query, target_map=m)` — switches an existing agent to a new map. The graph is rebuilt and a fresh thread id is rotated in ([`agent.py`](https://github.com/giswqs/geoagent/blob/main/geoagent/core/agent.py)), which resets conversation history. Use this when you genuinely want to hand the agent a different map mid-session.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import for_leafmap\n",
+    "from leafmap.maplibregl import Map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=[-83.92, 35.96], zoom=10)  # Knoxville, TN\n",
+    "agent = for_leafmap(m)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Chat 1 — list current layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = agent.chat(\"List the current map layers.\")\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "if result.answer_text:\n",
+    "    print(result.answer_text[:400])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Chat 2 — add a Sentinel-2 RGB COG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = agent.chat(\"Add a Sentinel-2 RGB COG layer over Knoxville TN for July 2024.\")\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Chat 3 — change the basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = agent.chat(\"Switch the basemap to Carto Voyager.\")\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Chat 4 — remove a layer\n",
+    "\n",
+    "Because `for_leafmap` keeps a single thread alive, the agent remembers the layer names from chat 2 and can act on them by ordinal reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = agent.chat(\"Remove the Sentinel-2 layer.\")\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Inspecting the mapping subagent's footprint\n",
+    "\n",
+    "`result.executed_tools` enumerates every tool the agent actually invoked during the call, in order. For mapping queries you should see entries like `list_layers`, `add_layer`, `set_basemap`, and `remove_layer` from the mapping subagent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for query in (\n",
+    "    \"Save the current map to /tmp/knoxville.html\",\n",
+    "    \"Zoom out to fit all layers.\",\n",
+    "):\n",
+    "    r = agent.chat(query)\n",
+    "    print(f\"{query!r:60s} -> {r.executed_tools}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/live_mapping.ipynb
+++ b/docs/examples/live_mapping.ipynb
@@ -5,9 +5,9 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Live mapping with `for_leafmap`\n",
+    "# Live mapping with a map-bound `GeoAgent`\n",
     "\n",
-    "When you bind a live `leafmap.maplibregl.Map` to a GeoAgent, the **mapping subagent** is added to the active subagent list and its tools (add layer, remove layer, set basemap, fly to, save) are wired to the very `Map` widget you passed in. Subsequent natural-language chats mutate that `Map` in place, so re-displaying the same widget shows the agent's work.\n"
+    "When you build a `GeoAgent` with a live `leafmap.maplibregl.Map` in its `GeoAgentContext`, the **mapping subagent** is added to the active subagent list and its tools (add layer, remove layer, set basemap, fly to, save) are wired to the very `Map` widget you passed in. Subsequent natural-language `agent.chat(...)` calls mutate that `Map` in place, so re-displaying the same widget shows the agent's work.\n"
    ]
   },
   {
@@ -15,12 +15,13 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Why `for_leafmap(m)` and not `chat(target_map=m)`?\n",
+    "## Three ways to bind a map (and which to use)\n",
     "\n",
-    "Both paths bind the agent to a map, but they have different state semantics:\n",
+    "GeoAgent exposes three ways to give an agent a live map. They differ in which API they expose and in how they manage state across calls:\n",
     "\n",
-    "- `for_leafmap(m)` — builds the agent once with `map_obj=m` already in the context. The deepagents graph and its `MemorySaver` thread persist across many chats, so the agent can reason about what it did before.\n",
-    "- `agent.chat(query, target_map=m)` — switches an existing agent to a new map. The graph is rebuilt and a fresh thread id is rotated in ([`agent.py`](https://github.com/giswqs/geoagent/blob/main/geoagent/core/agent.py)), which resets conversation history. Use this when you genuinely want to hand the agent a different map mid-session.\n"
+    "- `GeoAgent(context=GeoAgentContext(map_obj=m))` — builds the facade with `map_obj=m` already in the context. The deepagents graph and its `MemorySaver` thread persist across many chats, so the agent can reason about what it did before. Use this when you want the `.chat()` API and `GeoAgentResponse` introspection. **This notebook uses this form.**\n",
+    "- `agent.chat(query, target_map=m)` — switches an existing `GeoAgent` to a new map. The graph is rebuilt and a fresh thread id is rotated in (see [`agent.py`](https://github.com/opengeos/GeoAgent/blob/main/geoagent/core/agent.py)), which resets conversation history. Use this when you need to hand the agent a different map mid-session.\n",
+    "- `for_leafmap(m)` — a lower-level factory that returns a compiled deepagents `CompiledStateGraph` (not the `GeoAgent` facade). It does not expose `.chat()` or build a `GeoAgentResponse`; call it via `.invoke({\"messages\": [{\"role\": \"user\", \"content\": ...}]})`. Reach for it when you want to drive deepagents directly.\n"
    ]
   },
   {
@@ -38,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from geoagent import for_leafmap\n",
+    "from geoagent import GeoAgent, GeoAgentContext\n",
     "from leafmap.maplibregl import Map"
    ]
   },
@@ -50,7 +51,7 @@
    "outputs": [],
    "source": [
     "m = Map(center=[-83.92, 35.96], zoom=10)  # Knoxville, TN\n",
-    "agent = for_leafmap(m)\n",
+    "agent = GeoAgent(context=GeoAgentContext(map_obj=m))\n",
     "m"
    ]
   },
@@ -122,7 +123,7 @@
    "source": [
     "## Chat 4 — remove a layer\n",
     "\n",
-    "Because `for_leafmap` keeps a single thread alive, the agent remembers the layer names from chat 2 and can act on them by ordinal reference."
+    "Because the same `GeoAgent` instance keeps a single thread alive, the agent remembers the layer names from chat 2 and can act on them by ordinal reference."
    ]
   },
   {

--- a/docs/examples/maplibre_viz.ipynb
+++ b/docs/examples/maplibre_viz.ipynb
@@ -155,9 +155,9 @@
     "\n",
     "## Drive the same map with GeoAgent\n",
     "\n",
-    "`for_leafmap(m)` binds a long-lived agent to the live `Map` widget. The agent's mapping subagent calls leafmap tools (add layer, set basemap, fly to, save) against the very `m` you passed in, so subsequent `m` displays show the mutations.\n",
+    "Building a `GeoAgent` with `map_obj=m` in its `GeoAgentContext` activates the mapping subagent and binds its tools (add layer, set basemap, fly to, save) to the live `Map` widget. Subsequent `agent.chat(...)` calls mutate `m` in place, so re-displaying the widget shows the agent's work.\n",
     "\n",
-    "Prefer `for_leafmap(m)` over `agent.chat(query, target_map=m)`: the latter rebuilds the deepagents graph and rotates the LangGraph thread id, which resets conversation history (see `geoagent/core/agent.py`).\n"
+    "Prefer this over `agent.chat(query, target_map=m)`, which rebuilds the deepagents graph and rotates the LangGraph thread id (resetting conversation history). The lower-level `for_leafmap(m)` factory is also available, but it returns a raw deepagents graph rather than the `GeoAgent` facade — see [live_mapping.ipynb](live_mapping.ipynb) for a side-by-side comparison.\n"
    ]
   },
   {
@@ -166,11 +166,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from geoagent import for_leafmap\n",
+    "from geoagent import GeoAgent, GeoAgentContext\n",
     "from leafmap.maplibregl import Map\n",
     "\n",
     "live_map = Map(center=[-122.4194, 37.7749], zoom=10)\n",
-    "agent = for_leafmap(live_map)"
+    "agent = GeoAgent(context=GeoAgentContext(map_obj=live_map))"
    ]
   },
   {

--- a/docs/examples/maplibre_viz.ipynb
+++ b/docs/examples/maplibre_viz.ipynb
@@ -146,6 +146,55 @@
     "    m.add_cog_layer(item.assets[\"visual\"].href, name=item.id)\n",
     "    m"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Drive the same map with GeoAgent\n",
+    "\n",
+    "`for_leafmap(m)` binds a long-lived agent to the live `Map` widget. The agent's mapping subagent calls leafmap tools (add layer, set basemap, fly to, save) against the very `m` you passed in, so subsequent `m` displays show the mutations.\n",
+    "\n",
+    "Prefer `for_leafmap(m)` over `agent.chat(query, target_map=m)`: the latter rebuilds the deepagents graph and rotates the LangGraph thread id, which resets conversation history (see `geoagent/core/agent.py`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import for_leafmap\n",
+    "from leafmap.maplibregl import Map\n",
+    "\n",
+    "live_map = Map(center=[-122.4194, 37.7749], zoom=10)\n",
+    "agent = for_leafmap(live_map)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = agent.chat(\"Add a Sentinel-2 RGB layer over San Francisco for July 2024.\")\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "live_map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = agent.chat(\"List the current map layers.\")\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "if result.answer_text:\n",
+    "    print(result.answer_text[:500])"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/stac_search.ipynb
+++ b/docs/examples/stac_search.ipynb
@@ -145,6 +145,36 @@
     "cat = reg.get_catalog(\"my_stac\")\n",
     "print(f\"Custom catalog URL: {cat.url}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Ask GeoAgent for the same data\n",
+    "\n",
+    "The data subagent wraps the same STAC tooling shown above. Asking the agent in natural language fires `search_stac` (and possibly `get_stac_collections`) under the hood. Inspect `result.executed_tools` to confirm.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import GeoAgent\n",
+    "\n",
+    "agent = GeoAgent()\n",
+    "result = agent.search(\n",
+    "    \"Find the most recent Sentinel-2 scenes over Knoxville TN with cloud cover under 15%.\"\n",
+    ")\n",
+    "print(\"Success:\", result.success)\n",
+    "print(\"Tools fired:\", result.executed_tools)\n",
+    "if result.answer_text:\n",
+    "    print(\"---\")\n",
+    "    print(result.answer_text[:600])"
+   ]
   }
  ],
  "metadata": {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,9 +84,12 @@ nav:
         - examples/intro.ipynb
         - examples/stac_search.ipynb
         - examples/maplibre_viz.ipynb
+        - examples/live_mapping.ipynb
         - examples/earth_science_queries.ipynb
         - examples/contextual_qa.ipynb
         - examples/event_monitoring.ipynb
+        - examples/hitl_confirm.ipynb
+        - examples/custom_tools.ipynb
     - API Reference:
         - GeoAgent: geoagent.md
         - Factory: factory.md


### PR DESCRIPTION
## Summary

- Update all six existing example notebooks to use v1.0 idioms (`executed_tools`, `answer_text`, dict access into `plan` / `data` / `analysis`) instead of the v0.x typed accesses (`result.plan.intent`, `result.data.total_items`, `result.analysis.result_data`, `data.search_query`) that no longer work because `GeoAgentResponse` treats those fields as opaque dicts and the deepagents subagents do not write them to graph state.
- Add three new notebooks demonstrating capabilities introduced by the Phase 2 rewrite:
  - `hitl_confirm.ipynb` — `ConfirmCallback` / `ConfirmRequest` flow with the three built-in callbacks plus a custom one.
  - `custom_tools.ipynb` — extending GeoAgent with `@geo_tool` and `stamp_geo_meta`.
  - `live_mapping.ipynb` — `for_leafmap(m)` driving a `maplibregl` widget across multiple chats; contrasted with the graph-rebuilding `chat(target_map=...)` path.
- Wire the three new notebooks into the `Examples` nav in `mkdocs.yml`.

## Test plan

- [x] AST-parse all 9 notebooks (199 code cells) — clean.
- [x] `pre-commit run --all-files` — passes (black-jupyter, nbstripout, codespell, etc.).
- [x] `mkdocs build --strict` — clean (the only `--strict` warnings before this commit were `no git logs` for the new files, which now have a commit).
- [x] `pytest tests/ -q` — 79/79 passed.
- [ ] Reviewer spot-check that the agent-introspection idioms in the updated notebooks match the v1.0 surface (`executed_tools`, `answer_text`, `cancelled_tools`).
- [ ] Optional: execute the three new notebooks against a real LLM provider to confirm cell outputs render as expected (notebooks are committed with cleared outputs per `nbstripout`).