### PR TITLE
docs: add Google-style docstrings across the codebase

### DIFF
--- a/geoagent/cli.py
+++ b/geoagent/cli.py
@@ -13,6 +13,7 @@ import subprocess
 
 
 def _run_solara_app() -> int:
+    """Launch the Solara UI application."""
     try:
         from geoagent.ui import PAGES_DIR
     except Exception as e:
@@ -28,6 +29,7 @@ def _run_solara_app() -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the script entry point."""
     parser = argparse.ArgumentParser(
         prog="geoagent",
         description="GeoAgent command line interface",

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -20,6 +20,7 @@ from geoagent.tools._qt_marshal import is_qt_gui_thread, process_qt_events
 
 
 def _result_to_text(result: Any) -> str:
+    """Extract response text from a Strands result object."""
     if result is None:
         return ""
     msg = getattr(result, "message", None)
@@ -69,6 +70,7 @@ class GeoAgent:
         self._rebuild_strands_agent()
 
     def _rebuild_strands_agent(self) -> None:
+        """Recreate the underlying Strands agent from current settings."""
         self._cancelled = []
         prompt = FAST_SYSTEM_PROMPT if self._fast else DEFAULT_SYSTEM_PROMPT
         hook = ConfirmationHookProvider(self._registry, self._confirm, self._cancelled)
@@ -84,6 +86,7 @@ class GeoAgent:
 
     @property
     def context(self) -> GeoAgentContext:
+        """GeoAgent runtime context."""
         return self._context
 
     @property
@@ -108,6 +111,7 @@ class GeoAgent:
 
     @property
     def config(self) -> GeoAgentConfig:
+        """GeoAgent model and runtime configuration."""
         return self._config
 
     def __getattr__(self, name: str) -> Any:
@@ -194,6 +198,7 @@ class GeoAgent:
         box: dict[str, Any] = {}
 
         def _worker() -> None:
+            """Execute chat work off the GUI thread."""
             try:
                 box["response"] = self._chat_impl(query)
             except BaseException as exc:  # pragma: no cover - defensive path
@@ -232,6 +237,7 @@ class GeoAgent:
         """
 
         def _worker() -> None:
+            """Execute chat work and dispatch callbacks."""
             try:
                 resp = self.chat(query, target_map=target_map)
                 if on_result is not None:

--- a/geoagent/core/config.py
+++ b/geoagent/core/config.py
@@ -11,6 +11,7 @@ ProviderName = Literal["bedrock", "openai", "anthropic", "gemini", "ollama"]
 
 
 def _default_provider_from_env() -> ProviderName:
+    """Infer the default provider from available environment variables."""
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
     if os.environ.get("ANTHROPIC_API_KEY"):

--- a/geoagent/core/confirmation_hook.py
+++ b/geoagent/core/confirmation_hook.py
@@ -27,9 +27,11 @@ class ConfirmationHookProvider(HookProvider):
     def register_hooks(
         self, registry: HookRegistry, **kwargs: Any
     ) -> None:  # noqa: ARG002
+        """Register confirmation callbacks with the Strands hook registry."""
         registry.add_callback(BeforeToolCallEvent, self._before_tool)
 
     def _resolve_meta(self, tool_name: str, selected: Any | None) -> GeoToolMeta | None:
+        """Resolve metadata from the selected tool or registry."""
         if selected is not None:
             attached: GeoToolMeta | None = getattr(selected, "_geoagent_meta", None)
             if attached is not None:
@@ -37,6 +39,7 @@ class ConfirmationHookProvider(HookProvider):
         return self._registry.get(tool_name)
 
     def _before_tool(self, event: BeforeToolCallEvent) -> None:
+        """Handle the pre-tool execution hook."""
         use = event.tool_use
         name = str(use.get("name", ""))
         selected = event.selected_tool

