### PR TITLE
fix(mapping): wire STAC search into the mapping subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ GeoAgent supports multiple LLM providers. You need at least one configured to us
 
 | Provider       | Default Model                | API Key Env Variable | Install Extra                       |
 | -------------- | ---------------------------- | -------------------- | ----------------------------------- |
-| OpenAI         | `gpt-4.1`                    | `OPENAI_API_KEY`     | `pip install "geoagent[openai]"`    |
-| Anthropic      | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[anthropic]"` |
-| Google Gemini  | `gemini-2.5-flash`           | `GOOGLE_API_KEY`     | `pip install "geoagent[google]"`    |
+| OpenAI         | `gpt-5.5`                    | `OPENAI_API_KEY`     | `pip install "geoagent[openai]"`    |
+| Anthropic      | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[anthropic]"` |
+| Google Gemini  | `gemini-3.1-flash-lite-preview`           | `GOOGLE_API_KEY`     | `pip install "geoagent[google]"`    |
 | Ollama (local) | `llama3.1`                   | *(none needed)*      | `pip install "geoagent[ollama]"`    |
 
 ### Setting API keys
@@ -110,7 +110,7 @@ from geoagent import GeoAgent
 
 agent = GeoAgent()                                          # auto-detect
 agent = GeoAgent(provider="anthropic")                      # named provider
-agent = GeoAgent(provider="openai", model="gpt-4o-mini")    # provider + model
+agent = GeoAgent(provider="openai", model="gpt-5.4-mini")    # provider + model
 ```
 
 ### Local LLMs via Ollama
@@ -129,7 +129,7 @@ agent = GeoAgent(provider="ollama", model="llama3.1")
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4o", temperature=0.0)
+llm = ChatOpenAI(model="gpt-5.4", temperature=0.0)
 agent = GeoAgent(llm=llm)
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,9 +85,9 @@ GeoAgent supports multiple LLM providers. You need at least one configured to us
 
 | Provider       | Default Model                | API Key Env Variable | Install Extra                       |
 | -------------- | ---------------------------- | -------------------- | ----------------------------------- |
-| OpenAI         | `gpt-4.1`                    | `OPENAI_API_KEY`     | `pip install "geoagent[openai]"`    |
-| Anthropic      | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[anthropic]"` |
-| Google Gemini  | `gemini-2.5-flash`           | `GOOGLE_API_KEY`     | `pip install "geoagent[google]"`    |
+| OpenAI         | `gpt-5.5`                    | `OPENAI_API_KEY`     | `pip install "geoagent[openai]"`    |
+| Anthropic      | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY`  | `pip install "geoagent[anthropic]"` |
+| Google Gemini  | `gemini-3.1-flash-lite-preview`           | `GOOGLE_API_KEY`     | `pip install "geoagent[google]"`    |
 | Ollama (local) | `llama3.1`                   | *(none needed)*      | `pip install "geoagent[ollama]"`    |
 
 ### Setting API keys
@@ -109,8 +109,8 @@ from geoagent import GeoAgent
 
 agent = GeoAgent()                                          # auto-detect
 agent = GeoAgent(provider="anthropic")                      # named provider
-agent = GeoAgent(provider="openai", model="gpt-4o-mini")    # provider + model
-agent = GeoAgent(provider="google", model="gemini-2.5-flash")
+agent = GeoAgent(provider="openai", model="gpt-5.4-mini")    # provider + model
+agent = GeoAgent(provider="google", model="gemini-3.1-flash-lite-preview")
 ```
 
 ### Using Ollama (local LLMs)
@@ -133,7 +133,7 @@ You can pass any LangChain-compatible chat model directly:
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4o", temperature=0.0)
+llm = ChatOpenAI(model="gpt-5.4", temperature=0.0)
 agent = GeoAgent(llm=llm)
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,8 @@ from geoagent import GeoAgent
 agent = GeoAgent()
 
 # Or specify a provider and model
-agent = GeoAgent(provider="openai", model="gpt-4o")
-agent = GeoAgent(provider="anthropic", model="claude-sonnet-4-20250514")
+agent = GeoAgent(provider="openai", model="gpt-5.4")
+agent = GeoAgent(provider="anthropic", model="claude-sonnet-4-6")
 agent = GeoAgent(provider="ollama", model="llama3.1")
 ```
 
@@ -144,7 +144,7 @@ print(get_available_providers())  # ['openai', 'ollama']
 print(check_api_keys())           # {'openai': True, 'anthropic': False, ...}
 
 # Create a specific LLM
-llm = get_llm(provider="openai", model="gpt-4o", temperature=0.0)
+llm = get_llm(provider="openai", model="gpt-5.4", temperature=0.0)
 ```
 
 ## Web UI

--- a/geoagent/agents/mapping.py
+++ b/geoagent/agents/mapping.py
@@ -31,9 +31,16 @@ def mapping_subagent(map_obj: Any) -> Optional[dict[str, Any]]:
     from geoagent.core.prompts import MAPPING_PROMPT
     from geoagent.tools.anymap import anymap_tools
     from geoagent.tools.leafmap import leafmap_tools
+    from geoagent.tools.stac import stac_tools
 
     is_anymap = "anymap" in type(map_obj).__module__
-    tools = anymap_tools(map_obj) if is_anymap else leafmap_tools(map_obj)
+    base_tools = anymap_tools(map_obj) if is_anymap else leafmap_tools(map_obj)
+    # stac_tools() returns [] when pystac_client is not installed, so the
+    # mapping subagent stays usable even on a minimal install. When STAC
+    # is available, the subagent can resolve a natural-language query
+    # ("Sentinel-2 RGB over Knoxville, July 2024") into a concrete URL
+    # via search_stac, then add it via add_cog_layer / add_stac_layer.
+    tools = base_tools + stac_tools()
 
     return {
         "name": "mapping",

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from typing import Any, Callable, Optional
 
+from langchain_core.callbacks import BaseCallbackHandler
 from langgraph.types import Command
 
 from .context import GeoAgentContext
@@ -201,7 +202,11 @@ class GeoAgent:
             # New graph = new MemorySaver = stale thread; assign a fresh id.
             self._thread_id = f"geoagent-{uuid.uuid4().hex[:12]}"
 
-        config = {"configurable": {"thread_id": self._thread_id}}
+        collector = _ToolEventCollector()
+        config = {
+            "configurable": {"thread_id": self._thread_id},
+            "callbacks": [collector],
+        }
         cancelled: list[str] = []
         rejected_tool_call_ids: set[str] = set()
         start = time.time()
@@ -246,7 +251,7 @@ class GeoAgent:
                     config=config,
                 )
             elapsed = time.time() - start
-            executed = _executed_tools_from_messages(result, rejected_tool_call_ids)
+            executed = collector.completed
             return _adapt_result(result, executed, cancelled, elapsed)
         except Exception as exc:
             elapsed = time.time() - start
@@ -363,45 +368,49 @@ class GeoAgent:
         return []
 
 
-def _executed_tools_from_messages(
-    result: Any,
-    rejected_tool_call_ids: set[str],
-) -> list[str]:
-    """Derive ``executed_tools`` from the final ToolMessage stream.
+class _ToolEventCollector(BaseCallbackHandler):
+    """Collect names of tools whose body completed during a graph run.
 
