### PR TITLE
feat: add NASA OPERA tools and QGIS workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos,ot",
+                  "--ignore-words-list=pre-empt,alos",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos",
+                  "--ignore-words-list=pre-empt,alos,ot",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ own agent framework.
 | `for_leafmap` | Factory that binds tools to a `leafmap.Map`-compatible object. |
 | `for_anymap` | Factory that binds tools to an `anymap.Map`-compatible object. |
 | `for_qgis` | Factory that binds tools to `qgis.utils.iface` and an optional `QgsProject`. |
+| `for_nasa_opera` | Factory that binds NASA OPERA search/display tools plus QGIS tools. |
 | `create_agent` | Factory for custom tools or package-specific integrations. |
 
 ## Installation
@@ -61,6 +62,7 @@ and `pydantic`. Geospatial packages and provider clients are optional extras:
 | `GeoAgent[anymap]` | anymap live map integration. |
 | `GeoAgent[stac]` | STAC client dependencies. |
 | `GeoAgent[earthdata]` | NASA Earthdata dependencies. |
+| `GeoAgent[nasa-opera]` | NASA OPERA search dependencies. |
 | `GeoAgent[geoai]` | geoai integration dependencies. |
 | `GeoAgent[earthengine]` | Google Earth Engine dependencies. |
 | `GeoAgent[ui]` | Solara UI dependencies. |
@@ -205,6 +207,43 @@ marshaller:
 QGIS chat uses a sequential tool executor and GUI-thread marshalling so map
 canvas and layer-tree calls are routed safely.
 
+### NASA OPERA
+
+`for_nasa_opera(iface, project=None)` exposes NASA OPERA product tools and the
+standard QGIS tool surface:
+
+- inspect OPERA products: `get_available_datasets`, `get_dataset_info`;
+- search Earthdata granules: `search_opera_data`;
+- display results: `display_footprints`, `display_raster`, `create_mosaic`.
+
+The OPERA integration is implemented as native GeoAgent tools and does not wrap
+the NASA OPERA plugin's legacy `nasa_opera.ai.tools` registry.
+
+Use it from the QGIS Python console or from plugin code. For direct tool
+testing, use `submit_nasa_opera_search_task(...)`; this avoids LLM/provider
+initialization and reports progress in QGIS's message bar and Log Messages
+panel:
+
+```python
+from geoagent.tools.nasa_opera import submit_nasa_opera_search_task
+
+task = submit_nasa_opera_search_task(
+    iface,
+    dataset="OPERA_L3_DSWX-HLS_V1",
+    bbox="-95.5,29.5,-95.0,30.0",
+    start_date="2024-01-01",
+    end_date="2024-01-31",
+    max_results=5,
+    display_footprints=True,
+)
+```
+
+For a longer QGIS-console script, see `examples/nasa_opera_qgis.py`.
+
+Natural-language OPERA chat is intentionally disabled inside QGIS for now.
+Use direct tools or `submit_nasa_opera_search_task(...)` so QGIS task/thread
+ownership remains explicit.
+
 ## Direct Tool Calls
 
 Every GeoAgent exposes the underlying Strands tool caller. This is useful for
@@ -285,6 +324,7 @@ Runnable notebooks live under `docs/examples/`:
 - `docs/examples/intro.ipynb` — basic GeoAgent usage.
 - `docs/examples/live_mapping.ipynb` — live map workflow.
 - `docs/examples/qgis_agent.ipynb` — QGIS-oriented workflow using mocks.
+- `examples/nasa_opera_qgis.py` — NASA OPERA workflow for QGIS.
 
 Prompt ideas:
 
@@ -293,6 +333,7 @@ Prompt ideas:
 - "Show the QGIS project state and summarize each layer."
 - "Select parcels where population is greater than 10000."
 - "Add a STAC layer and set its opacity to 0.6."
+- "Search for January 2024 OPERA surface water near Houston and display the footprints."
 
 ## Development
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,7 +2,7 @@
 
 Interactive adapters live under **`geoagent.tools`**:
 
-- `leafmap_tools`, `anymap_tools`, `qgis_tools` — bound to live map / QGIS instances.
+- `leafmap_tools`, `anymap_tools`, `qgis_tools`, `nasa_opera_tools` — bound to live map / QGIS instances.
 - Optional stubs: `stac`, `geoai`, `earthengine`, `nasa_earthdata` (expand in future releases).
 
 Use **`@geo_tool`** ([`geoagent.core.decorators`](decorators.md)) so tools register Strands-compatible metadata for safety hooks.
@@ -30,3 +30,35 @@ Layer lookup accepts exact names or a unique case-insensitive substring for oper
 - Open UI / save: `open_attribute_table`, `save_project`.
 
 Destructive or persistent actions such as `remove_layer`, `clear_layers`, `save_map`, `save_project`, and `run_processing_algorithm` require confirmation through the GeoAgent safety hook.
+
+## NASA OPERA
+
+`for_nasa_opera(iface, project=None)` exposes native GeoAgent tools for NASA OPERA plugin workflows:
+
+- Inspect OPERA products: `get_available_datasets`, `get_dataset_info`.
+- Search Earthdata granules: `search_opera_data`.
+- Display results in QGIS: `display_footprints`, `display_raster`, `create_mosaic`.
+
+This integration replaces the plugin-local `nasa_opera.ai.tools` registry instead of wrapping it.
+
+Example QGIS-console workflow. This direct-tool path avoids LLM/provider
+initialization and reports progress in QGIS's message bar and Log Messages
+panel:
+
+```python
+from geoagent.tools.nasa_opera import submit_nasa_opera_search_task
+
+task = submit_nasa_opera_search_task(
+    iface,
+    dataset="OPERA_L3_DSWX-HLS_V1",
+    bbox="-95.5,29.5,-95.0,30.0",
+    start_date="2024-01-01",
+    end_date="2024-01-31",
+    max_results=5,
+    display_footprints=True,
+)
+```
+
+Natural-language OPERA chat is intentionally disabled inside QGIS for now.
+Use direct tools or `submit_nasa_opera_search_task(...)` so QGIS task/thread
+ownership remains explicit.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,5 +5,12 @@ Runnable Jupyter notebooks live under **`docs/examples/`**:
 - **`docs/examples/intro.ipynb`** — GeoAgent + Anthropic (no map).
 - **`docs/examples/live_mapping.ipynb`** — leafmap MapLibre + Claude; camera comes from **`m.view_state`** (see `get_map_state` tool).
 - **`docs/examples/qgis_agent.ipynb`** — QGIS-oriented tools using mock `iface` in Jupyter; snippet for real QGIS included.
+- **`examples/nasa_opera_qgis.py`** — NASA OPERA search and footprints workflow for the QGIS Python console.
 
 Install extras as shown in each notebook (`GeoAgent[anthropic]`, `GeoAgent[anthropic,leafmap]`).
+For NASA OPERA, install GeoAgent in the QGIS Python environment with the
+`nasa-opera` extra and run the example from QGIS:
+
+```bash
+pip install "GeoAgent[nasa-opera,openai]"
+```

