### PR TITLE
feat: tighten fast mode and auto-insert sample prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,15 +313,18 @@ arguments.
 
 ## Fast Mode
 
-Pass `fast=True` to reduce the exposed tool surface for lower-latency map
-control:
+Pass `fast=True` to reduce the exposed tool surface and cap response tokens for
+lower-latency map control:
 
 ```python
 agent = for_leafmap(m, fast=True)
 ```
 
-Fast mode keeps common inspection and navigation tools while filtering out
-heavier or more specialized tools.
+Fast mode keeps common inspection, navigation, and basemap tools, filters out
+heavier or more specialized tools, and limits model responses to short
+post-tool replies. The cap is conservative enough for tool calls while avoiding
+very long responses. The model call still dominates latency for local models,
+so small prompts may not show a large timing difference on every provider.
 
 ## Examples
 

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -59,6 +59,8 @@ class GeoAgent:
             cfg = cfg.model_copy(update={"provider": provider})
         if model_id is not None:
             cfg = cfg.model_copy(update={"model": model_id})
+        if fast and cfg.max_tokens > 2048:
+            cfg = cfg.model_copy(update={"max_tokens": 2048})
         self._config = cfg
         self._fast = fast
         self._qgis_safe_mode = qgis_safe_mode

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -3,4 +3,4 @@
 DEFAULT_SYSTEM_PROMPT = """You are GeoAgent, a geospatial assistant. Use tools for map and GIS actions.
 Prefer calling the right tool immediately when the user's intent is clear. Keep replies concise."""
 
-FAST_SYSTEM_PROMPT = """You are GeoAgent (fast mode). Answer briefly. For map commands (zoom, layers, basemap), call tools directly without planning."""
+FAST_SYSTEM_PROMPT = """You are GeoAgent (fast mode). Call the best tool immediately for map commands. After tool use, reply in one short sentence. Do not summarize, explain, or plan unless the user asks."""

--- a/geoagent/core/registry.py
+++ b/geoagent/core/registry.py
@@ -98,6 +98,7 @@ FAST_TOOL_FALLBACK: frozenset[str] = frozenset(
         "refresh_canvas",
         "zoom_to_extent",
         "set_scale",
+        "add_xyz_tile_layer",
     }
 )
 

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -353,11 +353,8 @@ class ChatDockWidget(QDockWidget):
             _enum_value(QSizePolicy, "Policy", "Ignored"),
             _enum_value(QSizePolicy, "Policy", "Fixed"),
         )
+        self.sample_combo.currentTextChanged.connect(self._select_sample_prompt)
         sample_layout.addWidget(self.sample_combo, 1)
-
-        self.insert_sample_btn = QPushButton("Insert")
-        self.insert_sample_btn.clicked.connect(self._insert_sample_prompt)
-        sample_layout.addWidget(self.insert_sample_btn)
         layout.addLayout(sample_layout)
 
         self.transcript = QTextEdit()
@@ -457,9 +454,8 @@ class ChatDockWidget(QDockWidget):
         self._worker.finished.connect(self._on_worker_finished)
         self._worker.start()
 
-    def _insert_sample_prompt(self):
+    def _select_sample_prompt(self, prompt):
         """Copy the selected sample prompt into the editor."""
-        prompt = self.sample_combo.currentText()
         if prompt and prompt != "Sample prompts...":
             self.prompt_input.setPlainText(prompt)
             self.prompt_input.setFocus()


### PR DESCRIPTION
## Summary
- Cap fast-mode `max_tokens` at 2048 and tighten the fast system prompt so post-tool replies stay short.
- Add `add_xyz_tile_layer` to the fast tool fallback so basemap switches still work in fast mode; refresh README to describe the new behavior.
- In the QGIS chat dock, drop the Insert button and auto-fill the prompt input when a sample is picked from the dropdown.

## Test plan
- [ ] `pytest tests/ -q`
- [ ] Manually verify `for_leafmap(m, fast=True)` keeps basemap switching working
- [ ] Manually verify selecting a sample prompt in the QGIS chat dock populates the prompt input