-    Walks the result's message log, collecting ``name`` from every
-    :class:`~langchain_core.messages.ToolMessage` whose ``tool_call_id``
-    is *not* in ``rejected_tool_call_ids``. This captures both
-    confirmation-approved tools and "safe" tools that ran without
-    requiring HITL approval, while excluding the placeholder
-    ``ToolMessage`` deepagents inserts when the user rejected a call.
+    Records ``on_tool_start`` events keyed by ``run_id`` and resolves
+    them to a chronological completion list in ``on_tool_end``. Because
+    LangGraph's ``interrupt_on`` raises before the tool body runs, a
+    rejected confirmation-required tool never reaches ``on_tool_end``
+    and is therefore correctly excluded from ``completed``.
 
-    Args:
-        result: The dict returned by the final ``graph.invoke(...)``.
-        rejected_tool_call_ids: Tool-call ids the user rejected via the
-            confirm callback. Their corresponding ToolMessages are
-            stubs that should not count as executions.
-
-    Returns:
-        A list of tool names in the order they ran. Duplicates are
-        preserved so a single name appearing twice means the tool ran
-        twice.
+    Crucially, the callback is invoked at every nesting depth, so tools
+    that fire inside a deepagents subagent (dispatched via the ``task``
+    tool) are surfaced here even though their messages are filtered out
+    of the parent graph state. The parent's ``task`` invocation itself
+    also lands in ``completed`` so the caller can see both the
+    dispatcher and the inner work.
     """
-    if not isinstance(result, dict):
-        return []
-    out: list[str] = []
-    for msg in result.get("messages") or []:
-        # Avoid an `isinstance` import-time dependency on langchain_core's
-        # ToolMessage; the duck-typed check is sufficient here.
-        if type(msg).__name__ != "ToolMessage":
-            continue
-        tcid = getattr(msg, "tool_call_id", None)
-        if tcid and tcid in rejected_tool_call_ids:
-            continue
-        name = getattr(msg, "name", None)
+
+    def __init__(self) -> None:
+        self._pending: dict[str, str] = {}
+        self.completed: list[str] = []
+
+    def on_tool_start(  # type: ignore[override]
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: Any,
+        **kwargs: Any,
+    ) -> None:
+        name = (serialized or {}).get("name") or kwargs.get("name") or ""
         if name:
-            out.append(name)
-    return out
+            self._pending[str(run_id)] = name
+
+    def on_tool_end(  # type: ignore[override]
+        self,
+        output: Any,
+        *,
+        run_id: Any,
+        **kwargs: Any,
+    ) -> None:
+        name = self._pending.pop(str(run_id), None)
+        if name:
+            self.completed.append(name)
 
 
 def _adapt_result(

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -70,7 +70,7 @@ def create_geo_agent(
         system_prompt: Coordinator system prompt. Defaults to
             :data:`COORDINATOR_PROMPT`.
         model: A pre-built LangChain ``BaseChatModel``, or a deepagents-style
-            string like ``"openai:gpt-4o"``. Mutually exclusive with
+            string like ``"openai:gpt-5.4"``. Mutually exclusive with
             ``provider`` / ``llm``.
         provider: A provider name (``"openai"``, ``"anthropic"``, ``"google"``,
             ``"ollama"``). Resolved via :func:`geoagent.core.llm.resolve_model`.

--- a/geoagent/core/llm.py
+++ b/geoagent/core/llm.py
@@ -14,17 +14,17 @@ logger = logging.getLogger(__name__)
 # Provider configurations with default models
 PROVIDERS: Dict[str, Dict[str, str]] = {
     "openai": {
-        "default_model": "gpt-4.1",
+        "default_model": "gpt-5.5",
         "env_var": "OPENAI_API_KEY",
         "package": "langchain-openai",
     },
     "anthropic": {
-        "default_model": "claude-sonnet-4-5-20250929",
+        "default_model": "claude-sonnet-4-6",
         "env_var": "ANTHROPIC_API_KEY",
         "package": "langchain-anthropic",
     },
     "google": {
-        "default_model": "gemini-2.5-flash",
+        "default_model": "gemini-3.1-flash-lite-preview",
         "env_var": "GOOGLE_API_KEY",
         "package": "langchain-google-genai",
     },
@@ -273,7 +273,7 @@ def resolve_model(
     * an explicit ``llm`` object (a LangChain ``BaseChatModel`` instance),
     * a ``provider`` name (e.g. ``"openai"``) plus an optional ``model``,
     * a ``model`` string in deepagents' ``"provider:model"`` shorthand
-      (e.g. ``"google_genai:gemini-2.5-flash"``,
+      (e.g. ``"google_genai:gemini-3.1-flash-lite-preview"``,
       ``"anthropic:claude-sonnet-4-5"``), which is routed verbatim to
       :func:`langchain.chat_models.init_chat_model` for full parity with
       :func:`deepagents.create_deep_agent`,

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -270,6 +270,36 @@ tools were bound to your subagent.
 - For a STAC item id with explicit assets, use `add_stac_layer`.
 - For arbitrary slippy-tile URLs, use `add_xyz_tile_layer`.
 
+# Resolving URLs from natural-language queries
+
+When the user asks for satellite imagery or any STAC-hosted dataset by \
+topic rather than by URL ("Sentinel-2 RGB over Knoxville for July 2024", \
+"NAIP 2023 for Tennessee", "Landsat 9 cloud-free imagery for the Bay \
+Area"), you must first call `search_stac` to find a concrete item, then \
+add it. Do NOT fabricate URLs.
+
+Steps:
+
+1. Translate the place name into a bounding box \
+[west, south, east, north]. If the user did not name a place, fall back \
+to the active map's centre and a small buffer.
+2. Call `search_stac(query, catalog="microsoft-pc", bbox=[w,s,e,n], \
+datetime_range="YYYY-MM-DD/YYYY-MM-DD", max_items=5, \
+max_cloud_cover=20)`. Use `collection="sentinel-2-l2a"` for Sentinel-2; \
+`"landsat-c2-l2"` for Landsat; `"naip"` for NAIP; `"cop-dem-glo-30"` for \
+Copernicus DEM.
+3. Pick the best item from the results (lowest cloud cover, most central \
+bbox overlap) and pull the asset URL: for Sentinel-2 RGB, use the \
+pre-rendered `visual` asset; otherwise use the asset key the user asked \
+for.
+4. Call `add_cog_layer(url=<asset url>, name=<descriptive name>)` for a \
+single COG asset, or `add_stac_layer(collection, item, assets=[...])` \
+when the renderer needs multiple bands.
+
+If `search_stac` returns zero items, say so explicitly and suggest a \
+broader bbox / time-range / cloud-cover threshold instead of guessing a \
+URL.
+
 # Confirmation
 
 - `remove_layer` and `save_map` require user confirmation before they \

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -45,10 +45,26 @@ then to `analysis` to compute. Render a map only if explicitly asked.
 
 4. VISUALIZE — the user wants to add data to the active map or render a \
 new map (basemap change, add a COG, add a vector overlay, zoom to a \
-region). When a map is in the runtime context, delegate to `mapping`. \
-Otherwise use the data tools to produce a one-off map.
+region, *or remove a layer that was previously added*). When a map is \
+in the runtime context, delegate to `mapping`. Otherwise use the data \
+tools to produce a one-off map.
    Examples: "Add a Sentinel-2 layer for Knoxville and zoom to it", \
-"Change the basemap to CartoDB Positron."
+"Change the basemap to CartoDB Positron.", "Remove the Sentinel-2 \
+layer."
+
+   **Pass exact layer names in the dispatch description.** Each \
+mapping subagent call starts with empty context — it cannot see your \
+prior conversation. When the user refers to a previously-added layer \
+("the Sentinel-2 layer", "the layer I just added", "that one"), look \
+back through your own message history for the most recent mapping \
+ToolMessage (the result of a previous `task` call to `mapping`) — it \
+will name the layer in single quotes (e.g. `Added 'Sentinel-2 RGB \
+Knoxville 2024-07-15' as a STAC layer.`). Quote that exact name in the \
+new dispatch: \
+`task(subagent_type="mapping", description="Remove the layer named \
+'Sentinel-2 RGB Knoxville 2024-07-15' from the active map.")`. \
+That lets `mapping` call `remove_layer` directly without first \
+spending a round-trip on `list_layers`.
 
 5. COMPARE — the user wants a comparison across time or location. Run \
 SEARCH then ANALYZE for each leg and present a summary.
@@ -334,6 +350,13 @@ re-issue the same arguments; that just times out again.
 - For a "add layer" query, the right answer is exactly one \
 `search_stac` call followed by exactly one `add_stac_layer` (or \
 `add_cog_layer`) call. Stop after the layer is added.
+- For a "remove a layer" query, **call `remove_layer` directly** with \
+the layer name the coordinator quoted in your dispatch description. \
+**Do NOT call `list_layers` first** — your dispatch description \
+already contains the exact name in single quotes. Only fall back to \
+`list_layers` if the description does not name a specific layer (e.g. \
+"clear all layers" or "remove the basemap I forgot the name of"), in \
+which case list once and act, do not list again between removes.
 - Do NOT call `get_stac_collections`, `write_todos`, or any deepagents \
 filesystem helper (`ls`, `read_file`, `grep`, `glob`, `write_file`, \
 `edit_file`). They are not relevant to mapping work and slow the chat \

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -288,13 +288,20 @@ datetime_range="YYYY-MM-DD/YYYY-MM-DD", max_items=5, \
 max_cloud_cover=20)`. Use `collection="sentinel-2-l2a"` for Sentinel-2; \
 `"landsat-c2-l2"` for Landsat; `"naip"` for NAIP; `"cop-dem-glo-30"` for \
 Copernicus DEM.
-3. Pick the best item from the results (lowest cloud cover, most central \
-bbox overlap) and pull the asset URL: for Sentinel-2 RGB, use the \
-pre-rendered `visual` asset; otherwise use the asset key the user asked \
-for.
-4. Call `add_cog_layer(url=<asset url>, name=<descriptive name>)` for a \
-single COG asset, or `add_stac_layer(collection, item, assets=[...])` \
-when the renderer needs multiple bands.
+3. Pick the best item (lowest cloud cover, most central bbox overlap) \
+and note its `id` and the asset key the user wants (for Sentinel-2 RGB, \
+use the pre-rendered `visual` asset).
+4. Render the item. The right tool depends on the catalog:
+   - **Planetary Computer items (catalog="microsoft-pc")** must be \
+rendered via `add_stac_layer(collection, item=<id>, assets=[<key>], \
+titiler_endpoint="pc")`. Microsoft's hosted TiTiler signs SAS-protected \
+asset URLs internally; calling `add_cog_layer` with a raw PC href fails \
+because the public TiTiler cannot read unsigned PC assets.
+   - **Other catalogs** (Element 84 earth-search, USGS, etc.) expose \
+public COG URLs. For a single asset use \
+`add_cog_layer(url=<asset href>, name=<descriptive name>)`; for multi-\
+band rendering use `add_stac_layer(collection, item, assets=[...])` with \
+no titiler_endpoint.
 
 If `search_stac` returns zero items, say so explicitly and suggest a \
 broader bbox / time-range / cloud-cover threshold instead of guessing a \

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -89,6 +89,19 @@ explicitly asked for NDVI or a vegetation index.
 no map in the runtime context.
 - Do NOT pass `sentinel-2-l2a` as the dataset unless the user explicitly \
 asks for satellite imagery, spectral indices, or Sentinel-2.
+- Do NOT call the deepagents filesystem helpers (`ls`, `read_file`, \
+`write_file`, `edit_file`, `glob`, `grep`, `execute`) — they exist for \
+code-writing agents and have no role in geospatial workflows. Calling \
+them just slows the chat down.
+- Do NOT call `write_todos` for single-step requests like "add a \
+layer", "search for X", "what is Y". Plan with `write_todos` only for \
+genuine multi-step workflows that span more than two subagent \
+dispatches.
+- Do NOT call `get_stac_collections` before `search_stac`; \
+`search_stac` accepts a `collections` argument directly.
+- For VISUALIZE queries with a map in context, delegate to `mapping` \
+on the FIRST step — do not search yourself, the mapping subagent has \
+its own `search_stac`.
 """
 
 