--- a/examples/nasa_opera_qgis.py
+++ b/examples/nasa_opera_qgis.py
@@ -1,0 +1,33 @@
+"""NASA OPERA GeoAgent example for the QGIS Python console.
+
+Run this from QGIS after installing GeoAgent in QGIS's Python environment.
+Progress appears in the QGIS message bar and in the Log Messages panel under
+``GeoAgent NASA OPERA``.
+"""
+
+from geoagent.tools.nasa_opera import (
+    nasa_opera_tools,
+    submit_nasa_opera_search_task,
+)
+from qgis.utils import iface  # type: ignore[import-not-found]
+
+tools = {tool.tool_name: tool for tool in nasa_opera_tools(iface)}
+print("OPERA tools:", sorted(tools))
+print("OPERA datasets:", tools["get_available_datasets"]())
+
+
+task = submit_nasa_opera_search_task(
+    iface,
+    dataset="OPERA_L3_DSWX-HLS_V1",
+    bbox="-95.5,29.5,-95.0,30.0",
+    start_date="2024-01-01",
+    end_date="2024-01-31",
+    max_results=5,
+    display_footprints=True,
+)
+print("Submitted task:", task.description())
+
+
+# Natural-language chat is intentionally disabled for NASA OPERA inside QGIS.
+# Use direct tools or submit_nasa_opera_search_task(...) so QGIS task/thread
+# ownership remains explicit.

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -21,7 +21,13 @@ from geoagent.core.safety import (
     auto_approve_safe_only,
     build_interrupt_on,
 )
-from geoagent.core.factory import create_agent, for_anymap, for_leafmap, for_qgis
+from geoagent.core.factory import (
+    create_agent,
+    for_anymap,
+    for_leafmap,
+    for_nasa_opera,
+    for_qgis,
+)
 from geoagent.core.agent import GeoAgent
 from geoagent.core.registry import GeoToolMeta, GeoToolRegistry
 