--- a/geoagent/core/decorators.py
+++ b/geoagent/core/decorators.py
@@ -40,6 +40,7 @@ def geo_tool(
     """
 
     def deco(fn: F) -> Any:
+        """Attach GeoAgent metadata to the decorated function."""
         kwargs: dict[str, Any] = {}
         if name is not None:
             kwargs["name"] = name

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -19,6 +19,7 @@ from geoagent.tools.qgis import qgis_tools
 
 
 def _filter_by_imports(tools: list[Any]) -> list[Any]:
+    """Drop tools whose declared optional packages are unavailable."""
     out: list[Any] = []
     for t in tools:
         meta = getattr(t, "_geoagent_meta", None)

--- a/geoagent/core/registry.py
+++ b/geoagent/core/registry.py
@@ -37,6 +37,7 @@ class GeoToolRegistry:
         self._by_name[meta.name] = meta
 
     def get(self, tool_name: str) -> GeoToolMeta | None:
+        """Return metadata for a registered tool name."""
         return self._by_name.get(tool_name)
 
     def list_names(self) -> list[str]:

--- a/geoagent/testing/_mocks.py
+++ b/geoagent/testing/_mocks.py
@@ -40,34 +40,43 @@ class MockLeafmap:
 
     # ----- viewport -----
     def set_center(self, lon: float, lat: float, zoom: Optional[int] = None) -> None:
+        """Set the mock map center and optional zoom."""
         self.center = [lon, lat]
         if zoom is not None:
             self.zoom = zoom
 
     def set_zoom(self, zoom: int) -> None:
+        """Set the mock map zoom level."""
         self.zoom = zoom
 
     def fit_bounds(self, bounds: list[list[float]]) -> None:
+        """Record the bounds requested by a fit operation."""
         self._bounds = bounds
 
     def fly_to(self, lon: float, lat: float, zoom: Optional[int] = None) -> None:
+        """Move the mock viewport to a center and optional zoom."""
         self.set_center(lon, lat, zoom)
 
     def get_center(self) -> list[float]:
+        """Return a copy of the mock map center."""
         return list(self.center)
 
     def get_zoom(self) -> int:
+        """Return the mock map zoom level."""
         return self.zoom
 
     def get_bounds(self) -> Optional[list[list[float]]]:
+        """Return the last fitted bounds."""
         return self._bounds
 
     # ----- basemap -----
     def add_basemap(self, basemap: str = "open-street-map") -> None:
+        """Record the selected basemap style."""
         self._style = basemap
 
     # ----- layers -----
     def add_layer(self, layer_dict: dict[str, Any]) -> None:
+        """Add layer."""
         self.layers.append(dict(layer_dict))
 
     def add_geojson(
@@ -77,6 +86,7 @@ class MockLeafmap:
         style: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
+        """Add geojson."""
         self.layers.append(
             {
                 "type": "geojson",
@@ -94,6 +104,7 @@ class MockLeafmap:
         fit_bounds: bool = False,
         **kwargs: Any,
     ) -> None:
+        """Add cog layer."""
         self.layers.append(
             {
                 "type": "cog",
@@ -111,9 +122,11 @@ class MockLeafmap:
         fit_bounds: bool = False,
         **kwargs: Any,
     ) -> None:
+        """Add raster."""
         self.add_cog_layer(url, name=layer_name, fit_bounds=fit_bounds, **kwargs)
 
     def add_pmtiles(self, url: str, name: str | None = None, **kwargs: Any) -> None:
+        """Add pmtiles."""
         self.layers.append(
             {
                 "type": "pmtiles",
@@ -130,6 +143,7 @@ class MockLeafmap:
         attribution: str = "",
         **kwargs: Any,
     ) -> None:
+        """Add xyz tile layer."""
         self.layers.append(
             {
                 "type": "xyz",
@@ -148,6 +162,7 @@ class MockLeafmap:
         name: str | None = None,
         **kwargs: Any,
     ) -> None:
+        """Add marker."""
         self.layers.append(
             {
                 "type": "marker",
@@ -167,6 +182,7 @@ class MockLeafmap:
         name: str | None = None,
         **kwargs: Any,
     ) -> None:
+        """Add stac layer."""
         self.layers.append(
             {
                 "type": "stac",
@@ -179,14 +195,17 @@ class MockLeafmap:
         )
 
     def remove_layer(self, name: str) -> bool:
+        """Remove layer."""
         before = len(self.layers)
         self.layers = [layer for layer in self.layers if layer.get("name") != name]
         return len(self.layers) != before
 
     def clear_layers(self) -> None:
+        """Clear layers."""
         self.layers = []
 
     def set_layer_visibility(self, name: str, visible: bool) -> bool:
+        """Set layer visibility."""
         for layer in self.layers:
             if layer.get("name") == name:
                 layer["visible"] = bool(visible)
@@ -194,6 +213,7 @@ class MockLeafmap:
         return False
 
     def set_layer_opacity(self, name: str, opacity: float) -> bool:
+        """Set layer opacity."""
         for layer in self.layers:
             if layer.get("name") == name:
                 layer["opacity"] = float(opacity)
@@ -202,9 +222,11 @@ class MockLeafmap:
 
     # ----- annotations / IO -----
     def add_title(self, title: str) -> None:
+        """Add title."""
         self.title = title
 
     def to_html(self, filename: str | None = None) -> str:
+        """Render the mock map state as simple HTML."""
         layer_list = "".join(
             f"<li>{layer.get('name', 'Unnamed')} ({layer.get('type', 'unknown')})</li>"
             for layer in self.layers
@@ -265,12 +287,15 @@ class MockQGISLayer:
         self._opacity = 1.0
 
     def name(self) -> str:
+        """Return the object name."""
         return self.layer_name
 
     def source(self) -> str:
+        """Return the data source."""
         return self.source_uri
 
     def type(self) -> str:
+        """Return the layer type."""
         return self.layer_type
 
     def extent(self) -> Optional[tuple[float, float, float, float]]:
@@ -285,52 +310,67 @@ class MockQGISLayer:
         return self._extent
 
     def isValid(self) -> bool:
+        """Return whether the mock layer is valid."""
         return True
 
     def fields(self) -> list[dict[str, Any]]:
+        """Return the layer fields."""
         return list(self._fields)
 
     def selectedFeatures(self) -> list[dict[str, Any]]:
+        """Return selected features."""
         return list(self._selected)
 
     def selectedFeatureCount(self) -> int:
+        """Return selected feature count."""
         return len(self._selected)
 
     def featureCount(self) -> int:
+        """Return feature count."""
         return len(self._selected)
 
     def selectByExpression(self, expression: str, behavior: Any = None) -> None:
+        """Select by expression."""
         self._selected = [{"id": 1, "expression": expression, "behavior": behavior}]
 
     def removeSelection(self) -> None:
+        """Remove selection."""
         self._selected = []
 
     def boundingBoxOfSelected(self) -> Optional[tuple[float, float, float, float]]:
+        """Return bounding box of selected."""
         if not self._selected:
             return None
         return self._extent
 
     def geometryType(self) -> str:
+        """Return geometry type."""
         return "unknown"
 
     def crs(self) -> Any:
+        """Return the mock layer CRS."""
         return None
 
     def id(self) -> str:
+        """Return the layer identifier."""
         return self.layer_name
 
     @property
     def visible(self) -> bool:
+        """Return the layer visibility."""
         return self._visible
 
     @visible.setter
     def visible(self, value: bool) -> None:
+        """Return the layer visibility."""
         self._visible = bool(value)
 
     def opacity(self) -> float:
+        """Return the layer opacity."""
         return self._opacity
 
     def setOpacity(self, opacity: float) -> None:
+        """Set opacity."""
         self._opacity = float(opacity)
 
 
@@ -352,18 +392,23 @@ class MockQGISCanvas:
         self.refresh_count: int = 0
 
     def zoomIn(self) -> None:
+        """Zoom in by decreasing the mock scale."""
         self.scale_value /= 2
 
     def zoomOut(self) -> None:
+        """Zoom out by increasing the mock scale."""
         self.scale_value *= 2
 
     def zoomByFactor(self, factor: float) -> None:
+        """Scale the mock canvas by a factor."""
         self.scale_value *= factor
 
     def setExtent(self, extent: tuple[float, float, float, float]) -> None:
+        """Set the mock canvas extent."""
         self.extent_value = tuple(extent)  # type: ignore[assignment]
 
     def setCenter(self, point: Any) -> None:
+        """Recenter the extent around a point."""
         try:
             x = point.x()
             y = point.y()
@@ -380,18 +425,23 @@ class MockQGISCanvas:
         )
 
     def zoomScale(self, scale: float) -> None:
+        """Set the mock canvas scale."""
         self.scale_value = float(scale)
 
     def extent(self) -> tuple[float, float, float, float]:
+        """Return the mock canvas extent."""
         return self.extent_value
 
     def zoomToFullExtent(self) -> None:
+        """Zoom to full extent."""
         self.extent_value = (-180.0, -90.0, 180.0, 90.0)
 
     def refresh(self) -> None:
+        """Record a canvas refresh."""
         self.refresh_count += 1
 
     def scale(self) -> float:
+        """Return the mock canvas scale."""
         return self.scale_value
 
 
@@ -408,31 +458,39 @@ class MockQGISProject:
         self.saved_path: Optional[str] = None
 
     def addMapLayer(self, layer: MockQGISLayer) -> MockQGISLayer:
+        """Add a layer to the mock project."""
         self._layers[layer.name()] = layer
         return layer
 
     def removeMapLayer(self, key: Any) -> None:
+        """Remove a layer by object or name."""
         if isinstance(key, MockQGISLayer):
             self._layers.pop(key.name(), None)
         else:
             self._layers.pop(key, None)
 
     def mapLayers(self) -> dict[str, MockQGISLayer]:
+        """Return all mock project layers."""
         return dict(self._layers)
 
     def mapLayersByName(self, name: str) -> list[MockQGISLayer]:
+        """Map layers by name."""
         return [layer for layer in self._layers.values() if layer.name() == name]
 
     def write(self, path: str | None = None) -> bool:
+        """Record the project save path."""
         self.saved_path = path or ""
         return True
 
     @classmethod
     def instance(cls) -> "MockQGISProject":
+        """Return the singleton instance."""
         return cls()
 
 
 class _MockMessageBar:
+    """Provide a mock implementation of message bar."""
+
     def pushMessage(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
         """No-op message-bar push, matching ``QgsMessageBar`` shape."""
         return None
@@ -452,36 +510,45 @@ class MockQGISIface:
         self._project = project or MockQGISProject()
 
     def mapCanvas(self) -> MockQGISCanvas:
+        """Return the mock map canvas."""
         return self._canvas
 
     def activeLayer(self) -> Optional[MockQGISLayer]:
+        """Return the active mock layer."""
         return self._active
 
     def setActiveLayer(self, layer: MockQGISLayer) -> None:
+        """Set the active mock layer."""
         self._active = layer
 
     def addVectorLayer(
         self, path: str, name: str, provider: str = "ogr"
     ) -> MockQGISLayer:
+        """Create and register a mock vector layer."""
         layer = MockQGISLayer(name, source=path, layer_type="vector")
         self._project.addMapLayer(layer)
         return layer
 
     def addRasterLayer(self, path: str, name: str) -> MockQGISLayer:
+        """Create and register a mock raster layer."""
         layer = MockQGISLayer(name, source=path, layer_type="raster")
         self._project.addMapLayer(layer)
         return layer
 
     def messageBar(self) -> _MockMessageBar:
+        """Return a mock QGIS message bar."""
         return _MockMessageBar()
 
     def project(self) -> MockQGISProject:
+        """Return the mock QGIS project."""
         return self._project
 
     def zoomFull(self) -> None:
+        """Zoom to the full project extent."""
         self._canvas.zoomToFullExtent()
 
     def zoomToActiveLayer(self) -> None:
+        """Zoom to active layer."""
         if self._active is not None:
             self._canvas.refresh()
 

--- a/geoagent/testing/_mocks.py
+++ b/geoagent/testing/_mocks.py
@@ -326,7 +326,7 @@ class MockQGISLayer:
         return len(self._selected)
 
     def featureCount(self) -> int:
-        """Return feature count."""
+        """Return selected feature count in this mock layer."""
         return len(self._selected)
 
     def selectByExpression(self, expression: str, behavior: Any = None) -> None:
@@ -362,7 +362,7 @@ class MockQGISLayer:
 
     @visible.setter
     def visible(self, value: bool) -> None:
-        """Return the layer visibility."""
+        """Set the layer visibility."""
         self._visible = bool(value)
 
     def opacity(self) -> float:

--- a/geoagent/tools/_qt_marshal.py
+++ b/geoagent/tools/_qt_marshal.py
@@ -70,6 +70,8 @@ def run_on_qt_gui_thread(func: Callable[[], T]) -> T:
     gui = app.thread()
 
     class _Invoker(QObject):
+        """Qt object used to invoke a callable on the GUI thread."""
+
         def __init__(self) -> None:
             super().__init__()
             self.value: Any = None
@@ -77,6 +79,7 @@ def run_on_qt_gui_thread(func: Callable[[], T]) -> T:
 
         @pyqtSlot()
         def run(self) -> None:
+            """Run the worker body."""
             try:
                 self.value = func()
             except BaseException as exc:  # pragma: no cover - passthrough path

--- a/geoagent/tools/leafmap.py
+++ b/geoagent/tools/leafmap.py
@@ -158,6 +158,7 @@ def _safe_call(obj: Any, names: list[str], *args: Any, **kwargs: Any) -> Any:
 
 
 def _layer_name(layer: Any) -> Optional[str]:
+    """Return a layer name from dict or object-style layer records."""
     if isinstance(layer, dict):
         name = layer.get("name") or layer.get("layer_name") or layer.get("id")
     else:
@@ -168,6 +169,7 @@ def _layer_name(layer: Any) -> Optional[str]:
 
 
 def _layer_attr(layer: Any, *keys: str, default: Any = None) -> Any:
+    """Return the first matching layer attribute or mapping key."""
     for key in keys:
         if isinstance(layer, dict) and key in layer:
             return layer[key]
@@ -178,6 +180,7 @@ def _layer_attr(layer: Any, *keys: str, default: Any = None) -> Any:
 
 
 def _layer_bounds(layer: Any) -> Optional[list[list[float]]]:
+    """Normalize layer bounds into southwest and northeast corners."""
     raw = _layer_attr(layer, "bounds", "bbox", "extent")
     if raw is None:
         return None
@@ -201,6 +204,7 @@ def _layer_bounds(layer: Any) -> Optional[list[list[float]]]:
 
 
 def _find_layer_entry(m: Any, name: str) -> Optional[Any]:
+    """Find a named layer entry on a map object."""
     for layer in getattr(m, "layers", None) or []:
         if _layer_name(layer) == name:
             return layer
@@ -208,6 +212,7 @@ def _find_layer_entry(m: Any, name: str) -> Optional[Any]:
 
 
 def _set_layer_attr(layer: Any, key: str, value: Any) -> bool:
+    """Set a layer attribute through mapping, setter, or attribute access."""
     if isinstance(layer, dict):
         layer[key] = value
         return True
@@ -223,6 +228,7 @@ def _set_layer_attr(layer: Any, key: str, value: Any) -> bool:
 
 
 def _layer_record(layer: Any) -> dict[str, Any]:
+    """Convert a layer entry into a serializable summary record."""
     name = _layer_name(layer) or "Unnamed"
     record = {
         "name": name,

--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -207,6 +207,7 @@ def _resolve_layer(project: Any, layer_name: str) -> Any:
 
 
 def _extent_payload(extent: Any) -> Any:
+    """Return a JSON-friendly representation of a QGIS extent."""
     if extent is None:
         return None
     if isinstance(extent, (list, tuple)) and len(extent) == 4:
@@ -221,6 +222,7 @@ def _extent_payload(extent: Any) -> Any:
 
 
 def _crs_payload(obj: Any) -> Optional[str]:
+    """Return a readable CRS identifier for a QGIS object."""
     if obj is None or not hasattr(obj, "crs"):
         return None
     try:
@@ -242,6 +244,7 @@ def _crs_payload(obj: Any) -> Optional[str]:
 
 
 def _call_int(obj: Any, method_name: str) -> Optional[int]:
+    """Call a no-argument method and coerce its result to an integer."""
     method = getattr(obj, method_name, None)
     if not callable(method):
         return None
@@ -252,6 +255,7 @@ def _call_int(obj: Any, method_name: str) -> Optional[int]:
 
 
 def _layer_visibility(project: Any, layer: Any) -> Optional[bool]:
+    """Return the layer tree visibility state for a layer."""
     try:
         root = project.layerTreeRoot()
         tree_layer = root.findLayer(layer.id())
@@ -268,6 +272,7 @@ def _layer_visibility(project: Any, layer: Any) -> Optional[bool]:
 
 
 def _layer_opacity(layer: Any) -> Optional[float]:
+    """Return layer opacity when the object exposes it."""
     value = getattr(layer, "opacity", None)
     if callable(value):
         try:
@@ -283,6 +288,7 @@ def _layer_opacity(layer: Any) -> Optional[float]:
 
 
 def _layer_metadata(layer: Any, project: Any | None = None) -> dict[str, Any]:
+    """Collect serializable metadata for a QGIS layer."""
     record: dict[str, Any] = {
         "id": str(layer.id()) if hasattr(layer, "id") else None,
         "name": layer.name() if hasattr(layer, "name") else str(layer),
@@ -321,9 +327,11 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         return []
 
     def _on_gui(func: Any) -> Any:
+        """Run a callable on the Qt GUI thread."""
         return run_on_qt_gui_thread(func)
 
     def _project() -> Any:
+        """Return the configured project or resolve it from the QGIS iface."""
         if project is not None:
             return project
         if hasattr(iface, "project"):
@@ -355,6 +363,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> list[dict[str, Any]]:
+            """Run the worker body."""
             proj = _project()
             return [_layer_metadata(layer, proj) for layer in proj.mapLayers().values()]
 
@@ -372,6 +381,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> dict[str, Any]:
+            """Run the worker body."""
             layer = iface.activeLayer()
             if layer is None:
                 return {"active_layer": None}
@@ -388,6 +398,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Return the QGIS project layer list and canvas camera state."""
 
         def _run() -> dict[str, Any]:
+            """Run the worker body."""
             proj = _project()
             canvas = iface.mapCanvas()
             active = iface.activeLayer()
@@ -425,6 +436,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             iface.mapCanvas().zoomIn()
             return "Zoomed in."
 
@@ -441,6 +453,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             iface.mapCanvas().zoomOut()
             return "Zoomed out."
 
@@ -460,6 +473,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             layer = _resolve_layer(_project(), layer_name)
             iface.setActiveLayer(layer)
             canvas = iface.mapCanvas()
@@ -525,6 +539,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             canvas = iface.mapCanvas()
             rect = _transform_bbox_to_canvas_crs(canvas, west, south, east, north, crs)
             canvas.setExtent(rect)
@@ -555,6 +570,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             canvas = iface.mapCanvas()
             point = _transform_point_to_canvas_crs(canvas, lon, lat, crs)
             if hasattr(canvas, "setCenter"):
@@ -594,6 +610,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Set the QGIS canvas map scale."""
 
         def _run() -> str:
+            """Run the worker body."""
             canvas = iface.mapCanvas()
             if hasattr(canvas, "zoomScale"):
                 canvas.zoomScale(float(scale))
@@ -627,6 +644,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             layer = iface.addVectorLayer(path_or_uri, name, provider)
             if layer is None or (hasattr(layer, "isValid") and not layer.isValid()):
                 return f"Failed to load vector layer from {path_or_uri!r}."
@@ -649,6 +667,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             layer = iface.addRasterLayer(path_or_uri, name)
             if layer is None or (hasattr(layer, "isValid") and not layer.isValid()):
                 return f"Failed to load raster layer from {path_or_uri!r}."
@@ -680,6 +699,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             parts = ["type=xyz", f"url={quote(url, safe='')}"]
             if zmin is not None:
                 parts.append(f"zmin={int(zmin)}")
@@ -729,6 +749,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             proj = _project()
             layers = proj.mapLayersByName(layer_name)
             if not layers:
@@ -757,6 +778,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             proj = _project()
             layer = _resolve_layer(proj, layer_name)
             # Try the layer-tree-based path first; fall back to a simple attribute.
@@ -780,6 +802,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Set a layer opacity from 0.0 (transparent) to 1.0 (opaque)."""
 
         def _run() -> str:
+            """Run the worker body."""
             value = min(1.0, max(0.0, float(opacity)))
             layer = _resolve_layer(_project(), layer_name)
             if hasattr(layer, "setOpacity"):
@@ -817,6 +840,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> list[dict[str, Any]]:
+            """Run the worker body."""
             layer = _resolve_layer(_project(), layer_name)
             out: list[dict[str, Any]] = []
             for field in layer.fields():
@@ -857,6 +881,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> list[dict[str, Any]]:
+            """Run the worker body."""
             if layer_name is None:
                 layer = iface.activeLayer()
                 if layer is None:
@@ -897,6 +922,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             layer = _resolve_layer(_project(), layer_name)
             if not hasattr(layer, "selectByExpression"):
                 return f"Layer {layer_name!r} does not support expression selection."
@@ -928,6 +954,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Clear selected features on one layer, or every project layer."""
 
         def _run() -> str:
+            """Run the worker body."""
             layers = (
                 [_resolve_layer(_project(), layer_name)]
                 if layer_name is not None
@@ -949,6 +976,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Zoom to the selected features on a layer or the active layer."""
 
         def _run() -> str:
+            """Run the worker body."""
             layer = (
                 iface.activeLayer()
                 if layer_name is None
@@ -979,6 +1007,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Return detailed metadata for a single project layer."""
 
         def _run() -> dict[str, Any]:
+            """Run the worker body."""
             layer = _resolve_layer(_project(), layer_name)
             summary = _layer_metadata(layer, _project())
             if hasattr(layer, "fields"):
@@ -1025,6 +1054,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> dict[str, Any]:
+            """Run the worker body."""
             try:
                 import processing  # type: ignore[import-not-found]
             except Exception as exc:  # pragma: no cover - QGIS-only path
@@ -1049,6 +1079,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             layer = _resolve_layer(_project(), layer_name)
             iface.setActiveLayer(layer)
             if hasattr(iface, "showAttributeTable"):
@@ -1068,6 +1099,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """
 
         def _run() -> str:
+            """Run the worker body."""
             iface.mapCanvas().refresh()
             return "Canvas refreshed."
 
@@ -1081,6 +1113,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         """Save the current QGIS project, optionally to a new file path."""
 
         def _run() -> str:
+            """Run the worker body."""
             proj = _project()
             if path:
                 out = Path(path).expanduser().resolve()

--- a/geoagent/ui/pages/00_home.py
+++ b/geoagent/ui/pages/00_home.py
@@ -1,8 +1,11 @@
+"""Utilities for 00 home.."""
+
 import solara
 
 
 @solara.component
 def Page():
+    """Render the Solara page."""
     with solara.Column(align="center"):
         markdown = """
         ## 🌍 GeoAgent

--- a/geoagent/ui/pages/00_home.py
+++ b/geoagent/ui/pages/00_home.py
@@ -1,4 +1,4 @@
-"""Utilities for 00 home.."""
+"""Solara home page."""
 
 import solara
 

--- a/geoagent/ui/pages/01_chat.py
+++ b/geoagent/ui/pages/01_chat.py
@@ -15,6 +15,7 @@ from geoagent import __version__
 
 @solara.component
 def Page():
+    """Render the Solara page."""
     with solara.AppBarTitle("GeoAgent chat"):
         pass
     with solara.Column(align="center"):

--- a/qgis_geoagent/install.py
+++ b/qgis_geoagent/install.py
@@ -96,6 +96,7 @@ def remove_plugin(plugin_dir: Path, plugin_name: str = "open_geoagent") -> bool:
 
 
 def main():
+    """Run the script entry point."""
     parser = argparse.ArgumentParser(description="Install or remove OpenGeoAgent")
     parser.add_argument(
         "--remove",

--- a/qgis_geoagent/open_geoagent/__init__.py
+++ b/qgis_geoagent/open_geoagent/__init__.py
@@ -5,7 +5,7 @@ from .deps_manager import ensure_venv_packages_available
 # Add isolated dependency site-packages to sys.path before importing GeoAgent.
 ensure_venv_packages_available()
 
-from .open_geoagent import OpenGeoAgent
+from .open_geoagent import OpenGeoAgent  # noqa: E402
 
 
 def classFactory(iface):

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -47,6 +47,7 @@ SAMPLE_PROMPTS = [
 
 
 def _setting(settings, key, default="", value_type=str):
+    """Read a plugin setting value."""
     return settings.value(f"{SETTINGS_PREFIX}{key}", default, type=value_type)
 
 
@@ -69,20 +70,24 @@ def _apply_environment_from_settings(settings):
 
 
 def _qt_value(enum_name, member_name):
+    """Return a Qt enum member across PyQt enum API variants."""
     container = getattr(Qt, enum_name, Qt)
     return getattr(container, member_name)
 
 
 def _enum_value(cls, enum_name, member_name):
+    """Return an enum member from either scoped or legacy Qt APIs."""
     container = getattr(cls, enum_name, cls)
     return getattr(container, member_name)
 
 
 def _plain_text_to_html(text):
+    """Convert plain text to basic HTML."""
     return html.escape(text).replace("\n", "<br>")
 
 
 def _inline_markdown_to_html(text):
+    """Convert inline Markdown spans to HTML."""
     text = html.escape(text)
     text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
     text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
@@ -100,6 +105,7 @@ def _markdown_to_basic_html(markdown):
     code_lines = []
 
     def close_lists():
+        """Close any open HTML list elements."""
         nonlocal in_ul, in_ol
         if in_ul:
             html_lines.append("</ul>")
@@ -180,6 +186,7 @@ class PromptTextEdit(QPlainTextEdit):
     next_requested = pyqtSignal()
 
     def keyPressEvent(self, event):
+        """Handle send and prompt-history keyboard shortcuts."""
         key = event.key()
         modifiers = event.modifiers()
         control = _qt_value("KeyboardModifier", "ControlModifier")
@@ -291,6 +298,7 @@ class ChatDockWidget(QDockWidget):
         self._load_settings()
 
     def _setup_ui(self):
+        """Build the chat dock widgets and signal connections."""
         main_widget = QWidget()
         self.setWidget(main_widget)
 
@@ -382,6 +390,7 @@ class ChatDockWidget(QDockWidget):
         layout.addWidget(self.status_label)
 
     def _load_settings(self):
+        """Load persisted model settings into the dock controls."""
         provider = _setting(self.settings, "provider", "openai")
         index = self.provider_combo.findText(provider)
         self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
@@ -394,6 +403,7 @@ class ChatDockWidget(QDockWidget):
         self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
 
     def _save_model_settings(self):
+        """Persist the selected provider, model, and fast-mode setting."""
         self.settings.setValue(
             f"{SETTINGS_PREFIX}provider", self.provider_combo.currentText()
         )
@@ -403,9 +413,11 @@ class ChatDockWidget(QDockWidget):
         )
 
     def _on_provider_changed(self, provider):
+        """Update the model field when the provider changes."""
         self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
 
     def _send_prompt(self):
+        """Start a chat request for the current prompt."""
         prompt = self.prompt_input.toPlainText().strip()
         if not prompt:
             return
@@ -439,17 +451,20 @@ class ChatDockWidget(QDockWidget):
         self._worker.start()
 
     def _insert_sample_prompt(self):
+        """Copy the selected sample prompt into the editor."""
         prompt = self.sample_combo.currentText()
         if prompt and prompt != "Sample prompts...":
             self.prompt_input.setPlainText(prompt)
             self.prompt_input.setFocus()
 
     def _record_prompt(self, prompt):
+        """Store a submitted prompt in history."""
         if not self._prompt_history or self._prompt_history[-1] != prompt:
             self._prompt_history.append(prompt)
         self._history_index = None
 
     def _previous_prompt(self):
+        """Load the previous prompt from history."""
         if not self._prompt_history:
             return
         if self._history_index is None:
@@ -459,6 +474,7 @@ class ChatDockWidget(QDockWidget):
         self._set_prompt_from_history()
 
     def _next_prompt(self):
+        """Load the next prompt from history."""
         if not self._prompt_history:
             return
         if self._history_index is None:
@@ -468,10 +484,12 @@ class ChatDockWidget(QDockWidget):
         self._set_prompt_from_history()
 
     def _set_prompt_from_history(self):
+        """Set prompt from history."""
         self.prompt_input.setPlainText(self._prompt_history[self._history_index])
         self.prompt_input.setFocus()
 
     def _on_worker_finished(self, result):
+        """Render the completed chat worker result."""
         if result.get("success"):
             answer = result.get("answer") or "(No text response.)"
             details = []
@@ -497,6 +515,7 @@ class ChatDockWidget(QDockWidget):
         self._worker = None
 
     def _append_message(self, sender, message, markdown=False):
+        """Append a chat message and refresh the transcript."""
         body = message.strip()
         self._messages.append({"sender": sender, "body": body, "markdown": markdown})
         if markdown:
@@ -505,6 +524,7 @@ class ChatDockWidget(QDockWidget):
         self._render_transcript()
 
     def _render_transcript(self):
+        """Render the stored chat messages as HTML."""
         blocks = []
         for msg in self._messages:
             sender = html.escape(msg["sender"])
@@ -523,6 +543,7 @@ class ChatDockWidget(QDockWidget):
         self.transcript.moveCursor(end_cursor)
 
     def _copy_latest_markdown(self):
+        """Copy the latest assistant Markdown response to the clipboard."""
         if not self._last_assistant_markdown:
             return
         clipboard = QGuiApplication.clipboard()
@@ -532,6 +553,7 @@ class ChatDockWidget(QDockWidget):
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
     def _clear_transcript(self):
+        """Clear all rendered chat messages."""
         self._messages = []
         self._last_assistant_markdown = ""
         self.copy_md_btn.setEnabled(False)

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -24,6 +24,7 @@ from .chat_dock import DEFAULT_MODELS, PROVIDERS, SETTINGS_PREFIX
 
 
 def _enum_value(cls, enum_name, member_name):
+    """Return an enum member from either scoped or legacy Qt APIs."""
     container = getattr(cls, enum_name, cls)
     return getattr(container, member_name)
 
@@ -46,6 +47,7 @@ class SettingsDockWidget(QDockWidget):
         self._load_settings()
 
     def _setup_ui(self):
+        """Build the settings dock widgets and tabs."""
         main_widget = QWidget()
         self.setWidget(main_widget)
 
@@ -81,6 +83,7 @@ class SettingsDockWidget(QDockWidget):
         layout.addWidget(self.status_label)
 
     def _create_dependencies_tab(self):
+        """Create the dependency status and installer tab."""
         from ..deps_manager import REQUIRED_PACKAGES
 
         widget = QWidget()
@@ -162,6 +165,7 @@ class SettingsDockWidget(QDockWidget):
         return widget
 
     def _create_model_tab(self):
+        """Create the model provider and credential tab."""
         widget = QWidget()
         layout = QVBoxLayout(widget)
 
@@ -234,6 +238,7 @@ class SettingsDockWidget(QDockWidget):
         return widget
 
     def _refresh_dependency_status(self):
+        """Refresh dependency labels from the dependency checker."""
         from ..deps_manager import check_dependencies
 
         deps = check_dependencies()
@@ -270,6 +275,7 @@ class SettingsDockWidget(QDockWidget):
             self.install_deps_btn.setEnabled(True)
 
     def _install_dependencies(self):
+        """Start background dependency installation."""
         from ..deps_manager import DepsInstallWorker
 
         self.install_deps_btn.setEnabled(False)
@@ -287,10 +293,12 @@ class SettingsDockWidget(QDockWidget):
         self._deps_worker.start()
 
     def _on_deps_install_progress(self, percent, message):
+        """Handle deps install progress."""
         self.deps_progress_bar.setValue(percent)
         self.deps_progress_label.setText(message)
 
     def _on_deps_install_finished(self, success, message):
+        """Handle deps install finished."""
         self.deps_progress_bar.setVisible(False)
         self.deps_progress_label.setVisible(False)
         self.install_deps_btn.setText("Install Dependencies")
@@ -327,12 +335,15 @@ class SettingsDockWidget(QDockWidget):
         self._deps_worker = None
 
     def show_dependencies_tab(self):
+        """Switch the settings dock to the dependencies tab."""
         self.tab_widget.setCurrentIndex(0)
 
     def _on_provider_changed(self, provider):
+        """Update the model field when the provider changes."""
         self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
 
     def _load_settings(self):
+        """Load persisted settings into the form fields."""
         provider = self.settings.value(f"{SETTINGS_PREFIX}provider", "openai", type=str)
         index = self.provider_combo.findText(provider)
         self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
@@ -362,6 +373,7 @@ class SettingsDockWidget(QDockWidget):
         )
 
     def _save_settings(self):
+        """Persist settings from the form fields."""
         self.settings.setValue(
             f"{SETTINGS_PREFIX}provider", self.provider_combo.currentText()
         )
@@ -392,6 +404,7 @@ class SettingsDockWidget(QDockWidget):
         self.iface.messageBar().pushSuccess("OpenGeoAgent", "Settings saved.")
 
     def _reset_defaults(self):
+        """Reset saved model settings after user confirmation."""
         reply = QMessageBox.question(
             self,
             "Reset Settings",

--- a/qgis_geoagent/open_geoagent/dialogs/update_checker.py
+++ b/qgis_geoagent/open_geoagent/dialogs/update_checker.py
@@ -117,6 +117,7 @@ class VersionCheckWorker(QThread):
         self._request = QgsBlockingNetworkRequest()
 
         def maybe_abort(_received, _total):
+            """Abort the network request if the worker was interrupted."""
             if self.isInterruptionRequested() and self._request is not None:
                 self._request.abort()
 
@@ -225,6 +226,7 @@ class DownloadWorker(QThread):
             except Exception as e:
                 # Restore backup if copy fails
                 def is_valid_plugin_dir(path):
+                    """Return whether a backup directory looks like the plugin."""
                     return os.path.exists(
                         os.path.join(path, "metadata.txt")
                     ) and os.path.exists(os.path.join(path, "open_geoagent.py"))
@@ -257,6 +259,7 @@ class DownloadWorker(QThread):
         self._request = QgsBlockingNetworkRequest()
 
         def on_progress(received, total):
+            """Emit download progress and abort when interrupted."""
             if self.isInterruptionRequested() and self._request is not None:
                 self._request.abort()
                 return
@@ -477,7 +480,8 @@ class UpdateCheckerDialog(QDialog):
         try:
             # Parse versions like "0.2.0" into tuples of integers
             def parse_version(v):
-                # Remove any non-numeric prefix/suffix and split by dots
+                """Parse a version string into comparable integer parts."""
+                # Remove any non-numeric prefix/suffix and split by dots.
                 parts = re.findall(r"\d+", v)
                 return tuple(int(p) for p in parts)
 

--- a/qgis_geoagent/open_geoagent/open_geoagent.py
+++ b/qgis_geoagent/open_geoagent/open_geoagent.py
@@ -180,6 +180,7 @@ class OpenGeoAgent:
             self._chat_dock.raise_()
 
     def _on_chat_visibility_changed(self, visible):
+        """Handle chat visibility changed."""
         self.chat_action.setChecked(visible)
 
     def _dependencies_missing(self):
@@ -242,6 +243,7 @@ class OpenGeoAgent:
             self._settings_dock.raise_()
 
     def _on_settings_visibility_changed(self, visible):
+        """Handle settings visibility changed."""
         self.settings_action.setChecked(visible)
 
     def show_about(self):

--- a/qgis_geoagent/package_plugin.py
+++ b/qgis_geoagent/package_plugin.py
@@ -177,7 +177,7 @@ def package_plugin(
                 files_added += 1
 
     print()
-    print(f"Package created successfully!")
+    print("Package created successfully!")
     print(f"  Files added: {files_added}")
     print(f"  Files excluded: {files_excluded}")
     print(f"  Output: {output_path}")
@@ -198,8 +198,6 @@ def verify_zip(zip_path: Path) -> None:
         for name in zipf.namelist():
             # Check for unwanted patterns
             basename = os.path.basename(name)
-            dirname = os.path.dirname(name)
-
             if "__pycache__" in name:
                 print(f"  WARNING: Found __pycache__: {name}")
                 has_issues = True
@@ -230,6 +228,7 @@ def verify_zip(zip_path: Path) -> None:
 
 
 def main():
+    """Run the script entry point."""
     parser = argparse.ArgumentParser(
         description="Package QGIS plugin for repository upload",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -289,7 +288,7 @@ def main():
         print()
         print("=" * 50)
         print("Plugin packaged successfully!")
-        print(f"Upload this file to the QGIS plugin repository:")
+        print("Upload this file to the QGIS plugin repository:")
         print(f"  {zip_path}")
         print("=" * 50)
 

--- a/qgis_geoagent/tests/__init__.py
+++ b/qgis_geoagent/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize the qgis_geoagent tests package."""

--- a/qgis_geoagent/tests/conftest.py
+++ b/qgis_geoagent/tests/conftest.py
@@ -71,6 +71,7 @@ class _QgsBlockingNetworkRequest:
 
 
 def _install_qgis_stub() -> None:
+    """Install a lightweight qgis module stub for plugin import tests."""
     qgis = types.ModuleType("qgis")
     qgis.__path__ = []
     sys.modules["qgis"] = qgis

--- a/scripts/write_example_notebooks.py
+++ b/scripts/write_example_notebooks.py
@@ -10,6 +10,7 @@ DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 def main() -> None:
+    """Run the script entry point."""
     meta = {
         "kernelspec": {
             "display_name": "Python 3",

--- a/tests/test_anymap_tools.py
+++ b/tests/test_anymap_tools.py
@@ -8,10 +8,12 @@ from geoagent.tools.anymap import anymap_tools
 
 
 def _by_name(m: MockAnymap) -> dict[str, object]:
+    """Index anymap tools by Strands tool name."""
     return {t.tool_name: t for t in anymap_tools(m)}
 
 
 def test_anymap_tool_surface_has_leafmap_parity() -> None:
+    """Verify that anymap tool surface has leafmap parity."""
     names = {t.tool_name for t in anymap_tools(MockAnymap())}
     expected = {
         "list_layers",
@@ -43,6 +45,7 @@ def test_anymap_tool_surface_has_leafmap_parity() -> None:
 
 
 def test_anymap_destructive_tools_require_confirmation() -> None:
+    """Verify that anymap destructive tools require confirmation."""
     tools = _by_name(MockAnymap())
     assert needs_confirmation(tools["remove_layer"]) is True
     assert needs_confirmation(tools["clear_layers"]) is True
@@ -50,6 +53,7 @@ def test_anymap_destructive_tools_require_confirmation() -> None:
 
 
 def test_anymap_layer_controls_and_data_helpers() -> None:
+    """Verify that anymap layer controls and data helpers."""
     m = MockAnymap()
     tools = _by_name(m)
     tools["add_marker"](lat=35.96, lon=-83.92, name="Knoxville")

--- a/tests/test_confirmation_hook.py
+++ b/tests/test_confirmation_hook.py
@@ -10,6 +10,7 @@ from geoagent.core.safety import ConfirmRequest
 
 
 def _build(meta: GeoToolMeta, callback) -> tuple[ConfirmationHookProvider, list[str]]:
+    """Build a confirmation hook with a small test registry."""
     registry = GeoToolRegistry()
     registry.register(meta)
     cancelled: list[str] = []
@@ -17,6 +18,7 @@ def _build(meta: GeoToolMeta, callback) -> tuple[ConfirmationHookProvider, list[
 
 
 def _event(name: str, args: dict, selected=None) -> SimpleNamespace:
+    """Create a minimal before-tool-call event object."""
     return SimpleNamespace(
         tool_use={"name": name, "input": args},
         selected_tool=selected,
@@ -25,6 +27,7 @@ def _event(name: str, args: dict, selected=None) -> SimpleNamespace:
 
 
 def test_denied_confirmation_cancels_and_records() -> None:
+    """Verify that denied confirmation cancels and records."""
     meta = GeoToolMeta(
         name="remove_layer",
         description="Remove a layer from the map.",
@@ -33,6 +36,7 @@ def test_denied_confirmation_cancels_and_records() -> None:
     requests: list[ConfirmRequest] = []
 
     def deny(req: ConfirmRequest) -> bool:
+        """Deny the confirmation request."""
         requests.append(req)
         return False
 
@@ -50,9 +54,11 @@ def test_denied_confirmation_cancels_and_records() -> None:
 
 
 def test_approved_confirmation_allows_tool() -> None:
+    """Verify that approved confirmation allows tool."""
     meta = GeoToolMeta(name="save_map", destructive=True)
 
     def approve(req: ConfirmRequest) -> bool:
+        """Approve the confirmation request."""
         return True
 
     hook, cancelled = _build(meta, approve)
@@ -65,10 +71,12 @@ def test_approved_confirmation_allows_tool() -> None:
 
 
 def test_unconfirmed_tool_skips_callback() -> None:
+    """Verify that unconfirmed tool skips callback."""
     meta = GeoToolMeta(name="list_layers")
     calls: list[ConfirmRequest] = []
 
     def callback(req: ConfirmRequest) -> bool:
+        """Handle the confirmation callback."""
         calls.append(req)
         return False
 

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -14,10 +14,13 @@ from geoagent.testing import MockLeafmap, MockQGISIface, MockQGISProject
 
 
 class _MockModel:
+    """Provide a test double for MockModel."""
+
     stateful = False
 
 
 def test_chat_success_from_mocked_strands() -> None:
+    """Verify that chat success from mocked strands."""
     m = MockLeafmap()
     agent = for_leafmap(m, model=_MockModel())
 
@@ -40,6 +43,7 @@ def test_chat_success_from_mocked_strands() -> None:
 
 
 def test_chat_in_background_returns_and_invokes_callback() -> None:
+    """Verify that chat in background returns and invokes callback."""
     m = MockLeafmap()
     agent = for_leafmap(m, model=_MockModel())
 
@@ -56,6 +60,7 @@ def test_chat_in_background_returns_and_invokes_callback() -> None:
     box = {}
 
     def _on_result(resp):
+        """Handle result."""
         box["resp"] = resp
         done.set()
 
@@ -67,42 +72,63 @@ def test_chat_in_background_returns_and_invokes_callback() -> None:
 
 
 def test_qgis_chat_on_gui_thread_runs_worker_and_pumps_events(monkeypatch) -> None:
+    """Verify that qgis chat on gui thread runs worker and pumps events."""
     main_thread = threading.current_thread()
     processed = threading.Event()
     calls = {"process_events": 0}
 
     class _FakeThread:
+        """Provide a test double for FakeThread."""
+
         def __eq__(self, other: object) -> bool:
             return isinstance(other, _FakeThread)
 
     class _QThread:
+        """Provide a test double for QThread."""
+
         @staticmethod
         def currentThread():
+            """Return the current thread."""
             return _FakeThread()
 
     class _App:
+        """Provide a test double for App."""
+
         def thread(self):
+            """Return the associated thread."""
             return _FakeThread()
 
         def processEvents(self):
+            """Process events."""
             calls["process_events"] += 1
             processed.set()
 
     class _QApplication:
+        """Provide a test double for QApplication."""
+
         @staticmethod
         def instance():
+            """Return the singleton instance."""
             return _App()
 
     class _QObject:
+        """Provide a test double for QObject."""
+
         def moveToThread(self, _thread):
+            """Move to thread."""
             return None
 
     class _QMetaObject:
+        """Provide a test double for QMetaObject."""
+
         @staticmethod
         def invokeMethod(*_args, **_kwargs):
+            """Invoke method."""
             return True
 
     class _Qt:
+        """Provide a test double for Qt."""
+
         BlockingQueuedConnection = 0
 
     fake_qt_core = types.SimpleNamespace(
@@ -124,6 +150,7 @@ def test_qgis_chat_on_gui_thread_runs_worker_and_pumps_events(monkeypatch) -> No
     worker_thread: list[threading.Thread] = []
 
     def _strands(_query: str):
+        """Return the mocked Strands response."""
         worker_thread.append(threading.current_thread())
         deadline = time.time() + 2.0
         while not processed.is_set() and time.time() < deadline:

--- a/tests/test_geoagent_factory.py
+++ b/tests/test_geoagent_factory.py
@@ -7,15 +7,19 @@ from geoagent.testing import MockLeafmap
 
 
 class _MockModel:
+    """Provide a test double for MockModel."""
+
     stateful = False
 
 
 def test_create_agent_empty_tools() -> None:
+    """Verify that create agent empty tools."""
     a = create_agent(tools=[], context=GeoAgentContext(), model=_MockModel())
     assert a.strands_agent.tool_names == []
 
 
 def test_for_leafmap_registers_tools() -> None:
+    """Verify that for leafmap registers tools."""
     m = MockLeafmap()
     a = for_leafmap(m, model=_MockModel())
     names = set(a.strands_agent.tool_names)
@@ -23,6 +27,7 @@ def test_for_leafmap_registers_tools() -> None:
 
 
 def test_for_leafmap_accepts_provider_and_model_id() -> None:
+    """Verify that for leafmap accepts provider and model id."""
     m = MockLeafmap()
     a = for_leafmap(
         m,
@@ -35,6 +40,7 @@ def test_for_leafmap_accepts_provider_and_model_id() -> None:
 
 
 def test_factory_accepts_gemini_provider() -> None:
+    """Verify that factory accepts gemini provider."""
     m = MockLeafmap()
     a = for_leafmap(
         m,

--- a/tests/test_geoagent_surface.py
+++ b/tests/test_geoagent_surface.py
@@ -7,6 +7,7 @@ from geoagent.testing import MockLeafmap
 
 
 def test_geoagent_exposes_tool_names_and_registry() -> None:
+    """Verify that geoagent exposes tool names and registry."""
     agent = for_leafmap(MockLeafmap())
     names = agent.tool_names
     assert "get_map_state" in names

--- a/tests/test_leafmap_tools.py
+++ b/tests/test_leafmap_tools.py
@@ -12,10 +12,12 @@ from geoagent.tools.leafmap import leafmap_tools
 
 
 def _by_name(m: MockLeafmap) -> dict[str, object]:
+    """Index leafmap tools by Strands tool name."""
     return {t.tool_name: t for t in leafmap_tools(m)}
 
 
 def test_factory_returns_full_tool_list() -> None:
+    """Verify that factory returns full tool list."""
     m = MockLeafmap()
     names = {t.tool_name for t in leafmap_tools(m)}
     expected = {
@@ -48,10 +50,12 @@ def test_factory_returns_full_tool_list() -> None:
 
 
 def test_factory_returns_empty_for_none() -> None:
+    """Verify that factory returns empty for none."""
     assert leafmap_tools(None) == []
 
 
 def test_remove_and_save_require_confirmation() -> None:
+    """Verify that remove and save require confirmation."""
     tools = _by_name(MockLeafmap())
     assert needs_confirmation(tools["remove_layer"]) is True
     assert needs_confirmation(tools["clear_layers"]) is True
@@ -61,6 +65,7 @@ def test_remove_and_save_require_confirmation() -> None:
 
 
 def test_add_layer_mutates_map() -> None:
+    """Verify that add layer mutates map."""
     m = MockLeafmap()
     tools = _by_name(m)
     tools["add_layer"](
@@ -72,6 +77,7 @@ def test_add_layer_mutates_map() -> None:
 
 
 def test_remove_layer_mutates_map() -> None:
+    """Verify that remove layer mutates map."""
     m = MockLeafmap()
     tools = _by_name(m)
     tools["add_layer"](
@@ -85,6 +91,7 @@ def test_remove_layer_mutates_map() -> None:
 
 
 def test_layer_visibility_opacity_and_zoom_to_layer() -> None:
+    """Verify that layer visibility opacity and zoom to layer."""
     m = MockLeafmap()
     tools = _by_name(m)
     m.layers.append(
@@ -107,6 +114,7 @@ def test_layer_visibility_opacity_and_zoom_to_layer() -> None:
 
 
 def test_add_marker_and_geojson_data() -> None:
+    """Verify that add marker and geojson data."""
     m = MockLeafmap()
     tools = _by_name(m)
     tools["add_marker"](lat=35.96, lon=-83.92, popup="Knoxville")
@@ -119,6 +127,7 @@ def test_add_marker_and_geojson_data() -> None:
 
 
 def test_clear_layers_mutates_map() -> None:
+    """Verify that clear layers mutates map."""
     m = MockLeafmap()
     tools = _by_name(m)
     tools["add_marker"](lat=0, lon=0, name="Zero")
@@ -128,6 +137,7 @@ def test_clear_layers_mutates_map() -> None:
 
 
 def test_fast_mode_filters_tools() -> None:
+    """Verify that fast mode filters tools."""
     m = MockLeafmap()
     items = leafmap_tools(m)
     reg = GeoToolRegistry()
@@ -139,6 +149,7 @@ def test_fast_mode_filters_tools() -> None:
 
 
 def test_get_map_state_and_viewport() -> None:
+    """Verify that get map state and viewport."""
     m = MockLeafmap()
     tools = _by_name(m)
     tools["set_center"](lat=35.96, lon=-83.92, zoom=10)
@@ -152,6 +163,8 @@ def test_get_map_state_prefers_view_state_maplibre() -> None:
     """MapLibre leafmap stores camera in ``view_state``, not ipyleaflet center/zoom."""
 
     class MapLibreStub:
+        """Provide a test double for MapLibreStub."""
+
         def __init__(self) -> None:
             self.layers: list = []
             self._style = "dark-matter"
@@ -177,6 +190,8 @@ def test_get_map_state_falls_back_to_map_options_when_view_state_empty() -> None
     """MapLibre can expose empty view_state until frontend sync."""
 
     class MapLibreStub:
+        """Provide a test double for MapLibreStub."""
+
         def __init__(self) -> None:
             self.layers: list = []
             self._style = None
@@ -200,6 +215,7 @@ def test_get_map_state_falls_back_to_map_options_when_view_state_empty() -> None
 
 
 def test_save_map_writes(tmp_path: Path) -> None:
+    """Verify that save map writes."""
     m = MockLeafmap()
     tools = _by_name(m)
     out = tmp_path / "x.html"

--- a/tests/test_map_state.py
+++ b/tests/test_map_state.py
@@ -6,6 +6,7 @@ from geoagent.tools._map_state import deep_plain, map_state_from_widget
 
 
 def test_deep_plain_sw_ne() -> None:
+    """Verify that deep plain sw ne."""
     d = {
         "center": {"lng": -1.0, "lat": 2.0},
         "bounds": {
@@ -18,7 +19,11 @@ def test_deep_plain_sw_ne() -> None:
 
 
 def test_map_state_from_view_state() -> None:
+    """Verify that map state from view state."""
+
     class M:
+        """Provide a test double for M."""
+
         layers = []
         _style = "x"
         view_state = {"zoom": 4, "center": {"lng": 0, "lat": 1}}

--- a/tests/test_qgis_import_safe.py
+++ b/tests/test_qgis_import_safe.py
@@ -20,6 +20,7 @@ def _reimport(name: str):
 
 
 def test_module_import_does_not_pull_qgis() -> None:
+    """Verify that module import does not pull qgis."""
     if "qgis" in sys.modules:
         pytest.skip("qgis is already imported in this environment.")
     module = _reimport("geoagent.tools.qgis")
@@ -29,6 +30,7 @@ def test_module_import_does_not_pull_qgis() -> None:
 
 
 def test_qgis_tools_with_none_iface_returns_empty_list() -> None:
+    """Verify that qgis tools with none iface returns empty list."""
     from geoagent.tools.qgis import qgis_tools
 
     assert qgis_tools(None) == []

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -18,10 +18,12 @@ from geoagent.tools.qgis import qgis_tools
 
 
 def test_qgis_module_imports_without_qgis() -> None:
-    # The module is already imported; confirm `qgis` was not pulled in.
-    # (If it was, this test would still pass — we just want to ensure import
-    # didn't fail when the user's environment has no qgis package.)
-    """Verify that qgis module imports without qgis."""
+    """Verify the qgis tools module imports without the qgis package.
+
+    The module is already imported; confirm ``qgis`` was not pulled in.
+    (If it was, this test would still pass; we just want to ensure import
+    did not fail when the user's environment has no qgis package.)
+    """
     assert "geoagent.tools.qgis" in sys.modules
 
 

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -21,14 +21,17 @@ def test_qgis_module_imports_without_qgis() -> None:
     # The module is already imported; confirm `qgis` was not pulled in.
     # (If it was, this test would still pass — we just want to ensure import
     # didn't fail when the user's environment has no qgis package.)
+    """Verify that qgis module imports without qgis."""
     assert "geoagent.tools.qgis" in sys.modules
 
 
 def test_qgis_tools_returns_empty_for_none() -> None:
+    """Verify that qgis tools returns empty for none."""
     assert qgis_tools(None) == []
 
 
 def test_factory_returns_tools_for_iface() -> None:
+    """Verify that factory returns tools for iface."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = qgis_tools(iface, project)
@@ -64,6 +67,7 @@ def test_factory_returns_tools_for_iface() -> None:
 
 
 def test_remove_layer_and_run_processing_require_confirmation() -> None:
+    """Verify that remove layer and run processing require confirmation."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -75,6 +79,7 @@ def test_remove_layer_and_run_processing_require_confirmation() -> None:
 
 
 def test_add_vector_layer_invokes_iface() -> None:
+    """Verify that add vector layer invokes iface."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -87,6 +92,7 @@ def test_add_vector_layer_invokes_iface() -> None:
 
 
 def test_remove_layer_drops_from_project() -> None:
+    """Verify that remove layer drops from project."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     project.addMapLayer(MockQGISLayer("Buildings", "/tmp/b.shp"))
@@ -97,6 +103,7 @@ def test_remove_layer_drops_from_project() -> None:
 
 
 def test_zoom_in_invokes_canvas() -> None:
+    """Verify that zoom in invokes canvas."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -106,6 +113,7 @@ def test_zoom_in_invokes_canvas() -> None:
 
 
 def test_list_project_layers() -> None:
+    """Verify that list project layers."""
     project = MockQGISProject()
     project.addMapLayer(MockQGISLayer("A", "a.shp", "vector"))
     project.addMapLayer(MockQGISLayer("B", "b.tif", "raster"))
@@ -118,6 +126,7 @@ def test_list_project_layers() -> None:
 
 
 def test_get_active_layer_returns_none_when_unset() -> None:
+    """Verify that get active layer returns none when unset."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -126,6 +135,7 @@ def test_get_active_layer_returns_none_when_unset() -> None:
 
 
 def test_get_active_layer_returns_metadata() -> None:
+    """Verify that get active layer returns metadata."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     layer = MockQGISLayer("Active", "a.shp", "vector")
@@ -138,6 +148,7 @@ def test_get_active_layer_returns_metadata() -> None:
 
 
 def test_get_project_state_includes_canvas_and_layers() -> None:
+    """Verify that get project state includes canvas and layers."""
     project = MockQGISProject()
     project.addMapLayer(MockQGISLayer("A", "a.shp", "vector"))
     iface = MockQGISIface(project=project)
@@ -148,6 +159,7 @@ def test_get_project_state_includes_canvas_and_layers() -> None:
 
 
 def test_zoom_to_layer_resolves_layer() -> None:
+    """Verify that zoom to layer resolves layer."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     layer = MockQGISLayer("Target", "t.shp")
@@ -179,6 +191,8 @@ def test_zoom_to_layer_transforms_extent_when_layer_crs_differs(monkeypatch) -> 
     project.addMapLayer(layer)
 
     class _Crs:
+        """Provide a test double for Crs."""
+
         def __init__(self, name):
             self.name = name
 
@@ -193,7 +207,10 @@ def test_zoom_to_layer_transforms_extent_when_layer_crs_differs(monkeypatch) -> 
     layer.crs = lambda: layer_crs  # type: ignore[method-assign]
 
     class _MapSettings:
+        """Provide a test double for MapSettings."""
+
         def destinationCrs(self):
+            """Return the destination crs."""
             return canvas_crs
 
     canvas.mapSettings = lambda: _MapSettings()  # type: ignore[method-assign]
@@ -201,17 +218,23 @@ def test_zoom_to_layer_transforms_extent_when_layer_crs_differs(monkeypatch) -> 
     transformed_extent = (-12_835_000.0, 4_330_000.0, -12_801_000.0, 4_355_000.0)
 
     class _CoordTransform:
+        """Provide a test double for CoordTransform."""
+
         def __init__(self, src, dst, project_arg):
             assert src is layer_crs
             assert dst is canvas_crs
 
         def transformBoundingBox(self, extent):
+            """Transform bounding box."""
             assert extent == layer_extent
             return transformed_extent
 
     class _QgsProject:
+        """Provide a test double for QgsProject."""
+
         @staticmethod
         def instance():
+            """Return the singleton instance."""
             return object()
 
     fake_qgs_core = types.SimpleNamespace(
@@ -249,6 +272,8 @@ def test_zoom_to_extent_transforms_bbox_to_canvas_crs(monkeypatch) -> None:
     canvas = iface.mapCanvas()
 
     class _Crs:
+        """Provide a test double for Crs."""
+
         def __init__(self, authid):
             self.authid = authid
 
@@ -262,7 +287,10 @@ def test_zoom_to_extent_transforms_bbox_to_canvas_crs(monkeypatch) -> None:
     dst_crs = _Crs("EPSG:3857")
 
     class _MapSettings:
+        """Provide a test double for MapSettings."""
+
         def destinationCrs(self):
+            """Return the destination crs."""
             return dst_crs
 
     canvas.mapSettings = lambda: _MapSettings()  # type: ignore[method-assign]
@@ -273,20 +301,27 @@ def test_zoom_to_extent_transforms_bbox_to_canvas_crs(monkeypatch) -> None:
     # Use a simple 4-tuple as the QgsRectangle stand-in so MockQGISCanvas's
     # ``setExtent`` (which calls ``tuple(extent)``) can record it cleanly.
     def _Rect(w, s, e, n):
+        """Return a tuple that stands in for QgsRectangle."""
         return (w, s, e, n)
 
     class _CoordTransform:
+        """Provide a test double for CoordTransform."""
+
         def __init__(self, src, dst, project_arg):
             assert src == src_crs
             assert dst == dst_crs
 
         def transformBoundingBox(self, rect):
+            """Transform bounding box."""
             assert tuple(rect) == seattle_latlon
             return _Rect(*seattle_mercator)
 
     class _QgsProject:
+        """Provide a test double for QgsProject."""
+
         @staticmethod
         def instance():
+            """Return the singleton instance."""
             return object()
 
     fake_qgs_core = types.SimpleNamespace(
@@ -340,6 +375,7 @@ def test_zoom_to_layer_uses_setExtent_when_extent_available() -> None:
 
 
 def test_zoom_to_layer_raises_when_missing() -> None:
+    """Verify that zoom to layer raises when missing."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -348,6 +384,7 @@ def test_zoom_to_layer_raises_when_missing() -> None:
 
 
 def test_refresh_canvas_increments_counter() -> None:
+    """Verify that refresh canvas increments counter."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -357,6 +394,7 @@ def test_refresh_canvas_increments_counter() -> None:
 
 
 def test_set_center_and_scale_update_canvas() -> None:
+    """Verify that set center and scale update canvas."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -368,6 +406,7 @@ def test_set_center_and_scale_update_canvas() -> None:
 
 
 def test_add_xyz_tile_layer_uses_raster_fallback() -> None:
+    """Verify that add xyz tile layer uses raster fallback."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -380,6 +419,7 @@ def test_add_xyz_tile_layer_uses_raster_fallback() -> None:
 
 
 def test_layer_opacity_selection_and_summary() -> None:
+    """Verify that layer opacity selection and summary."""
     project = MockQGISProject()
     layer = MockQGISLayer(
         "Parcels",
@@ -412,6 +452,7 @@ def test_layer_opacity_selection_and_summary() -> None:
 
 
 def test_save_project_records_path(tmp_path) -> None:
+    """Verify that save project records path."""
     project = MockQGISProject()
     iface = MockQGISIface(project=project)
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -421,12 +462,14 @@ def test_save_project_records_path(tmp_path) -> None:
 
 
 def test_qgis_tools_route_calls_through_gui_marshal(monkeypatch) -> None:
+    """Verify that qgis tools route calls through gui marshal."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
     calls: list[str] = []
 
     def _marshal(func):
+        """Run the function through the marshal hook."""
         calls.append("called")
         return func()
 

--- a/tests/test_qt_marshal.py
+++ b/tests/test_qt_marshal.py
@@ -18,33 +18,52 @@ def test_run_on_qt_gui_thread_runs_inline_when_current_equals_gui(monkeypatch) -
     """
 
     class _FakeThread:
+        """Provide a test double for FakeThread."""
+
         def __eq__(self, other: object) -> bool:
             return isinstance(other, _FakeThread)
 
     class _QThread:
+        """Provide a test double for QThread."""
+
         @staticmethod
         def currentThread():
+            """Return the current thread."""
             return _FakeThread()
 
     class _App:
+        """Provide a test double for App."""
+
         def thread(self):
+            """Return the associated thread."""
             return _FakeThread()
 
     class _QApplication:
+        """Provide a test double for QApplication."""
+
         @staticmethod
         def instance():
+            """Return the singleton instance."""
             return _App()
 
     class _QObject:
+        """Provide a test double for QObject."""
+
         def moveToThread(self, _thread):
+            """Move to thread."""
             return None
 
     class _QMetaObject:
+        """Provide a test double for QMetaObject."""
+
         @staticmethod
         def invokeMethod(*_args, **_kwargs):
+            """Invoke method."""
             raise AssertionError("invokeMethod must not run on GUI thread")
 
     class _Qt:
+        """Provide a test double for Qt."""
+
         BlockingQueuedConnection = 0
 
     fake_qt_core = types.SimpleNamespace(

--- a/tests/test_tool_thread_qgis.py
+++ b/tests/test_tool_thread_qgis.py
@@ -9,6 +9,7 @@ from geoagent.tools.qgis import qgis_tools
 
 
 def test_qgis_tool_runs_on_calling_thread() -> None:
+    """Verify that qgis tool runs on calling thread."""
     iface = MockQGISIface()
     project = MockQGISProject()
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
@@ -17,6 +18,7 @@ def test_qgis_tool_runs_on_calling_thread() -> None:
     box: list[threading.Thread] = []
 
     def run() -> None:
+        """Run the worker body."""
         tools["zoom_in"]()
         box.append(threading.current_thread())
 


### PR DESCRIPTION
## Summary
- Add concise Google-style docstrings to functions and methods that were previously undocumented across `geoagent/`, `qgis_geoagent/`, UI pages, scripts, and tests.
- Pure documentation: no behavior changes; the surrounding code is unchanged apart from black-driven reformatting that the docstrings triggered.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/ -q` (55 passed)