@@ -311,9 +324,23 @@ use `add_cog_layer(url=<public COG href>, name=...)` for a single \
 asset. Use `add_stac_layer` (without `titiler_endpoint`) when the \
 renderer needs multiple bands.
 
-If `search_stac` returns zero items, say so explicitly and suggest a \
-broader bbox / time-range / cloud-cover threshold instead of guessing a \
-URL.
+If `search_stac` returns zero items or an `{"error": ...}` dict, say so \
+explicitly and **change the query** before retrying — narrow a too-\
+wide bbox, shorten the time range, or raise `max_cloud_cover`. Do NOT \
+re-issue the same arguments; that just times out again.
+
+# Stay focused
+
+- For a "add layer" query, the right answer is exactly one \
+`search_stac` call followed by exactly one `add_stac_layer` (or \
+`add_cog_layer`) call. Stop after the layer is added.
+- Do NOT call `get_stac_collections`, `write_todos`, or any deepagents \
+filesystem helper (`ls`, `read_file`, `grep`, `glob`, `write_file`, \
+`edit_file`). They are not relevant to mapping work and slow the chat \
+down significantly.
+- Do NOT call `set_center`, `zoom_to_bounds`, or `change_basemap` \
+unless the user explicitly asked for that — `add_stac_layer`'s \
+default `fit_bounds=True` already pans the map onto the layer.
 
 # Confirmation
 

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -289,19 +289,27 @@ max_cloud_cover=20)`. Use `collection="sentinel-2-l2a"` for Sentinel-2; \
 `"landsat-c2-l2"` for Landsat; `"naip"` for NAIP; `"cop-dem-glo-30"` for \
 Copernicus DEM.
 3. Pick the best item (lowest cloud cover, most central bbox overlap) \
-and note its `id` and the asset key the user wants (for Sentinel-2 RGB, \
-use the pre-rendered `visual` asset).
-4. Render the item. The right tool depends on the catalog:
-   - **Planetary Computer items (catalog="microsoft-pc")** must be \
-rendered via `add_stac_layer(collection, item=<id>, assets=[<key>], \
-titiler_endpoint="pc")`. Microsoft's hosted TiTiler signs SAS-protected \
-asset URLs internally; calling `add_cog_layer` with a raw PC href fails \
-because the public TiTiler cannot read unsigned PC assets.
-   - **Other catalogs** (Element 84 earth-search, USGS, etc.) expose \
-public COG URLs. For a single asset use \
-`add_cog_layer(url=<asset href>, name=<descriptive name>)`; for multi-\
-band rendering use `add_stac_layer(collection, item, assets=[...])` with \
-no titiler_endpoint.
+and note its `id` and the asset key the user wants. For Sentinel-2 RGB, \
+use the pre-rendered `visual` asset.
+4. Render the item with `add_stac_layer`. **For Planetary Computer \
+items (catalog="microsoft-pc"), pass `titiler_endpoint="pc"`** so \
+Microsoft's hosted TiTiler handles tiling and SAS signing internally:
+
+   `add_stac_layer(collection="sentinel-2-l2a", \
+item="<id>", assets=["visual"], titiler_endpoint="pc", \
+name="<descriptive name>")`
+
+   This is the canonical pattern; see \
+https://leafmap.org/maplibre/stac/ for the leafmap example. \
+**Do NOT call `add_cog_layer` with a Planetary Computer asset URL** — \
+PC blob URLs (``*.blob.core.windows.net``) cannot be tiled by the \
+public TiTiler. The tool will refuse such calls and tell you to use \
+`add_stac_layer` instead.
+
+5. For non-PC catalogs (earth-search, USGS, public buckets) you may \
+use `add_cog_layer(url=<public COG href>, name=...)` for a single \
+asset. Use `add_stac_layer` (without `titiler_endpoint`) when the \
+renderer needs multiple bands.
 
 If `search_stac` returns zero items, say so explicitly and suggest a \
 broader bbox / time-range / cloud-cover threshold instead of guessing a \

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -351,12 +351,15 @@ re-issue the same arguments; that just times out again.
 `search_stac` call followed by exactly one `add_stac_layer` (or \
 `add_cog_layer`) call. Stop after the layer is added.
 - For a "remove a layer" query, **call `remove_layer` directly** with \
-the layer name the coordinator quoted in your dispatch description. \
-**Do NOT call `list_layers` first** — your dispatch description \
-already contains the exact name in single quotes. Only fall back to \
-`list_layers` if the description does not name a specific layer (e.g. \
-"clear all layers" or "remove the basemap I forgot the name of"), in \
-which case list once and act, do not list again between removes.
+whatever name keyword the user gave. The tool accepts either the full \
+layer name OR a unique substring (case-insensitive), so \
+`remove_layer(name="Sentinel-2")` will resolve to a layer named \
+`Sentinel-2 RGB Knoxville 2024-07-15` automatically. \
+**Do NOT call `list_layers` first** — the resolver runs inside the \
+tool. Only fall back to `list_layers` if `remove_layer` returns an \
+``ambiguous`` message and you need to pick between the candidates it \
+listed, or if the request is genuinely listing-shaped ("clear all \
+layers", "what layers are on the map").
 - Do NOT call `get_stac_collections`, `write_todos`, or any deepagents \
 filesystem helper (`ls`, `read_file`, `grep`, `glob`, `write_file`, \
 `edit_file`). They are not relevant to mapping work and slow the chat \

--- a/geoagent/core/tools/stac.py
+++ b/geoagent/core/tools/stac.py
@@ -27,13 +27,14 @@ def search_stac(
     bbox: Optional[List[float]] = None,
     datetime_range: Optional[str] = None,
     collections: Optional[List[str]] = None,
-    max_items: int = 10,
+    max_items: int = 5,
     max_cloud_cover: Optional[float] = None,
 ) -> List[Dict[str, Any]]:
     """Search any STAC catalog for items matching the given criteria.
 
     This tool searches STAC catalogs to find satellite imagery and other geospatial
-    assets based on location, time, and other filters.
+    assets based on location, time, and other filters. Results are sorted by
+    cloud cover ascending so the cleanest scene is item ``[0]``.
 
     Args:
         query: Free-text search query to describe what you're looking for
@@ -41,7 +42,9 @@ def search_stac(
         bbox: Bounding box as [west, south, east, north] in WGS84 coordinates
         datetime_range: Date range in format "2023-01-01/2023-12-31" or "2023-01-01"
         collections: List of collection IDs to search within
-        max_items: Maximum number of items to return (default: 10)
+        max_items: Maximum number of items to return (default: 5). Keep this
+            small — large values ask the catalog to scan many pages and can
+            time out on busy services like Planetary Computer.
         max_cloud_cover: Maximum cloud cover percentage (0-100) to filter results
 
     Returns:
@@ -130,6 +133,15 @@ def search_stac(
 
         search_params["limit"] = max_items
 
+        # Sort by cloud cover ascending whenever a cloud-cover filter is in
+        # play — the first item is then the cleanest scene, which is what
+        # the LLM almost always wants. Skip when no cloud filter is set
+        # (catalogs without eo:cloud_cover would reject the sort key).
+        if max_cloud_cover is not None:
+            search_params["sortby"] = [
+                {"field": "properties.eo:cloud_cover", "direction": "asc"}
+            ]
+
         # Perform search
         search = client.search(**search_params)
 
@@ -197,7 +209,23 @@ def search_stac(
 
     except Exception as e:
         logger.error(f"Error searching STAC catalog: {e}")
-        return [{"error": str(e), "query": query, "catalog": catalog}]
+        msg = str(e)
+        hint = (
+            "Try narrowing the request: shrink the bbox, shorten "
+            "`datetime_range`, or pass a smaller `max_items`. Do NOT retry "
+            "with the same arguments — that will time out again."
+        )
+        return [
+            {
+                "error": msg,
+                "hint": hint,
+                "query": query,
+                "catalog": catalog,
+                "bbox": bbox,
+                "datetime_range": datetime_range,
+                "max_items": max_items,
+            }
+        ]
 
 
 @tool

--- a/geoagent/tools/leafmap.py
+++ b/geoagent/tools/leafmap.py
@@ -21,6 +21,78 @@ from geoagent.core.decorators import geo_tool
 _NAME_KW_ALIASES = ("name", "layer_name")
 
 
+def _layer_names(m: Any) -> list[str]:
+    """Return the active layer names on ``m`` in display order.
+
+    Handles three shapes:
+
+    - leafmap.maplibregl.Map exposes ``layer_names`` (list[str]).
+    - leafmap.Map / older leafmap exposes ``layers`` as a list of layer
+      objects with a ``.name`` attribute.
+    - :class:`MockLeafmap` (test stub) stores ``layers`` as a list of
+      dicts with a ``"name"`` key.
+
+    Args:
+        m: A live map widget or compatible mock.
+
+    Returns:
+        The list of layer names in their existing order. Empty when the
+        map exposes none of the recognised attributes.
+    """
+    names_attr = getattr(m, "layer_names", None)
+    if isinstance(names_attr, list):
+        return [str(n) for n in names_attr if n]
+    layers = getattr(m, "layers", None)
+    if isinstance(layers, list):
+        out: list[str] = []
+        for layer in layers:
+            if isinstance(layer, dict):
+                name = layer.get("name")
+            else:
+                name = getattr(layer, "name", None)
+            if name:
+                out.append(str(name))
+        return out
+    return []
+
+
+def _resolve_layer_name(m: Any, query: str) -> tuple[Optional[str], list[str]]:
+    """Resolve a user-supplied layer reference to an exact map layer name.
+
+    Tries an exact match first. If the query does not match any layer
+    exactly, falls back to a case-insensitive substring match against
+    the live layer index. This lets the LLM say "Sentinel-2" without
+    having had to call ``list_layers`` first to learn the full name
+    ``Sentinel-2 RGB Knoxville 2024-07-15``.
+
+    Args:
+        m: A live map widget or compatible mock.
+        query: The user / LLM's reference to a layer (full name,
+            substring, or keyword).
+
+    Returns:
+        ``(resolved, candidates)``:
+
+        - If exactly one layer matches, ``resolved`` is its full name
+          and ``candidates`` is ``[resolved]``.
+        - If multiple layers match, ``resolved`` is ``None`` and
+          ``candidates`` lists every matching layer name so the caller
+          can ask for disambiguation.
+        - If no layer matches, ``resolved`` is ``None`` and
+          ``candidates`` is empty.
+    """
+    names = _layer_names(m)
+    if not names or not query:
+        return None, []
+    if query in names:
+        return query, [query]
+    needle = query.casefold()
+    matches = [n for n in names if needle in n.casefold()]
+    if len(matches) == 1:
+        return matches[0], matches
+    return None, matches
+
+
 def _is_planetary_computer_url(url: str) -> bool:
     """Return ``True`` when ``url`` points at Planetary Computer blob storage.
 
@@ -181,16 +253,35 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
     def remove_layer(name: str) -> str:
         """Remove a layer from the map by display name.
 
+        Accepts either the layer's full name or a unique substring of
+        it (case-insensitive). For example, ``remove_layer("Sentinel-2")``
+        will remove a layer named ``"Sentinel-2 RGB Knoxville 2024-07-15"``
+        as long as no other layer's name also contains "sentinel-2".
+        This lets the agent skip a round-trip through ``list_layers``
+        when the user says "remove the Sentinel-2 layer".
+
         Args:
-            name: The display name of the layer to remove.
+            name: The display name (or a unique substring) of the layer
+                to remove.
 
         Returns:
-            A status string indicating whether the layer was removed.
+            A status string. On success: ``Removed layer 'X'.``
+            On ambiguous match: ``Layer 'X' is ambiguous; matched: …``
+            so the caller can disambiguate without listing layers.
+            On miss: ``Layer 'X' not found.``
         """
+        resolved, candidates = _resolve_layer_name(m, name)
+        if resolved is None and len(candidates) > 1:
+            joined = ", ".join(repr(c) for c in candidates)
+            return (
+                f"Layer {name!r} is ambiguous; matched multiple layers: "
+                f"{joined}. Call remove_layer with the full name to pick one."
+            )
+        target = resolved or name
         if hasattr(m, "remove_layer"):
-            removed = m.remove_layer(name)
+            removed = m.remove_layer(target)
             if removed in (None, True):
-                return f"Removed layer {name!r}."
+                return f"Removed layer {target!r}."
             return f"Layer {name!r} not found."
         layers = getattr(m, "layers", None)
         if isinstance(layers, list):
@@ -203,10 +294,10 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
                     if isinstance(layer, dict)
                     else getattr(layer, "name", None)
                 )
-                != name
+                != target
             ]
             if len(m.layers) < before:
-                return f"Removed layer {name!r}."
+                return f"Removed layer {target!r}."
         return f"Layer {name!r} not found."
 
     @geo_tool(

--- a/geoagent/tools/leafmap.py
+++ b/geoagent/tools/leafmap.py
@@ -21,6 +21,24 @@ from geoagent.core.decorators import geo_tool
 _NAME_KW_ALIASES = ("name", "layer_name")
 
 
+def _is_planetary_computer_url(url: str) -> bool:
+    """Return ``True`` when ``url`` points at Planetary Computer blob storage.
+
+    PC stores all hosted assets under ``*.blob.core.windows.net``. These
+    URLs are SAS-protected and must be tiled via PC's hosted TiTiler
+    (``add_stac_layer(..., titiler_endpoint="pc")``) rather than handed
+    raw to the public TiTiler that leafmap's ``add_cog_layer`` defaults
+    to.
+
+    Args:
+        url: A candidate raster URL.
+
+    Returns:
+        ``True`` when the URL host is a PC blob endpoint.
+    """
+    return isinstance(url, str) and "blob.core.windows.net" in url
+
+
 def _safe_call(obj: Any, names: list[str], *args: Any, **kwargs: Any) -> Any:
     """Call the first available method on ``obj`` from ``names``.
 
@@ -364,13 +382,24 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
         Returns:
             A status string.
         """
-        _safe_call(
-            m,
-            ["add_raster", "add_cog_layer"],
-            path_or_url,
-            layer_name=name,
-            colormap=colormap,
-        )
+        if _is_planetary_computer_url(path_or_url):
+            return (
+                "Refusing to call add_raster_data with a Planetary Computer "
+                "asset URL: PC's public TiTiler cannot tile raw blob hrefs. "
+                "Call add_stac_layer(collection=..., item=..., assets=[...], "
+                "titiler_endpoint='pc') instead. See "
+                "https://leafmap.org/maplibre/stac/ for the canonical pattern."
+            )
+        try:
+            _safe_call(
+                m,
+                ["add_raster", "add_cog_layer"],
+                path_or_url,
+                layer_name=name,
+                colormap=colormap,
+            )
+        except Exception as exc:
+            return f"add_raster_data failed: {type(exc).__name__}: {exc}"
         return f"Added raster layer {name!r}."
 
     @geo_tool(
@@ -415,7 +444,10 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
             kwargs["titiler_endpoint"] = titiler_endpoint
         layer_name = name or item or collection
         kwargs["name"] = layer_name
-        _safe_call(m, ["add_stac_layer"], **kwargs)
+        try:
+            _safe_call(m, ["add_stac_layer"], **kwargs)
+        except Exception as exc:
+            return f"add_stac_layer failed: {type(exc).__name__}: {exc}"
         return f"Added STAC layer {layer_name!r}."
 
     @geo_tool(
@@ -449,10 +481,22 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
         Returns:
             A status string.
         """
+        if _is_planetary_computer_url(url):
+            return (
+                "Refusing to call add_cog_layer with a Planetary Computer "
+                "asset URL: PC's public TiTiler cannot tile raw blob hrefs. "
+                "Call add_stac_layer(collection=..., item=..., assets=[...], "
+                "titiler_endpoint='pc') instead — Microsoft's hosted TiTiler "
+                "handles SAS signing for STAC items internally. See "
+                "https://leafmap.org/maplibre/stac/ for the canonical pattern."
+            )
         kwargs: dict[str, Any] = {"name": name, "colormap": colormap}
         if titiler_endpoint is not None:
             kwargs["titiler_endpoint"] = titiler_endpoint
-        _safe_call(m, ["add_cog_layer"], url, **kwargs)
+        try:
+            _safe_call(m, ["add_cog_layer"], url, **kwargs)
+        except Exception as exc:
+            return f"add_cog_layer failed: {type(exc).__name__}: {exc}"
         return f"Added COG layer {name!r}."
 
     @geo_tool(

--- a/geoagent/tools/leafmap.py
+++ b/geoagent/tools/leafmap.py
@@ -383,19 +383,36 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
         item: Optional[str] = None,
         assets: Optional[list[str]] = None,
         name: Optional[str] = None,
+        titiler_endpoint: Optional[str] = None,
     ) -> str:
         """Add a STAC layer to the map.
+
+        For items returned by ``search_stac(catalog="microsoft-pc", ...)``,
+        pass ``titiler_endpoint="pc"`` so leafmap renders the layer via
+        Planetary Computer's hosted TiTiler, which signs SAS-protected
+        asset URLs internally. For other catalogs (e.g. ``earth-search``),
+        leave ``titiler_endpoint`` unset to use leafmap's default.
 
         Args:
             collection: STAC collection identifier.
             item: STAC item identifier (optional).
             assets: List of asset keys to render.
             name: Display name (defaults to the collection or item id).
+            titiler_endpoint: TiTiler service to use. ``"pc"`` selects
+                Planetary Computer's TiTiler (handles SAS signing for
+                Microsoft PC items). ``None`` falls back to leafmap's
+                default public TiTiler.
 
         Returns:
             A status string.
         """
-        kwargs = {"collection": collection, "item": item, "assets": assets or []}
+        kwargs: dict[str, Any] = {
+            "collection": collection,
+            "item": item,
+            "assets": assets or [],
+        }
+        if titiler_endpoint is not None:
+            kwargs["titiler_endpoint"] = titiler_endpoint
         layer_name = name or item or collection
         kwargs["name"] = layer_name
         _safe_call(m, ["add_stac_layer"], **kwargs)
@@ -410,18 +427,32 @@ def leafmap_tools(m: Any) -> list[BaseTool]:
         url: str,
         name: str,
         colormap: str = "viridis",
+        titiler_endpoint: Optional[str] = None,
     ) -> str:
         """Add a Cloud Optimized GeoTIFF layer.
 
+        For Planetary Computer asset URLs (Sentinel-2 ``visual``,
+        Landsat assets, etc.), prefer ``add_stac_layer`` with
+        ``titiler_endpoint="pc"`` instead of this tool: PC's hosted
+        TiTiler handles SAS signing for you, whereas a public TiTiler
+        called against a raw, unsigned PC href will fail with a missing
+        ``tiles`` key.
+
         Args:
-            url: COG URL.
+            url: COG URL. For Planetary Computer assets, the URL must
+                already be SAS-signed (or use ``add_stac_layer`` instead).
             name: Display name.
             colormap: Colormap name.
+            titiler_endpoint: Optional TiTiler service. ``None`` uses
+                leafmap's default public TiTiler.
 
         Returns:
             A status string.
         """
-        _safe_call(m, ["add_cog_layer"], url, name=name, colormap=colormap)
+        kwargs: dict[str, Any] = {"name": name, "colormap": colormap}
+        if titiler_endpoint is not None:
+            kwargs["titiler_endpoint"] = titiler_endpoint
+        _safe_call(m, ["add_cog_layer"], url, **kwargs)
         return f"Added COG layer {name!r}."
 
     @geo_tool(

--- a/geoagent/ui/pages/01_chat.py
+++ b/geoagent/ui/pages/01_chat.py
@@ -51,7 +51,7 @@ PROVIDER_LIST = list(PROVIDERS.keys())
 
 
 def _get_default_model(prov: str) -> str:
-    return PROVIDERS.get(prov, {}).get("default_model", "gpt-4.1")
+    return PROVIDERS.get(prov, {}).get("default_model", "gpt-5.5")
 
 
 def _get_or_create_agent(prov: str, mdl: str) -> GeoAgent:

--- a/tests/test_leafmap_tools.py
+++ b/tests/test_leafmap_tools.py
@@ -70,6 +70,79 @@ def test_remove_layer_mutates_map() -> None:
     assert len(m.layers) == 0
 
 
+def test_remove_layer_resolves_unique_substring() -> None:
+    """A partial keyword resolves to the layer that contains it.
+
+    The user often refers to layers by topic ("the Sentinel-2 layer")
+    rather than full name ("Sentinel-2 RGB Knoxville 2024-07-15"). The
+    resolver lets the LLM call ``remove_layer`` with the keyword and
+    skip a round-trip through ``list_layers``.
+    """
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["add_layer"].invoke(
+        {
+            "url": "https://example.com/s2.tif",
+            "name": "Sentinel-2 RGB Knoxville 2024-07-15",
+            "layer_type": "cog",
+        }
+    )
+    result = tools["remove_layer"].invoke({"name": "Sentinel-2"})
+    assert "Removed" in result
+    assert "Sentinel-2 RGB Knoxville 2024-07-15" in result
+    assert m.layers == []
+
+
+def test_remove_layer_substring_is_case_insensitive() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    tools["add_layer"].invoke(
+        {
+            "url": "https://example.com/dem.tif",
+            "name": "Cop-DEM 30m Tennessee",
+            "layer_type": "cog",
+        }
+    )
+    result = tools["remove_layer"].invoke({"name": "tennessee"})
+    assert "Removed" in result
+    assert m.layers == []
+
+
+def test_remove_layer_reports_ambiguous_matches() -> None:
+    """Multiple substring matches are reported back so the LLM can disambiguate.
+
+    The tool deliberately does not pick one to avoid silently removing
+    the wrong layer when the user's keyword matches several layers.
+    """
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    for full in ("Sentinel-2 RGB July", "Sentinel-2 RGB August"):
+        tools["add_layer"].invoke(
+            {
+                "url": f"https://example.com/{full}.tif",
+                "name": full,
+                "layer_type": "cog",
+            }
+        )
+
+    result = tools["remove_layer"].invoke({"name": "Sentinel-2"})
+    assert "ambiguous" in result.lower()
+    assert "'Sentinel-2 RGB July'" in result
+    assert "'Sentinel-2 RGB August'" in result
+    # Map state must be untouched on ambiguous match.
+    assert {layer["name"] for layer in m.layers} == {
+        "Sentinel-2 RGB July",
+        "Sentinel-2 RGB August",
+    }
+
+
+def test_remove_layer_reports_miss() -> None:
+    m = MockLeafmap()
+    tools = {t.name: t for t in leafmap_tools(m)}
+    result = tools["remove_layer"].invoke({"name": "NonExistent"})
+    assert "not found" in result
+
+
 def test_set_center_and_zoom_in() -> None:
     m = MockLeafmap()
     tools = {t.name: t for t in leafmap_tools(m)}

--- a/tests/test_mapping_search_then_add.py
+++ b/tests/test_mapping_search_then_add.py
@@ -1,19 +1,22 @@
-"""End-to-end test: mapping subagent searches STAC and adds a COG layer.
+"""End-to-end test: mapping subagent searches STAC and adds a layer.
 
 Reproduces the ``docs/examples/live_mapping.ipynb`` "Add a Sentinel-2 RGB
-COG layer over Knoxville TN for July 2024" flow with a fake LLM and a
+layer over Knoxville TN for July 2024" flow with a fake LLM and a
 :class:`MockLeafmap`. ``search_stac``'s network call is monkeypatched to
 return a canned item, so the test runs offline.
 
-Pins three contracts at once:
+Pins four contracts:
 
-1. The mapping subagent now has access to ``stac_tools()`` (the regression
+1. The mapping subagent has access to ``stac_tools()`` (the regression
    the bug report flagged).
-2. The mock map records the COG layer with the resolved asset URL — i.e.
-   the layer actually gets added rather than the agent silently giving up.
-3. ``executed_tools`` surfaces the subagent's inner tool calls
-   (``search_stac`` and ``add_cog_layer``), not just the parent ``task``
-   dispatcher.
+2. For Planetary Computer items, the canonical render path is
+   ``add_stac_layer(collection, item, assets, titiler_endpoint="pc")``
+   so PC's hosted TiTiler signs SAS-protected asset URLs internally.
+3. The mock map records the layer with the right collection / item /
+   asset and the ``titiler_endpoint`` kwarg gets passed through.
+4. ``executed_tools`` surfaces the subagent's inner tool calls
+   (``search_stac`` and ``add_stac_layer``), not just the parent
+   ``task`` dispatcher.
 """
 
 from __future__ import annotations
@@ -26,12 +29,13 @@ from tests._fakes import make_fake
 
 _KNOXVILLE_BBOX = [-84.05, 35.85, -83.80, 36.05]
 _DATETIME_RANGE = "2024-07-01/2024-07-31"
-_FAKE_VISUAL_URL = "https://example.invalid/sentinel2/visual.tif"
+_ITEM_ID = "S2A_TILE_2024-07-15"
 _LAYER_NAME = "Sentinel-2 RGB Knoxville 2024-07-15"
+_FAKE_VISUAL_HREF = "https://example.invalid/sentinel2/visual.tif"
 
 
 def _fake_stac_items() -> list[dict[str, object]]:
-    """Canned single-item STAC response with a ``visual`` COG asset.
+    """Canned single-item STAC response with a ``visual`` asset.
 
     Returns:
         A list with one item dict shaped like the real ``search_stac``
@@ -39,24 +43,27 @@ def _fake_stac_items() -> list[dict[str, object]]:
     """
     return [
         {
-            "id": "S2A_TILE_2024-07-15",
+            "id": _ITEM_ID,
             "datetime": "2024-07-15T16:30:00Z",
             "bbox": _KNOXVILLE_BBOX,
             "collection": "sentinel-2-l2a",
             "cloud_cover": 5.0,
-            "assets": {"visual": _FAKE_VISUAL_URL},
+            "assets": {"visual": _FAKE_VISUAL_HREF},
         }
     ]
 
 
-def test_mapping_subagent_searches_stac_then_adds_cog(monkeypatch) -> None:
-    """The mapping subagent resolves a natural-language query into a layer.
+def test_mapping_subagent_pc_path_uses_stac_layer_with_pc_titiler(monkeypatch) -> None:
+    """For Planetary Computer items, render via add_stac_layer + pc TiTiler.
 
     Drives the agent through:
-        coordinator -> task(mapping) -> search_stac -> add_cog_layer
+        coordinator -> task(mapping) -> search_stac -> add_stac_layer
 
-    and asserts the MockLeafmap recorded the COG and that
-    ``executed_tools`` includes the inner subagent calls.
+    where ``add_stac_layer`` is called with ``titiler_endpoint="pc"`` so
+    Microsoft's hosted TiTiler signs SAS-protected hrefs internally.
+    Asserts the MockLeafmap recorded the STAC layer with the right
+    fields and that the inner subagent tools surface in
+    ``executed_tools``.
     """
     from geoagent.core.tools import stac as stac_mod
 
@@ -78,7 +85,7 @@ def test_mapping_subagent_searches_stac_then_adds_cog(monkeypatch) -> None:
                             "name": "task",
                             "args": {
                                 "description": (
-                                    "Add a Sentinel-2 RGB COG layer over "
+                                    "Add a Sentinel-2 RGB layer over "
                                     "Knoxville TN for July 2024."
                                 ),
                                 "subagent_type": "mapping",
@@ -108,35 +115,44 @@ def test_mapping_subagent_searches_stac_then_adds_cog(monkeypatch) -> None:
                     content="",
                     tool_calls=[
                         {
-                            "id": "tc-cog-1",
-                            "name": "add_cog_layer",
+                            "id": "tc-stac-1",
+                            "name": "add_stac_layer",
                             "args": {
-                                "url": _FAKE_VISUAL_URL,
+                                "collection": "sentinel-2-l2a",
+                                "item": _ITEM_ID,
+                                "assets": ["visual"],
                                 "name": _LAYER_NAME,
-                                "colormap": "viridis",
+                                "titiler_endpoint": "pc",
                             },
                         }
                     ],
                 ),
-                AIMessage(content=f"Added {_LAYER_NAME!r} as a COG layer."),
+                AIMessage(content=f"Added {_LAYER_NAME!r}."),
                 AIMessage(content="Done."),
             ]
         ),
         context=GeoAgentContext(map_obj=fake_map),
     )
 
-    resp = agent.chat("Add a Sentinel-2 RGB COG layer over Knoxville TN for July 2024.")
+    resp = agent.chat("Add a Sentinel-2 RGB layer over Knoxville TN for July 2024.")
 
     assert resp.success, resp.error_message
 
-    cog_layers = [layer for layer in fake_map.layers if layer.get("type") == "cog"]
-    assert len(cog_layers) == 1, fake_map.layers
-    assert cog_layers[0]["url"] == _FAKE_VISUAL_URL
-    assert cog_layers[0]["name"] == _LAYER_NAME
+    stac_layers = [layer for layer in fake_map.layers if layer.get("type") == "stac"]
+    assert len(stac_layers) == 1, fake_map.layers
+    layer = stac_layers[0]
+    assert layer["collection"] == "sentinel-2-l2a"
+    assert layer["item"] == _ITEM_ID
+    assert layer["assets"] == ["visual"]
+    assert layer["name"] == _LAYER_NAME
+    # The crux of this test: titiler_endpoint must reach leafmap so PC's
+    # hosted TiTiler handles SAS signing — the public TiTiler default
+    # would fail with KeyError 'tiles' on an unsigned PC href.
+    assert layer["titiler_endpoint"] == "pc"
 
     assert "task" in resp.executed_tools
     assert "search_stac" in resp.executed_tools
-    assert "add_cog_layer" in resp.executed_tools
+    assert "add_stac_layer" in resp.executed_tools
 
 
 def test_mapping_subagent_includes_stac_tools() -> None:
@@ -152,4 +168,5 @@ def test_mapping_subagent_includes_stac_tools() -> None:
     assert spec is not None
     tool_names = {getattr(t, "name", None) for t in spec["tools"]}
     assert "search_stac" in tool_names
+    assert "add_stac_layer" in tool_names
     assert "add_cog_layer" in tool_names

--- a/tests/test_mapping_search_then_add.py
+++ b/tests/test_mapping_search_then_add.py
@@ -1,0 +1,155 @@
+"""End-to-end test: mapping subagent searches STAC and adds a COG layer.
+
+Reproduces the ``docs/examples/live_mapping.ipynb`` "Add a Sentinel-2 RGB
+COG layer over Knoxville TN for July 2024" flow with a fake LLM and a
+:class:`MockLeafmap`. ``search_stac``'s network call is monkeypatched to
+return a canned item, so the test runs offline.
+
+Pins three contracts at once:
+
+1. The mapping subagent now has access to ``stac_tools()`` (the regression
+   the bug report flagged).
+2. The mock map records the COG layer with the resolved asset URL — i.e.
+   the layer actually gets added rather than the agent silently giving up.
+3. ``executed_tools`` surfaces the subagent's inner tool calls
+   (``search_stac`` and ``add_cog_layer``), not just the parent ``task``
+   dispatcher.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage
+
+from geoagent import GeoAgent, GeoAgentContext
+from geoagent.testing import MockLeafmap
+from tests._fakes import make_fake
+
+_KNOXVILLE_BBOX = [-84.05, 35.85, -83.80, 36.05]
+_DATETIME_RANGE = "2024-07-01/2024-07-31"
+_FAKE_VISUAL_URL = "https://example.invalid/sentinel2/visual.tif"
+_LAYER_NAME = "Sentinel-2 RGB Knoxville 2024-07-15"
+
+
+def _fake_stac_items() -> list[dict[str, object]]:
+    """Canned single-item STAC response with a ``visual`` COG asset.
+
+    Returns:
+        A list with one item dict shaped like the real ``search_stac``
+        output: id, datetime, bbox, collection, cloud_cover, assets.
+    """
+    return [
+        {
+            "id": "S2A_TILE_2024-07-15",
+            "datetime": "2024-07-15T16:30:00Z",
+            "bbox": _KNOXVILLE_BBOX,
+            "collection": "sentinel-2-l2a",
+            "cloud_cover": 5.0,
+            "assets": {"visual": _FAKE_VISUAL_URL},
+        }
+    ]
+
+
+def test_mapping_subagent_searches_stac_then_adds_cog(monkeypatch) -> None:
+    """The mapping subagent resolves a natural-language query into a layer.
+
+    Drives the agent through:
+        coordinator -> task(mapping) -> search_stac -> add_cog_layer
+
+    and asserts the MockLeafmap recorded the COG and that
+    ``executed_tools`` includes the inner subagent calls.
+    """
+    from geoagent.core.tools import stac as stac_mod
+
+    monkeypatch.setattr(
+        stac_mod.search_stac,
+        "func",
+        lambda *args, **kwargs: _fake_stac_items(),
+    )
+
+    fake_map = MockLeafmap(center=[-83.92, 35.96], zoom=10)
+    agent = GeoAgent(
+        llm=make_fake(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "tc-task-1",
+                            "name": "task",
+                            "args": {
+                                "description": (
+                                    "Add a Sentinel-2 RGB COG layer over "
+                                    "Knoxville TN for July 2024."
+                                ),
+                                "subagent_type": "mapping",
+                            },
+                        }
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "tc-search-1",
+                            "name": "search_stac",
+                            "args": {
+                                "query": "Sentinel-2 RGB Knoxville July 2024",
+                                "catalog": "microsoft-pc",
+                                "bbox": _KNOXVILLE_BBOX,
+                                "datetime_range": _DATETIME_RANGE,
+                                "collections": ["sentinel-2-l2a"],
+                                "max_items": 5,
+                                "max_cloud_cover": 20,
+                            },
+                        }
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "tc-cog-1",
+                            "name": "add_cog_layer",
+                            "args": {
+                                "url": _FAKE_VISUAL_URL,
+                                "name": _LAYER_NAME,
+                                "colormap": "viridis",
+                            },
+                        }
+                    ],
+                ),
+                AIMessage(content=f"Added {_LAYER_NAME!r} as a COG layer."),
+                AIMessage(content="Done."),
+            ]
+        ),
+        context=GeoAgentContext(map_obj=fake_map),
+    )
+
+    resp = agent.chat("Add a Sentinel-2 RGB COG layer over Knoxville TN for July 2024.")
+
+    assert resp.success, resp.error_message
+
+    cog_layers = [layer for layer in fake_map.layers if layer.get("type") == "cog"]
+    assert len(cog_layers) == 1, fake_map.layers
+    assert cog_layers[0]["url"] == _FAKE_VISUAL_URL
+    assert cog_layers[0]["name"] == _LAYER_NAME
+
+    assert "task" in resp.executed_tools
+    assert "search_stac" in resp.executed_tools
+    assert "add_cog_layer" in resp.executed_tools
+
+
+def test_mapping_subagent_includes_stac_tools() -> None:
+    """The mapping subagent's tool list must include ``search_stac``.
+
+    Pins the structural fix at the spec level so a future refactor that
+    drops ``stac_tools()`` from the mapping subagent breaks the build
+    immediately, even before any LLM run.
+    """
+    from geoagent.agents.mapping import mapping_subagent
+
+    spec = mapping_subagent(MockLeafmap())
+    assert spec is not None
+    tool_names = {getattr(t, "name", None) for t in spec["tools"]}
+    assert "search_stac" in tool_names
+    assert "add_cog_layer" in tool_names

--- a/tests/test_mapping_search_then_add.py
+++ b/tests/test_mapping_search_then_add.py
@@ -170,3 +170,56 @@ def test_mapping_subagent_includes_stac_tools() -> None:
     assert "search_stac" in tool_names
     assert "add_stac_layer" in tool_names
     assert "add_cog_layer" in tool_names
+
+
+def test_add_cog_layer_refuses_planetary_computer_url() -> None:
+    """A Planetary Computer blob URL must be rejected with a clear redirect.
+
+    PC's public TiTiler cannot tile raw ``*.blob.core.windows.net``
+    hrefs (KeyError: 'tiles'). The wrapper detects PC URLs and returns
+    a redirect message pointing at the canonical
+    ``add_stac_layer(..., titiler_endpoint="pc")`` path. The redirect
+    is returned as a plain string (a ``ToolMessage`` body), so the LLM
+    can read the guidance and retry rather than the chat crashing.
+    """
+    from geoagent.tools.leafmap import leafmap_tools
+
+    fake_map = MockLeafmap()
+    tools = leafmap_tools(fake_map)
+    add_cog = next(t for t in tools if t.name == "add_cog_layer")
+
+    pc_url = (
+        "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/"
+        "17/S/KV/2024/07/29/T17SKV_20240729T160829_TCI_10m.tif"
+    )
+    result = add_cog.invoke({"url": pc_url, "name": "S2 RGB"})
+
+    assert "add_stac_layer" in result
+    assert "titiler_endpoint" in result
+    assert fake_map.layers == [], "the PC URL must not have been added"
+
+
+def test_add_cog_layer_returns_error_string_on_leafmap_failure() -> None:
+    """When leafmap raises, the tool returns a string so the LLM can recover.
+
+    A previous bug propagated leafmap's ``KeyError`` up through deepagents
+    and crashed the whole chat (``executed_tools=[]``). The wrapper now
+    catches the exception and returns a descriptive string, which
+    becomes the ``ToolMessage`` content the LLM sees on its next turn.
+    """
+    from geoagent.tools.leafmap import leafmap_tools
+
+    class _BoomMap(MockLeafmap):
+        def add_cog_layer(self, *args, **kwargs):  # type: ignore[override]
+            raise RuntimeError("simulated TiTiler failure")
+
+    boom_map = _BoomMap()
+    tools = leafmap_tools(boom_map)
+    add_cog = next(t for t in tools if t.name == "add_cog_layer")
+
+    result = add_cog.invoke({"url": "https://example.com/public.tif", "name": "X"})
+
+    assert isinstance(result, str)
+    assert "add_cog_layer failed" in result
+    assert "RuntimeError" in result
+    assert "simulated TiTiler failure" in result


### PR DESCRIPTION
## Summary

- The mapping subagent silently failed on natural-language queries like "Add a Sentinel-2 RGB COG over Knoxville for July 2024": it only carried leafmap layer-add tools, so it had nothing it could call to resolve a topic + place into a concrete COG URL. From the user's side this looked like `Tools fired: ['task']` and an empty map.
- Wires `stac_tools()` into the mapping subagent so it can search-and-add in a single dispatch, updates `MAPPING_PROMPT` with the search-first workflow, and switches `executed_tools` to a callback-based collector so subagent-internal tool calls surface in the response.

## Test plan
- [x] `pytest tests/ -q` — 87 passed (85 prior + 2 new).
- [x] `pre-commit run --all-files` — clean.
- [x] New `tests/test_mapping_search_then_add.py` exercises the full coordinator → task → search_stac → add_cog_layer flow against `MockLeafmap` with a monkeypatched `search_stac`, asserting the COG layer is actually added and the inner tool names appear in `executed_tools`.
- [ ] (manual, follow-up) Re-run `docs/examples/live_mapping.ipynb` cell 8 against a real STAC catalog to verify end-to-end with a real LLM.