@@ -36,6 +42,7 @@ __all__ = [
     "create_agent",
     "for_anymap",
     "for_leafmap",
+    "for_nasa_opera",
     "for_qgis",
     "geo_tool",
     "get_geo_meta",

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -73,6 +73,9 @@ class GeoAgent:
         """Recreate the underlying Strands agent from current settings."""
         self._cancelled = []
         prompt = FAST_SYSTEM_PROMPT if self._fast else DEFAULT_SYSTEM_PROMPT
+        extra_prompt = self._context.metadata.get("system_prompt")
+        if extra_prompt:
+            prompt = f"{prompt}\n\n{extra_prompt}"
         hook = ConfirmationHookProvider(self._registry, self._confirm, self._cancelled)
 
         self._strands = Agent(
@@ -147,6 +150,22 @@ class GeoAgent:
                 confirm=self._confirm,
             )
             return other.chat(query)
+
+        if (
+            self._context.metadata.get("integration") == "nasa_opera"
+            and self._qgis_safe_mode
+            and is_qt_gui_thread()
+        ):
+            return GeoAgentResponse(
+                success=False,
+                error_message=(
+                    "NASA OPERA chat should be launched from a worker thread inside "
+                    "QGIS. Use the NASA OPERA AI Assistant panel or "
+                    "geoagent.tools.nasa_opera.submit_nasa_opera_search_task(...) "
+                    "for direct QGIS-console workflows."
+                ),
+                map=self._context.map_obj,
+            )
 
         if self._qgis_safe_mode and is_qt_gui_thread():
             return self._chat_on_qgis_gui_thread(query)

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -87,11 +87,11 @@ def assemble_tools(
         register_all_tools(registry, qt)
         collected.extend(qt)
     if include_nasa_opera:
-        ot = _filter_by_imports(
+        opera_tools = _filter_by_imports(
             nasa_opera_tools(context.qgis_iface, context.qgis_project)
         )
-        register_all_tools(registry, ot)
-        collected.extend(ot)
+        register_all_tools(registry, opera_tools)
+        collected.extend(opera_tools)
     if extra_tools:
         register_all_tools(registry, extra_tools)
         collected.extend(extra_tools)

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -15,7 +15,27 @@ from geoagent.core.safety import ConfirmCallback
 from geoagent.core.agent import GeoAgent
 from geoagent.tools.anymap import anymap_tools
 from geoagent.tools.leafmap import leafmap_tools
+from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
+
+NASA_OPERA_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS for NASA OPERA satellite data.
+Use the OPERA tools to search, display, and summarize NASA OPERA products.
+
+Dataset guidance:
+- Water, flood, inundation: prefer OPERA_L3_DSWX-HLS_V1 or OPERA_L3_DSWX-S1_V1.
+- Deforestation, fire damage, vegetation loss, land disturbance: prefer
+  OPERA_L3_DIST-ALERT-HLS_V1 or OPERA_L3_DIST-ANN-HLS_V1.
+- SAR/radar/backscatter: prefer OPERA_L2_RTC-S1_V1.
+- Interferometry/phase workflows: prefer OPERA_L2_CSLC-S1_V1.
+
+Workflow guidance:
+- Search before displaying footprints or rasters.
+- If the user gives no location, use the current QGIS map extent.
+- For raster display, choose a specific data link from search results.
+- Keep responses concise and include result counts, date range, and relevant
+  first-result identifiers when available.
+"""
 
 
 def _filter_by_imports(tools: list[Any]) -> list[Any]:
@@ -48,6 +68,7 @@ def assemble_tools(
     include_leafmap: bool = False,
     include_anymap: bool = False,
     include_qgis: bool = False,
+    include_nasa_opera: bool = False,
     fast: bool = False,
 ) -> tuple[list[Any], GeoToolRegistry]:
     """Collect tools for a context and build a metadata registry."""
@@ -65,6 +86,12 @@ def assemble_tools(
         qt = _filter_by_imports(qgis_tools(context.qgis_iface, context.qgis_project))
         register_all_tools(registry, qt)
         collected.extend(qt)
+    if include_nasa_opera:
+        ot = _filter_by_imports(
+            nasa_opera_tools(context.qgis_iface, context.qgis_project)
+        )
+        register_all_tools(registry, ot)
+        collected.extend(ot)
     if extra_tools:
         register_all_tools(registry, extra_tools)
         collected.extend(extra_tools)
@@ -220,11 +247,64 @@ def for_qgis(
     )
 
 
+def for_nasa_opera(
+    iface: Any,
+    project: Any = None,
+    *,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+    include_qgis: bool = True,
+) -> GeoAgent:
+    """Bind an agent to the NASA OPERA QGIS plugin runtime.
+
+    The factory exposes native GeoAgent OPERA tools and, by default, the
+    general QGIS map/project tools used for navigation and layer management.
+    """
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={
+            "integration": "nasa_opera",
+            "system_prompt": NASA_OPERA_SYSTEM_PROMPT,
+        },
+    )
+    tools, registry = assemble_tools(
+        context=ctx,
+        include_qgis=include_qgis,
+        include_nasa_opera=True,
+        extra_tools=extra_tools,
+        fast=fast,
+    )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+        qgis_safe_mode=True,
+    )
+
+
 __all__ = [
     "assemble_tools",
     "create_agent",
     "for_anymap",
     "for_leafmap",
+    "for_nasa_opera",
     "for_qgis",
     "register_all_tools",
 ]

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -79,7 +79,7 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         host = cfg.ollama_host or os.environ.get(
             "OLLAMA_HOST", "http://127.0.0.1:11434"
         )
-        model_id = cfg.model or os.environ.get("OLLAMA_MODEL", "llama3.1")
+        model_id = cfg.model or os.environ.get("OLLAMA_MODEL", "qwen3.5:4b")
         return OllamaModel(
             host,
             model_id=model_id,

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from geoagent.tools.anymap import anymap_tools
 from geoagent.tools.leafmap import leafmap_tools
+from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 
-__all__ = ["anymap_tools", "leafmap_tools", "qgis_tools"]
+__all__ = ["anymap_tools", "leafmap_tools", "nasa_opera_tools", "qgis_tools"]

--- a/geoagent/tools/_qt_marshal.py
+++ b/geoagent/tools/_qt_marshal.py
@@ -52,7 +52,7 @@ def run_on_qt_gui_thread(func: Callable[[], T]) -> T:
     Outside Qt/QGIS (tests, CI), this degrades to a direct call.
     """
     try:
-        from qgis.PyQt.QtCore import QMetaObject, QObject, Qt, pyqtSlot  # type: ignore[import-not-found]
+        from qgis.PyQt.QtCore import QMetaObject, QObject, Qt, QThread, pyqtSlot  # type: ignore[import-not-found]
         from qgis.PyQt.QtWidgets import QApplication  # type: ignore[import-not-found]
     except Exception:
         return func()
@@ -67,6 +67,7 @@ def run_on_qt_gui_thread(func: Callable[[], T]) -> T:
     if is_qt_gui_thread():
         return func()
 
+    source_thread = QThread.currentThread()
     gui = app.thread()
 
     class _Invoker(QObject):
@@ -84,6 +85,15 @@ def run_on_qt_gui_thread(func: Callable[[], T]) -> T:
                 self.value = func()
             except BaseException as exc:  # pragma: no cover - passthrough path
                 self.error = exc
+            finally:
+                # The object was created in the caller thread and moved to the
+                # GUI thread for invocation. Move it back before Python drops
+                # the wrapper, otherwise Qt may destroy a GUI-affine QObject
+                # from the worker thread and crash QGIS.
+                try:
+                    self.moveToThread(source_thread)
+                except Exception:
+                    pass
 
     invoker = _Invoker()
     invoker.moveToThread(gui)
@@ -95,8 +105,8 @@ def run_on_qt_gui_thread(func: Callable[[], T]) -> T:
         "run",
         blocking,
     )
-    if not ok:
-        return func()
+    if ok is False:
+        raise RuntimeError("Failed to marshal QGIS API call to the Qt GUI thread.")
     if invoker.error is not None:
         raise invoker.error
     return invoker.value

--- a/geoagent/tools/nasa_opera.py
+++ b/geoagent/tools/nasa_opera.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
+import uuid
 from datetime import datetime
 from typing import Any, Callable, Optional
+from urllib.parse import urlparse
 
 from geoagent.core.decorators import geo_tool
 from geoagent.tools._qt_marshal import run_on_qt_gui_thread
@@ -90,8 +93,35 @@ def _earthdata_login() -> None:
     )
 
 
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_filename(value: str, *, fallback: str = "opera") -> str:
+    """Return a filesystem-safe basename derived from a user-provided string.
+
+    Strips path separators, query strings, and other non-portable characters so
+    the result can be joined with a temp/cache directory without escaping it.
+    """
+    candidate = os.path.basename(value or "").strip()
+    candidate = _SAFE_NAME_RE.sub("_", candidate).strip("._")
+    return candidate or fallback
+
+
+def _filename_from_url(url: str, *, fallback: str = "opera") -> str:
+    """Return a stable basename for ``url`` ignoring query strings."""
+    parsed = urlparse(url)
+    raw = os.path.basename(parsed.path) if parsed.scheme else os.path.basename(url)
+    return _safe_filename(raw, fallback=fallback)
+
+
 def _setup_gdal_for_earthdata() -> tuple[bool, Optional[str]]:
-    """Configure GDAL for Earthdata S3 access."""
+    """Configure GDAL for Earthdata S3 access.
+
+    TLS verification stays enabled by default. To work around hosts with broken
+    certificate chains, set ``GEOAGENT_OPERA_INSECURE_SSL=1`` in the
+    environment. The unsafe option is opt-in because it disables verification
+    for every subsequent GDAL HTTP read in the QGIS process.
+    """
     try:
         import earthaccess
         from osgeo import gdal
@@ -107,7 +137,12 @@ def _setup_gdal_for_earthdata() -> tuple[bool, Optional[str]]:
         gdal.SetConfigOption(
             "CPL_VSIL_CURL_ALLOWED_EXTENSIONS", ".tif,.TIF,.tiff,.TIFF"
         )
-        gdal.SetConfigOption("GDAL_HTTP_UNSAFESSL", "YES")
+        if os.environ.get("GEOAGENT_OPERA_INSECURE_SSL", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }:
+            gdal.SetConfigOption("GDAL_HTTP_UNSAFESSL", "YES")
         cookies = os.path.expanduser("~/cookies.txt")
         gdal.SetConfigOption("GDAL_HTTP_COOKIEFILE", cookies)
         gdal.SetConfigOption("GDAL_HTTP_COOKIEJAR", cookies)
@@ -500,7 +535,8 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         The tool tries GDAL virtual-file streaming first, then falls back to
         downloading the file through ``earthaccess``.
         """
-        name = layer_name or url.rstrip("/").split("/")[-1] or "OPERA Raster"
+        url_basename = _filename_from_url(url, fallback="opera_raster")
+        name = layer_name or url_basename or "OPERA Raster"
         if prefer_streaming:
             success, error = _setup_gdal_for_earthdata()
             if success:
@@ -522,7 +558,7 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
             os.path.expanduser("~"), "nasa_opera_cache"
         )
         os.makedirs(target_dir, exist_ok=True)
-        local_path = os.path.join(target_dir, url.rstrip("/").split("/")[-1])
+        local_path = os.path.join(target_dir, url_basename)
         if not os.path.exists(local_path):
             downloaded = earthaccess.download([url], local_path=target_dir, threads=1)
             if downloaded:
@@ -543,6 +579,7 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         name="create_mosaic",
         requires_confirmation=True,
         long_running=True,
+        requires_packages=("osgeo", "earthaccess"),
     )
     def create_mosaic(
         urls: list[str],
@@ -552,7 +589,10 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         if not urls:
             return {"error": "No URLs provided."}
 
-        from osgeo import gdal  # type: ignore[import-not-found]
+        try:
+            from osgeo import gdal  # type: ignore[import-not-found]
+        except ImportError as exc:
+            return {"error": f"GDAL Python bindings are not available: {exc}"}
 
         success, error = _setup_gdal_for_earthdata()
         if not success:
@@ -568,7 +608,10 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         if not accessible:
             return {"error": "None of the provided OPERA URLs are accessible."}
 
-        vrt_path = os.path.join(tempfile.gettempdir(), f"{layer_name}.vrt")
+        safe_stem = _safe_filename(layer_name, fallback="opera_mosaic")
+        vrt_path = os.path.join(
+            tempfile.gettempdir(), f"{safe_stem}_{uuid.uuid4().hex}.vrt"
+        )
         vrt_ds = gdal.BuildVRT(vrt_path, accessible)
         if vrt_ds is None:
             return {"error": "Failed to build OPERA VRT mosaic."}
@@ -610,9 +653,20 @@ def submit_nasa_opera_search_task(
     reports progress through QGIS's Log Messages panel and message bar, and it
     retains the returned task in a module-level list so the task remains alive.
     """
+    if iface is None:
+        raise ValueError(
+            "submit_nasa_opera_search_task requires a QGIS iface; got None."
+        )
+
     from qgis.core import Qgis, QgsApplication, QgsTask  # type: ignore[import-not-found]
 
     tools = {tool.tool_name: tool for tool in nasa_opera_tools(iface, project)}
+    required = ("search_opera_data", "display_footprints")
+    missing = [name for name in required if name not in tools]
+    if missing:
+        raise RuntimeError(
+            "NASA OPERA tool registration missing required tools: " + ", ".join(missing)
+        )
 
     def _run(task: Any) -> dict[str, Any]:
         task.setProgress(1)
@@ -629,31 +683,40 @@ def submit_nasa_opera_search_task(
     def _finished(
         exception: BaseException | None, result: dict[str, Any] | None = None
     ) -> None:
-        if exception is not None:
+        try:
+            if exception is not None:
+                _qgis_log(
+                    iface,
+                    f"NASA OPERA search failed: {exception}",
+                    Qgis.MessageLevel.Critical,
+                )
+                if on_finished is not None:
+                    on_finished(None)
+                return
+            if result is None:
+                _qgis_log(
+                    iface,
+                    "NASA OPERA search was cancelled.",
+                    Qgis.MessageLevel.Warning,
+                )
+                if on_finished is not None:
+                    on_finished(None)
+                return
+
             _qgis_log(
                 iface,
-                f"NASA OPERA search failed: {exception}",
-                Qgis.MessageLevel.Critical,
+                f"NASA OPERA search finished: {result['count']} granules found.",
             )
+            if display_footprints:
+                footprint_result = tools["display_footprints"](layer_name=layer_name)
+                _qgis_log(iface, footprint_result)
             if on_finished is not None:
-                on_finished(None)
-            return
-        if result is None:
-            _qgis_log(
-                iface, "NASA OPERA search was cancelled.", Qgis.MessageLevel.Warning
-            )
-            if on_finished is not None:
-                on_finished(None)
-            return
-
-        _qgis_log(
-            iface, f"NASA OPERA search finished: {result['count']} granules found."
-        )
-        if display_footprints:
-            footprint_result = tools["display_footprints"](layer_name=layer_name)
-            _qgis_log(iface, footprint_result)
-        if on_finished is not None:
-            on_finished(result)
+                on_finished(result)
+        finally:
+            try:
+                _QGIS_TASKS.remove(task)
+            except ValueError:
+                pass
 
     task = QgsTask.fromFunction(
         "GeoAgent NASA OPERA search",

--- a/geoagent/tools/nasa_opera.py
+++ b/geoagent/tools/nasa_opera.py
@@ -1,0 +1,700 @@
+"""Tool adapters for the NASA OPERA QGIS plugin.
+
+The tools in this module are native GeoAgent tools. They intentionally do not
+wrap ``nasa_opera.ai.tools`` because that plugin-local agent surface is being
+replaced by GeoAgent. The module also avoids importing NASA OPERA plugin UI
+modules because they import QGIS/PyQt objects at module scope and are unsafe
+from background task threads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime
+from typing import Any, Callable, Optional
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+_QGIS_TASKS: list[Any] = []
+
+OPERA_DATASETS: dict[str, dict[str, str]] = {
+    "OPERA_L3_DSWX-HLS_V1": {
+        "title": "Dynamic Surface Water Extent from Harmonized Landsat Sentinel-2 (Version 1)",
+        "short_title": "DSWX-HLS",
+        "description": "Surface water extent derived from HLS data",
+    },
+    "OPERA_L3_DSWX-S1_V1": {
+        "title": "Dynamic Surface Water Extent from Sentinel-1 (Version 1)",
+        "short_title": "DSWX-S1",
+        "description": "Surface water extent derived from Sentinel-1 SAR data",
+    },
+    "OPERA_L3_DIST-ALERT-HLS_V1": {
+        "title": "Land Surface Disturbance Alert from HLS (Version 1)",
+        "short_title": "DIST-ALERT",
+        "description": "Near real-time disturbance alerts",
+    },
+    "OPERA_L3_DIST-ANN-HLS_V1": {
+        "title": "Land Surface Disturbance Annual from HLS (Version 1)",
+        "short_title": "DIST-ANN",
+        "description": "Annual land surface disturbance product",
+    },
+    "OPERA_L2_RTC-S1_V1": {
+        "title": "Radiometric Terrain Corrected SAR Backscatter from Sentinel-1 (Version 1)",
+        "short_title": "RTC-S1",
+        "description": "Analysis-ready SAR backscatter data",
+    },
+    "OPERA_L2_RTC-S1-STATIC_V1": {
+        "title": "RTC-S1 Static Layers (Version 1)",
+        "short_title": "RTC-S1-STATIC",
+        "description": "Static layers for RTC-S1 product",
+    },
+    "OPERA_L2_CSLC-S1_V1": {
+        "title": "Coregistered Single-Look Complex from Sentinel-1 (Version 1)",
+        "short_title": "CSLC-S1",
+        "description": "SLC data coregistered to a common reference",
+    },
+    "OPERA_L2_CSLC-S1-STATIC_V1": {
+        "title": "CSLC-S1 Static Layers (Version 1)",
+        "short_title": "CSLC-S1-STATIC",
+        "description": "Static layers for CSLC-S1 product",
+    },
+}
+
+
+def _on_gui(fn: Any) -> Any:
+    """Run ``fn`` on the Qt GUI thread when QGIS is available."""
+    return run_on_qt_gui_thread(fn)
+
+
+def _datasets() -> dict[str, dict[str, str]]:
+    """Return OPERA dataset metadata."""
+    return dict(OPERA_DATASETS)
+
+
+def _earthdata_login() -> None:
+    """Authenticate with NASA Earthdata using earthaccess env/netrc defaults."""
+    import earthaccess
+
+    for strategy in ("environment", "netrc"):
+        try:
+            if earthaccess.login(strategy=strategy):
+                return
+        except Exception:
+            continue
+    raise RuntimeError(
+        "NASA Earthdata authentication failed. Configure Earthdata credentials "
+        "in the NASA OPERA plugin settings, environment, or ~/.netrc."
+    )
+
+
+def _setup_gdal_for_earthdata() -> tuple[bool, Optional[str]]:
+    """Configure GDAL for Earthdata S3 access."""
+    try:
+        import earthaccess
+        from osgeo import gdal
+
+        _earthdata_login()
+        creds = earthaccess.get_s3_credentials(daac="PODAAC")
+        gdal.SetConfigOption("AWS_ACCESS_KEY_ID", creds["accessKeyId"])
+        gdal.SetConfigOption("AWS_SECRET_ACCESS_KEY", creds["secretAccessKey"])
+        gdal.SetConfigOption("AWS_SESSION_TOKEN", creds["sessionToken"])
+        gdal.SetConfigOption("AWS_REGION", "us-west-2")
+        gdal.SetConfigOption("AWS_S3_ENDPOINT", "s3.us-west-2.amazonaws.com")
+        gdal.SetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "EMPTY_DIR")
+        gdal.SetConfigOption(
+            "CPL_VSIL_CURL_ALLOWED_EXTENSIONS", ".tif,.TIF,.tiff,.TIFF"
+        )
+        gdal.SetConfigOption("GDAL_HTTP_UNSAFESSL", "YES")
+        cookies = os.path.expanduser("~/cookies.txt")
+        gdal.SetConfigOption("GDAL_HTTP_COOKIEFILE", cookies)
+        gdal.SetConfigOption("GDAL_HTTP_COOKIEJAR", cookies)
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _vsicurl_path(url: str) -> str:
+    """Return a GDAL virtual filesystem path for an OPERA asset URL."""
+    if url.startswith("s3://"):
+        return f"/vsis3/{url[5:]}"
+    if url.startswith(("https://", "http://")):
+        return f"/vsicurl/{url}"
+    return url
+
+
+def _parse_bbox(bbox: Optional[str]) -> tuple[float, float, float, float] | None:
+    """Parse a west,south,east,north bbox string."""
+    if not bbox:
+        return None
+    parts = [float(part.strip()) for part in bbox.split(",")]
+    if len(parts) != 4:
+        raise ValueError("bbox must have exactly four values: west,south,east,north")
+    west, south, east, north = parts
+    if west >= east or south >= north:
+        raise ValueError("bbox coordinates must satisfy west < east and south < north")
+    return west, south, east, north
+
+
+def _current_bbox_wgs84(iface: Any) -> tuple[float, float, float, float]:
+    """Return the current QGIS canvas extent as WGS84 coordinates."""
+
+    def _run() -> tuple[float, float, float, float]:
+        canvas = iface.mapCanvas()
+        extent = canvas.extent()
+        crs = canvas.mapSettings().destinationCrs()
+        if crs.authid() != "EPSG:4326":
+            from qgis.core import (  # type: ignore[import-not-found]
+                QgsCoordinateReferenceSystem,
+                QgsCoordinateTransform,
+                QgsProject,
+            )
+
+            transform = QgsCoordinateTransform(
+                crs,
+                QgsCoordinateReferenceSystem("EPSG:4326"),
+                QgsProject.instance(),
+            )
+            extent = transform.transformBoundingBox(extent)
+        return (
+            float(extent.xMinimum()),
+            float(extent.yMinimum()),
+            float(extent.xMaximum()),
+            float(extent.yMaximum()),
+        )
+
+    return _on_gui(_run)
+
+
+def _add_qgis_raster_layer(
+    iface: Any,
+    project_getter: Callable[[], Any],
+    path_or_uri: str,
+    layer_name: str,
+) -> dict[str, Any]:
+    """Add a raster layer to QGIS on the GUI thread."""
+
+    def _run() -> dict[str, Any]:
+        from qgis.core import QgsRasterLayer  # type: ignore[import-not-found]
+
+        layer = QgsRasterLayer(path_or_uri, layer_name)
+        if not layer.isValid():
+            return {"error": f"Failed to load raster from {path_or_uri}."}
+        project_getter().addMapLayer(layer)
+        iface.mapCanvas().refresh()
+        return {"success": True, "layer_name": layer_name}
+
+    return _on_gui(_run)
+
+
+def _granule_links(granule: Any) -> list[str]:
+    """Return data links from an earthaccess granule."""
+    if hasattr(granule, "data_links"):
+        try:
+            return list(granule.data_links())
+        except Exception:
+            return []
+    links = (
+        granule.get("umm", {}).get("RelatedUrls", []) if hasattr(granule, "get") else []
+    )
+    out: list[str] = []
+    for link in links:
+        url = link.get("URL") if isinstance(link, dict) else None
+        if url:
+            out.append(str(url))
+    return out
+
+
+def _granule_geometry(granule: Any) -> dict[str, Any] | None:
+    """Extract a GeoJSON geometry from an earthaccess granule."""
+    umm = granule.get("umm", {}) if hasattr(granule, "get") else {}
+    spatial = umm.get("SpatialExtent", {})
+    horizontal = spatial.get("HorizontalSpatialDomain", {})
+    geometry = horizontal.get("Geometry", {})
+
+    rects = geometry.get("BoundingRectangles", [])
+    if rects:
+        rect = rects[0]
+        west = rect.get("WestBoundingCoordinate", 0)
+        south = rect.get("SouthBoundingCoordinate", 0)
+        east = rect.get("EastBoundingCoordinate", 0)
+        north = rect.get("NorthBoundingCoordinate", 0)
+        return {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [west, south],
+                    [east, south],
+                    [east, north],
+                    [west, north],
+                    [west, south],
+                ]
+            ],
+        }
+
+    polygons = geometry.get("GPolygons", [])
+    if polygons:
+        points = polygons[0].get("Boundary", {}).get("Points", [])
+        coords = [[p.get("Longitude", 0), p.get("Latitude", 0)] for p in points]
+        if coords:
+            if coords[0] != coords[-1]:
+                coords.append(coords[0])
+            return {"type": "Polygon", "coordinates": [coords]}
+    return None
+
+
+def _granule_summary(granule: Any, *, max_links: int = 5) -> dict[str, Any]:
+    """Return a compact, JSON-serializable granule summary."""
+    meta = granule.get("meta", {}) if hasattr(granule, "get") else {}
+    umm = granule.get("umm", {}) if hasattr(granule, "get") else {}
+    temporal = umm.get("TemporalExtent", {}).get("RangeDateTime", {})
+    links = _granule_links(granule)
+    return {
+        "native_id": meta.get("native-id", ""),
+        "producer_granule_id": meta.get("producer-granule-id", ""),
+        "concept_id": meta.get("concept-id", ""),
+        "begin_date": temporal.get("BeginningDateTime", ""),
+        "end_date": temporal.get("EndingDateTime", ""),
+        "num_links": len(links),
+        "data_links": links[:max_links],
+    }
+
+
+def _qgis_log(iface: Any, message: Any, level: Any = None) -> None:
+    """Log to QGIS message log and message bar on the GUI thread."""
+    try:
+        text = str(message)
+
+        def _run() -> None:
+            from qgis.core import Qgis, QgsMessageLog  # type: ignore[import-not-found]
+
+            msg_level = level if level is not None else Qgis.MessageLevel.Info
+            QgsMessageLog.logMessage(text, "GeoAgent NASA OPERA", msg_level)
+            try:
+                iface.messageBar().pushMessage(
+                    "GeoAgent NASA OPERA",
+                    text,
+                    level=msg_level,
+                    duration=5,
+                )
+            except Exception:
+                pass
+
+        _on_gui(_run)
+    except Exception:
+        print(message)
+
+
+def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
+    """Return GeoAgent tools for NASA OPERA workflows in QGIS.
+
+    Args:
+        iface: The QGIS ``QgisInterface`` from the NASA OPERA plugin runtime.
+        project: Optional ``QgsProject`` instance. The tools fall back to
+            ``QgsProject.instance()`` when omitted.
+    """
+    if iface is None:
+        return []
+
+    state: dict[str, Any] = {}
+
+    def _project() -> Any:
+        """Return the bound or singleton QGIS project."""
+        if project is not None:
+            return project
+        from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+        return QgsProject.instance()
+
+    @geo_tool(
+        category="nasa_opera",
+        name="get_available_datasets",
+        available_in=("full", "fast"),
+    )
+    def get_available_datasets() -> list[dict[str, str]]:
+        """List NASA OPERA product short names, titles, and descriptions."""
+        return [
+            {
+                "short_name": short_name,
+                "title": info["title"],
+                "short_title": info["short_title"],
+                "description": info["description"],
+            }
+            for short_name, info in _datasets().items()
+        ]
+
+    @geo_tool(
+        category="nasa_opera",
+        name="get_dataset_info",
+        available_in=("full", "fast"),
+    )
+    def get_dataset_info(dataset_name: str) -> list[dict[str, str]]:
+        """Find OPERA datasets by short name, title, short title, or keyword."""
+        query = dataset_name.strip().upper()
+        matches: list[dict[str, str]] = []
+        for short_name, info in _datasets().items():
+            haystack = " ".join(
+                [
+                    short_name,
+                    info["title"],
+                    info["short_title"],
+                    info["description"],
+                ]
+            ).upper()
+            if query in haystack:
+                matches.append(
+                    {
+                        "short_name": short_name,
+                        "title": info["title"],
+                        "short_title": info["short_title"],
+                        "description": info["description"],
+                    }
+                )
+        return matches
+
+    @geo_tool(
+        category="nasa_opera",
+        name="search_opera_data",
+        requires_packages=("earthaccess",),
+    )
+    def search_opera_data(
+        dataset: str,
+        bbox: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        max_results: int = 20,
+    ) -> dict[str, Any]:
+        """Search NASA OPERA granules by product, bbox, and date range.
+
+        Args:
+            dataset: OPERA dataset short name, such as
+                ``OPERA_L3_DSWX-HLS_V1``.
+            bbox: Optional ``west,south,east,north`` WGS84 bounding box. When
+                omitted, the current QGIS map extent is used.
+            start_date: Optional start date in ``YYYY-MM-DD`` format.
+            end_date: Optional end date in ``YYYY-MM-DD`` format.
+            max_results: Maximum number of granules to return.
+        """
+        import earthaccess
+
+        parsed_bbox = _parse_bbox(bbox)
+        if parsed_bbox is None:
+            parsed_bbox = _current_bbox_wgs84(iface)
+
+        _earthdata_login()
+        count = max(1, int(max_results))
+        search_params: dict[str, Any] = {
+            "short_name": dataset,
+            "count": count,
+            "bounding_box": parsed_bbox,
+        }
+        if start_date and end_date:
+            search_params["temporal"] = (start_date, end_date)
+        elif start_date:
+            search_params["temporal"] = (
+                start_date,
+                datetime.today().strftime("%Y-%m-%d"),
+            )
+
+        results = list(earthaccess.search_data(**search_params))
+        state["last_search_results"] = results
+        state["last_search_dataset"] = dataset
+        state["last_search_bbox"] = parsed_bbox
+
+        return {
+            "count": len(results),
+            "dataset": dataset,
+            "bbox": parsed_bbox,
+            "granules": [_granule_summary(granule) for granule in results],
+        }
+
+    @geo_tool(
+        category="nasa_opera",
+        name="display_footprints",
+    )
+    def display_footprints(layer_name: str = "OPERA Footprints") -> dict[str, Any]:
+        """Display footprints for the most recent OPERA search results."""
+
+        def _run() -> dict[str, Any]:
+            results = state.get("last_search_results")
+            if not results:
+                return {"error": "No OPERA search results are available."}
+
+            features: list[dict[str, Any]] = []
+            for granule in results:
+                geometry = _granule_geometry(granule)
+                if geometry is None:
+                    continue
+                summary = _granule_summary(granule, max_links=0)
+                features.append(
+                    {
+                        "type": "Feature",
+                        "geometry": geometry,
+                        "properties": summary,
+                    }
+                )
+
+            if not features:
+                return {"error": "No valid footprint geometries found."}
+
+            geojson = {
+                "type": "FeatureCollection",
+                "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
+                "features": features,
+            }
+            path = os.path.join(
+                tempfile.gettempdir(), "geoagent_opera_footprints.geojson"
+            )
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(geojson, f)
+
+            from qgis.PyQt.QtGui import QColor  # type: ignore[import-not-found]
+            from qgis.core import (  # type: ignore[import-not-found]
+                QgsFillSymbol,
+                QgsVectorLayer,
+            )
+
+            proj = _project()
+            for existing in proj.mapLayersByName(layer_name):
+                proj.removeMapLayer(existing.id())
+
+            layer = QgsVectorLayer(path, layer_name, "ogr")
+            if not layer.isValid():
+                return {"error": "Failed to create OPERA footprint layer."}
+
+            symbol = QgsFillSymbol.createSimple({})
+            fill = symbol.symbolLayer(0)
+            fill.setColor(QColor(25, 118, 210, 50))
+            fill.setStrokeColor(QColor(25, 118, 210, 200))
+            fill.setStrokeWidth(0.5)
+            layer.renderer().setSymbol(symbol)
+
+            proj.addMapLayer(layer)
+            iface.mapCanvas().refresh()
+            return {
+                "success": True,
+                "layer_name": layer_name,
+                "feature_count": len(features),
+                "path": path,
+            }
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="nasa_opera",
+        name="display_raster",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("earthaccess",),
+    )
+    def display_raster(
+        url: str,
+        layer_name: Optional[str] = None,
+        prefer_streaming: bool = True,
+        cache_dir: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Load an OPERA raster asset URL into QGIS.
+
+        The tool tries GDAL virtual-file streaming first, then falls back to
+        downloading the file through ``earthaccess``.
+        """
+        name = layer_name or url.rstrip("/").split("/")[-1] or "OPERA Raster"
+        if prefer_streaming:
+            success, error = _setup_gdal_for_earthdata()
+            if success:
+                result = _add_qgis_raster_layer(
+                    iface,
+                    _project,
+                    _vsicurl_path(url),
+                    name,
+                )
+                if result.get("success"):
+                    result["mode"] = "streaming"
+                    return result
+            state["last_streaming_error"] = error
+
+        import earthaccess
+
+        _earthdata_login()
+        target_dir = cache_dir or os.path.join(
+            os.path.expanduser("~"), "nasa_opera_cache"
+        )
+        os.makedirs(target_dir, exist_ok=True)
+        local_path = os.path.join(target_dir, url.rstrip("/").split("/")[-1])
+        if not os.path.exists(local_path):
+            downloaded = earthaccess.download([url], local_path=target_dir, threads=1)
+            if downloaded:
+                local_path = str(downloaded[0])
+
+        result = _add_qgis_raster_layer(iface, _project, local_path, name)
+        if result.get("success"):
+            return {
+                "success": True,
+                "layer_name": name,
+                "mode": "download",
+                "path": local_path,
+            }
+        return result
+
+    @geo_tool(
+        category="nasa_opera",
+        name="create_mosaic",
+        requires_confirmation=True,
+        long_running=True,
+    )
+    def create_mosaic(
+        urls: list[str],
+        layer_name: str = "OPERA Mosaic",
+    ) -> dict[str, Any]:
+        """Create and display a GDAL VRT mosaic from OPERA raster URLs."""
+        if not urls:
+            return {"error": "No URLs provided."}
+
+        from osgeo import gdal  # type: ignore[import-not-found]
+
+        success, error = _setup_gdal_for_earthdata()
+        if not success:
+            return {"error": f"Failed to configure GDAL: {error}"}
+
+        accessible: list[str] = []
+        for path in [_vsicurl_path(url) for url in urls]:
+            ds = gdal.Open(path)
+            if ds:
+                accessible.append(path)
+                ds = None
+
+        if not accessible:
+            return {"error": "None of the provided OPERA URLs are accessible."}
+
+        vrt_path = os.path.join(tempfile.gettempdir(), f"{layer_name}.vrt")
+        vrt_ds = gdal.BuildVRT(vrt_path, accessible)
+        if vrt_ds is None:
+            return {"error": "Failed to build OPERA VRT mosaic."}
+        vrt_ds.FlushCache()
+        vrt_ds = None
+
+        result = _add_qgis_raster_layer(iface, _project, vrt_path, layer_name)
+        if result.get("success"):
+            result["path"] = vrt_path
+            result["source_count"] = len(accessible)
+        return result
+
+    return [
+        get_available_datasets,
+        get_dataset_info,
+        search_opera_data,
+        display_footprints,
+        display_raster,
+        create_mosaic,
+    ]
+
+
+def submit_nasa_opera_search_task(
+    iface: Any,
+    *,
+    dataset: str,
+    bbox: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    max_results: int = 20,
+    project: Optional[Any] = None,
+    display_footprints: bool = True,
+    layer_name: str = "OPERA Footprints",
+    on_finished: Optional[Callable[[dict[str, Any] | None], None]] = None,
+) -> Any:
+    """Submit an OPERA search as a QGIS-managed background task.
+
+    This helper is intended for the QGIS Python console and plugin UI code. It
+    reports progress through QGIS's Log Messages panel and message bar, and it
+    retains the returned task in a module-level list so the task remains alive.
+    """
+    from qgis.core import Qgis, QgsApplication, QgsTask  # type: ignore[import-not-found]
+
+    tools = {tool.tool_name: tool for tool in nasa_opera_tools(iface, project)}
+
+    def _run(task: Any) -> dict[str, Any]:
+        task.setProgress(1)
+        result = tools["search_opera_data"](
+            dataset=dataset,
+            bbox=bbox,
+            start_date=start_date,
+            end_date=end_date,
+            max_results=max_results,
+        )
+        task.setProgress(90)
+        return result
+
+    def _finished(
+        exception: BaseException | None, result: dict[str, Any] | None = None
+    ) -> None:
+        if exception is not None:
+            _qgis_log(
+                iface,
+                f"NASA OPERA search failed: {exception}",
+                Qgis.MessageLevel.Critical,
+            )
+            if on_finished is not None:
+                on_finished(None)
+            return
+        if result is None:
+            _qgis_log(
+                iface, "NASA OPERA search was cancelled.", Qgis.MessageLevel.Warning
+            )
+            if on_finished is not None:
+                on_finished(None)
+            return
+
+        _qgis_log(
+            iface, f"NASA OPERA search finished: {result['count']} granules found."
+        )
+        if display_footprints:
+            footprint_result = tools["display_footprints"](layer_name=layer_name)
+            _qgis_log(iface, footprint_result)
+        if on_finished is not None:
+            on_finished(result)
+
+    task = QgsTask.fromFunction(
+        "GeoAgent NASA OPERA search",
+        _run,
+        on_finished=_finished,
+    )
+    _QGIS_TASKS.append(task)
+    QgsApplication.taskManager().addTask(task)
+    _qgis_log(iface, "Submitted GeoAgent NASA OPERA search task.")
+    return task
+
+
+def submit_nasa_opera_chat_task(
+    agent: Any,
+    query: str,
+    *,
+    on_finished: Optional[Callable[[Any | None], None]] = None,
+) -> Any:
+    """Fail closed for NASA OPERA chat inside QGIS.
+
+    LLM-driven chat can choose QGIS tools dynamically, which has repeatedly
+    triggered Qt thread-affinity crashes in the QGIS process. Use
+    :func:`submit_nasa_opera_search_task` or direct tools instead.
+    """
+    from qgis.core import Qgis  # type: ignore[import-not-found]
+
+    iface = agent.context.qgis_iface
+    _qgis_log(
+        iface,
+        "NASA OPERA chat is disabled in QGIS. Use submit_nasa_opera_search_task(...) "
+        "or direct nasa_opera_tools(...) calls instead.",
+        Qgis.MessageLevel.Critical,
+    )
+    if on_finished is not None:
+        on_finished(None)
+    return None
+
+
+__all__ = [
+    "OPERA_DATASETS",
+    "nasa_opera_tools",
+    "submit_nasa_opera_chat_task",
+    "submit_nasa_opera_search_task",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,12 @@ geemap = ["geemap"]
 earthengine = ["earthengine-api>=1.0", "geemap"]
 stac = ["pystac-client>=0.8", "planetary-computer>=1.0"]
 earthdata = ["earthaccess>=0.10"]
+nasa-opera = ["earthaccess>=0.10"]
 ui = ["solara>=1.35"]
 qgis = []
 providers = ["GeoAgent[openai,anthropic,gemini,ollama]"]
 all = [
-    "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,ui]",
+    "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,nasa-opera,ui]",
 ]
 dev = [
     "pytest>=8.0",

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -93,7 +93,7 @@ Default models:
 | OpenAI | `gpt-5.5` |
 | Anthropic | `claude-sonnet-4-6` |
 | Google Gemini | `gemini-3.1-pro-preview` |
-| Ollama | `llama3.1` |
+| Ollama | `qwen3.5:4b` |
 
 ## Chat Workflow
 

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -3,9 +3,10 @@
 import os
 import html
 import re
+import time
 import traceback
 
-from qgis.PyQt.QtCore import Qt, QSettings, QThread, pyqtSignal
+from qgis.PyQt.QtCore import Qt, QSettings, QThread, QTimer, pyqtSignal
 from qgis.PyQt.QtGui import QGuiApplication, QTextCursor
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
@@ -31,7 +32,7 @@ DEFAULT_MODELS = {
     "openai": "gpt-5.5",
     "anthropic": "claude-sonnet-4-6",
     "gemini": "gemini-3.1-pro-preview",
-    "ollama": "llama3.1",
+    "ollama": "qwen3.5:4b",
 }
 PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama"]
 SAMPLE_PROMPTS = [
@@ -288,6 +289,12 @@ class ChatDockWidget(QDockWidget):
         self._history_index = None
         self._messages = []
         self._last_assistant_markdown = ""
+        self._status_started_at = None
+        self._status_base_text = "Running"
+        self._status_frame = 0
+        self._status_timer = QTimer(self)
+        self._status_timer.setInterval(500)
+        self._status_timer.timeout.connect(self._update_running_status)
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -440,8 +447,8 @@ class ChatDockWidget(QDockWidget):
 
         self._append_message("You", prompt, markdown=False)
         self.prompt_input.clear()
-        self.status_label.setText("Running...")
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
+        self._start_running_status("Running GeoAgent")
         self.send_btn.setEnabled(False)
 
         self._worker = ChatWorker(
@@ -490,6 +497,7 @@ class ChatDockWidget(QDockWidget):
 
     def _on_worker_finished(self, result):
         """Render the completed chat worker result."""
+        self._stop_running_status()
         if result.get("success"):
             answer = result.get("answer") or "(No text response.)"
             details = []
@@ -513,6 +521,41 @@ class ChatDockWidget(QDockWidget):
 
         self.send_btn.setEnabled(True)
         self._worker = None
+
+    def _start_running_status(self, base_text):
+        """Start or update the animated status text."""
+        self._status_base_text = base_text
+        if self._status_started_at is None:
+            self._status_started_at = time.monotonic()
+            self._status_frame = 0
+        if not self._status_timer.isActive():
+            self._status_timer.start()
+        self._update_running_status()
+
+    def _stop_running_status(self):
+        """Stop the animated status text."""
+        if self._status_timer.isActive():
+            self._status_timer.stop()
+        self._status_started_at = None
+        self._status_frame = 0
+
+    def _update_running_status(self):
+        """Refresh the animated status text."""
+        if self._status_started_at is None:
+            return
+        elapsed = int(time.monotonic() - self._status_started_at)
+        spinner = ("-", "\\", "|", "/")[self._status_frame % 4]
+        self._status_frame += 1
+        dots = "." * (self._status_frame % 4)
+        if elapsed >= 30:
+            suffix = "large QGIS operations can take a while"
+        elif elapsed >= 10:
+            suffix = "running tools and waiting for the model"
+        else:
+            suffix = "working"
+        self.status_label.setText(
+            f"{spinner} {self._status_base_text}{dots} {elapsed}s - {suffix}"
+        )
 
     def _append_message(self, sender, message, markdown=False):
         """Append a chat message and refresh the transcript."""

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -601,3 +601,20 @@ class ChatDockWidget(QDockWidget):
         self._last_assistant_markdown = ""
         self.copy_md_btn.setEnabled(False)
         self.transcript.clear()
+
+    def _shutdown_running_state(self):
+        """Stop the animated status timer when the dock is dismissed."""
+        try:
+            self._stop_running_status()
+        except Exception:
+            pass
+
+    def hideEvent(self, event):
+        """Stop the animated status timer when the dock is hidden."""
+        self._shutdown_running_state()
+        super().hideEvent(event)
+
+    def closeEvent(self, event):
+        """Stop the animated status timer when the dock is closed."""
+        self._shutdown_running_state()
+        super().closeEvent(event)

--- a/tests/test_nasa_opera_tools.py
+++ b/tests/test_nasa_opera_tools.py
@@ -1,0 +1,136 @@
+"""Tests for the NASA OPERA GeoAgent tool factory."""
+
+from __future__ import annotations
+
+import threading
+import sys
+import types
+
+from geoagent import for_nasa_opera
+from geoagent.tools.nasa_opera import nasa_opera_tools, submit_nasa_opera_chat_task
+from geoagent.testing import MockQGISIface, MockQGISProject
+
+
+class _MockModel:
+    """Provide a test double for MockModel."""
+
+    stateful = False
+
+
+def test_nasa_opera_module_imports_without_qgis() -> None:
+    """Verify NASA OPERA tools are import-safe outside QGIS."""
+    assert "geoagent.tools.nasa_opera" in sys.modules
+    assert "qgis" not in sys.modules
+    assert "nasa_opera.ai.tools" not in sys.modules
+
+
+def test_nasa_opera_tools_returns_empty_for_none_iface() -> None:
+    """Verify the OPERA factory returns no tools without a QGIS iface."""
+    assert nasa_opera_tools(None) == []
+
+
+def test_nasa_opera_dataset_tools_use_geoagent_surface() -> None:
+    """Verify OPERA dataset metadata tools are available without plugin AI tools."""
+    tools = {t.tool_name: t for t in nasa_opera_tools(object())}
+
+    datasets = tools["get_available_datasets"]()
+    names = {item["short_name"] for item in datasets}
+
+    assert "OPERA_L3_DSWX-HLS_V1" in names
+    assert "OPERA_L2_RTC-S1_V1" in names
+    assert "nasa_opera.ai.tools" not in sys.modules
+
+
+def test_for_nasa_opera_registers_opera_and_qgis_tools() -> None:
+    """Verify the NASA OPERA factory combines OPERA and QGIS tool surfaces."""
+    agent = for_nasa_opera(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    names = set(agent.strands_agent.tool_names)
+
+    assert "get_available_datasets" in names
+    assert "get_dataset_info" in names
+    assert "display_footprints" in names
+    assert "list_project_layers" in names
+    assert agent.context.metadata["integration"] == "nasa_opera"
+
+
+def test_for_nasa_opera_chat_in_background_returns_thread(monkeypatch) -> None:
+    """Verify QGIS OPERA users can start chat without blocking the caller."""
+    agent = for_nasa_opera(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    called = threading.Event()
+
+    def _chat(query: str, **kwargs):
+        called.set()
+        return query
+
+    monkeypatch.setattr(agent, "chat", _chat)
+
+    thread = agent.chat_in_background("show OPERA datasets")
+    thread.join(timeout=2)
+
+    assert called.is_set()
+    assert not thread.is_alive()
+
+
+def test_for_nasa_opera_chat_on_gui_thread_fails_closed(monkeypatch) -> None:
+    """Verify synchronous OPERA chat is blocked on the QGIS GUI thread."""
+
+    class _FakeThread:
+        """Provide a test double for FakeThread."""
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, _FakeThread)
+
+    class _QThread:
+        """Provide a test double for QThread."""
+
+        @staticmethod
+        def currentThread():
+            """Return current thread."""
+            return _FakeThread()
+
+    class _App:
+        """Provide a test double for App."""
+
+        def thread(self):
+            """Return GUI thread."""
+            return _FakeThread()
+
+    class _QApplication:
+        """Provide a test double for QApplication."""
+
+        @staticmethod
+        def instance():
+            """Return app instance."""
+            return _App()
+
+    fake_qt_core = types.SimpleNamespace(QThread=_QThread)
+    fake_qt_widgets = types.SimpleNamespace(QApplication=_QApplication)
+    fake_pyqt = types.SimpleNamespace(QtCore=fake_qt_core, QtWidgets=fake_qt_widgets)
+    fake_qgis = types.SimpleNamespace(PyQt=fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis", fake_qgis)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt", fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtCore", fake_qt_core)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtWidgets", fake_qt_widgets)
+
+    agent = for_nasa_opera(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    resp = agent.chat("search OPERA")
+
+    assert resp.success is False
+    assert "submit_nasa_opera_search_task" in str(resp.error_message)
+
+
+def test_submit_nasa_opera_chat_task_is_importable() -> None:
+    """Verify the QGIS chat task helper is exposed."""
+    assert callable(submit_nasa_opera_chat_task)


### PR DESCRIPTION
## Summary
- Add `for_nasa_opera` factory and native NASA OPERA tools (`get_available_datasets`, `get_dataset_info`, `search_opera_data`, `display_footprints`, `display_raster`, `create_mosaic`).
- Provide `submit_nasa_opera_search_task` for direct, QGIS-thread-safe use from the QGIS Python console (no LLM/provider init required).
- Wire the integration into the package surface, docs, README, examples, and add a `nasa-opera` install extra.

## Test plan
- [x] `pytest tests/test_nasa_opera_tools.py -q` (7 passed)
- [x] `pre-commit run --all-files`
- [ ] Manual: run `examples/nasa_opera_qgis.py` from the QGIS Python console to verify footprints/raster display