### PR TITLE
feat: add GEE Data Catalogs tools and QGIS factory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos",
+                  "--ignore-words-list=pre-empt,alos,nd",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -24,6 +24,7 @@ from geoagent.core.safety import (
 from geoagent.core.factory import (
     create_agent,
     for_anymap,
+    for_gee_data_catalogs,
     for_leafmap,
     for_nasa_opera,
     for_qgis,
@@ -41,6 +42,7 @@ __all__ = [
     "GeoToolRegistry",
     "create_agent",
     "for_anymap",
+    "for_gee_data_catalogs",
     "for_leafmap",
     "for_nasa_opera",
     "for_qgis",

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -115,7 +115,6 @@ def assemble_tools(
         gee_tools = _filter_by_imports(
             gee_data_catalogs_tools(
                 context.qgis_iface,
-                context.qgis_project,
                 plugin=gee_data_catalogs_plugin,
             )
         )

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -49,6 +49,15 @@ Workflow guidance:
   exact Earth Engine asset id.
 - Prefer the current QGIS map extent or a user-provided bbox for spatially
   constrained ImageCollection requests.
+- When the user asks to clip a raster/Image/ImageCollection to an administrative
+  boundary or other vector region, use load_gee_dataset with
+  clip_collection_asset_id and clip_filter_property/value. The tool applies
+  ee.Image.clipToCollection to the raster output. For Tennessee, use
+  TIGER/2018/States with NAME=Tennessee.
+- When the user asks for normalized difference indexes such as NDVI, NDWI,
+  MNDWI, NDMI, or NBR, use calculate_gee_normalized_difference. Do not display
+  a single source band as a proxy. Common Sentinel-2/HLS S30 pairs: NDVI B8/B4,
+  NDWI B3/B8, MNDWI B3/B11, NBR B8/B12.
 - Ask for or infer visualization bands only when needed; common RGB defaults
   are acceptable for Landsat and Sentinel imagery.
 - Keep responses concise and include asset ids, layer names, and filters used.

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -14,6 +14,7 @@ from geoagent.core.registry import (
 from geoagent.core.safety import ConfirmCallback
 from geoagent.core.agent import GeoAgent
 from geoagent.tools.anymap import anymap_tools
+from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
 from geoagent.tools.leafmap import leafmap_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
@@ -35,6 +36,22 @@ Workflow guidance:
 - For raster display, choose a specific data link from search results.
 - Keep responses concise and include result counts, date range, and relevant
   first-result identifiers when available.
+"""
+
+GEE_DATA_CATALOGS_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS for Google Earth Engine data catalogs.
+Use the GEE Data Catalogs tools to search official and community datasets,
+inspect metadata, initialize Earth Engine, configure plugin panels, and load
+Earth Engine layers into the current QGIS project.
+
+Workflow guidance:
+- Search the catalog before loading when the user names a topic rather than an
+  exact Earth Engine asset id.
+- Prefer the current QGIS map extent or a user-provided bbox for spatially
+  constrained ImageCollection requests.
+- Ask for or infer visualization bands only when needed; common RGB defaults
+  are acceptable for Landsat and Sentinel imagery.
+- Keep responses concise and include asset ids, layer names, and filters used.
 """
 
 
@@ -69,6 +86,8 @@ def assemble_tools(
     include_anymap: bool = False,
     include_qgis: bool = False,
     include_nasa_opera: bool = False,
+    include_gee_data_catalogs: bool = False,
+    gee_data_catalogs_plugin: Any | None = None,
     fast: bool = False,
 ) -> tuple[list[Any], GeoToolRegistry]:
     """Collect tools for a context and build a metadata registry."""
@@ -92,6 +111,16 @@ def assemble_tools(
         )
         register_all_tools(registry, opera_tools)
         collected.extend(opera_tools)
+    if include_gee_data_catalogs:
+        gee_tools = _filter_by_imports(
+            gee_data_catalogs_tools(
+                context.qgis_iface,
+                context.qgis_project,
+                plugin=gee_data_catalogs_plugin,
+            )
+        )
+        register_all_tools(registry, gee_tools)
+        collected.extend(gee_tools)
     if extra_tools:
         register_all_tools(registry, extra_tools)
         collected.extend(extra_tools)
@@ -299,10 +328,65 @@ def for_nasa_opera(
     )
 
 
+def for_gee_data_catalogs(
+    iface: Any,
+    project: Any = None,
+    *,
+    plugin: Any | None = None,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+    include_qgis: bool = True,
+) -> GeoAgent:
+    """Bind an agent to the QGIS GEE Data Catalogs plugin runtime.
+
+    The factory exposes native GEE Data Catalogs tools and, by default, the
+    general QGIS map/project tools used for navigation and layer management.
+    """
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={
+            "integration": "gee_data_catalogs",
+            "system_prompt": GEE_DATA_CATALOGS_SYSTEM_PROMPT,
+        },
+    )
+    tools, registry = assemble_tools(
+        context=ctx,
+        include_qgis=include_qgis,
+        include_gee_data_catalogs=True,
+        gee_data_catalogs_plugin=plugin,
+        extra_tools=extra_tools,
+        fast=fast,
+    )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+        qgis_safe_mode=True,
+    )
+
+
 __all__ = [
     "assemble_tools",
     "create_agent",
     "for_anymap",
+    "for_gee_data_catalogs",
     "for_leafmap",
     "for_nasa_opera",
     "for_qgis",

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -1,8 +1,15 @@
 """Environment-specific tool factories."""
 
 from geoagent.tools.anymap import anymap_tools
+from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
 from geoagent.tools.leafmap import leafmap_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 
-__all__ = ["anymap_tools", "leafmap_tools", "nasa_opera_tools", "qgis_tools"]
+__all__ = [
+    "anymap_tools",
+    "gee_data_catalogs_tools",
+    "leafmap_tools",
+    "nasa_opera_tools",
+    "qgis_tools",
+]

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -111,20 +111,11 @@ def _build_vis_params(
 
 def gee_data_catalogs_tools(
     iface: Any,
-    project: Optional[Any] = None,
     plugin: Optional[Any] = None,
 ) -> list[Any]:
     """Return GeoAgent tools for the QGIS GEE Data Catalogs plugin."""
     if iface is None:
         return []
-
-    def _project() -> Any:
-        """Return the bound or singleton QGIS project."""
-        if project is not None:
-            return project
-        from qgis.core import QgsProject  # type: ignore[import-not-found]
-
-        return QgsProject.instance()
 
     def _ensure_plugin_catalog_dock() -> Any | None:
         """Return a live plugin catalog dock when a plugin instance was supplied."""
@@ -147,6 +138,7 @@ def gee_data_catalogs_tools(
         category="gee_data_catalogs",
         name="search_gee_datasets",
         available_in=("full", "fast"),
+        requires_packages=("gee_data_catalogs",),
     )
     def search_gee_datasets(
         query: str = "",
@@ -177,6 +169,7 @@ def gee_data_catalogs_tools(
         category="gee_data_catalogs",
         name="get_gee_dataset_info",
         available_in=("full", "fast"),
+        requires_packages=("gee_data_catalogs",),
     )
     def get_gee_dataset_info(
         asset_id: str,
@@ -196,6 +189,7 @@ def gee_data_catalogs_tools(
         category="gee_data_catalogs",
         name="summarize_gee_catalog",
         available_in=("full", "fast"),
+        requires_packages=("gee_data_catalogs",),
     )
     def summarize_gee_catalog(include_community: bool = True) -> dict[str, Any]:
         """Summarize dataset counts by catalog category."""
@@ -214,6 +208,7 @@ def gee_data_catalogs_tools(
         category="gee_data_catalogs",
         name="initialize_earth_engine",
         requires_confirmation=True,
+        requires_packages=("gee_data_catalogs",),
     )
     def initialize_earth_engine(project_id: Optional[str] = None) -> dict[str, Any]:
         """Initialize Earth Engine using the plugin utility and saved project id."""
@@ -231,6 +226,7 @@ def gee_data_catalogs_tools(
         name="load_gee_dataset",
         requires_confirmation=True,
         long_running=True,
+        requires_packages=("gee_data_catalogs", "ee"),
     )
     def load_gee_dataset(
         asset_id: str,

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -109,6 +109,33 @@ def _build_vis_params(
     return vis_params
 
 
+def _coerce_filter_value(value: str) -> Any:
+    """Convert simple string filter values to scalar Earth Engine values."""
+    text = str(value).strip()
+    if text.lower() == "true":
+        return True
+    if text.lower() == "false":
+        return False
+    try:
+        if "." not in text:
+            return int(text)
+        return float(text)
+    except ValueError:
+        return text
+
+
+def _default_index_palette(index_name: str) -> list[str]:
+    """Return a useful visualization palette for common normalized indexes."""
+    key = index_name.strip().upper()
+    if key in {"NDVI", "SAVI", "EVI"}:
+        return ["8c510a", "f6e8c3", "f5f5f5", "c7eae5", "01665e"]
+    if key in {"NDWI", "MNDWI", "NDMI"}:
+        return ["8c510a", "f7f7f7", "2166ac"]
+    if key in {"NBR", "NBR2"}:
+        return ["d7191c", "fdae61", "ffffbf", "a6d96a", "1a9641"]
+    return ["d73027", "f7f7f7", "1a9850"]
+
+
 def gee_data_catalogs_tools(
     iface: Any,
     plugin: Optional[Any] = None,
@@ -242,6 +269,9 @@ def gee_data_catalogs_tools(
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
         palette: Optional[str] = None,
+        clip_collection_asset_id: Optional[str] = None,
+        clip_filter_property: Optional[str] = None,
+        clip_filter_value: Optional[str] = None,
     ) -> dict[str, Any]:
         """Load a GEE Image, ImageCollection, or FeatureCollection into QGIS.
 
@@ -260,6 +290,13 @@ def gee_data_catalogs_tools(
             min_value: Optional visualization minimum.
             max_value: Optional visualization maximum.
             palette: Optional comma-separated colors or palette entries.
+            clip_collection_asset_id: Optional FeatureCollection asset id used
+                to clip raster outputs with ``ee.Image.clipToCollection``.
+                Example: TIGER/2018/States.
+            clip_filter_property: Optional property to filter the clipping
+                FeatureCollection before clipping. Example: NAME.
+            clip_filter_value: Optional value for ``clip_filter_property``.
+                Example: Tennessee.
         """
 
         def _run() -> dict[str, Any]:
@@ -279,6 +316,16 @@ def gee_data_catalogs_tools(
             resolved_type = asset_type or detect_asset_type(asset_id)
             name = layer_name or asset_id.split("/")[-1]
             parsed_bbox = _parse_bbox(bbox)
+            clip_collection = None
+            if clip_collection_asset_id:
+                clip_collection = ee.FeatureCollection(clip_collection_asset_id)
+                if clip_filter_property and clip_filter_value is not None:
+                    clip_collection = clip_collection.filter(
+                        ee.Filter.eq(
+                            clip_filter_property,
+                            _coerce_filter_value(clip_filter_value),
+                        )
+                    )
 
             if resolved_type == "ImageCollection":
                 collection = ee.ImageCollection(asset_id)
@@ -317,7 +364,10 @@ def gee_data_catalogs_tools(
                     palette=palette,
                 )
 
-            layer = add_ee_layer(ee_object, vis_params, name[:50])
+            if clip_collection is not None and resolved_type != "FeatureCollection":
+                ee_object = ee.Image(ee_object).clipToCollection(clip_collection)
+
+            add_ee_layer(ee_object, vis_params, name[:50])
             try:
                 iface.mapCanvas().refresh()
             except Exception:
@@ -328,6 +378,176 @@ def gee_data_catalogs_tools(
                 "asset_type": resolved_type,
                 "layer_name": name[:50],
                 "vis_params": vis_params,
+                "clip": (
+                    {
+                        "collection_asset_id": clip_collection_asset_id,
+                        "filter_property": clip_filter_property,
+                        "filter_value": clip_filter_value,
+                        "method": "ee.Image.clipToCollection",
+                    }
+                    if clip_collection_asset_id
+                    else None
+                ),
+            }
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="calculate_gee_normalized_difference",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("gee_data_catalogs", "ee"),
+    )
+    def calculate_gee_normalized_difference(
+        asset_id: str,
+        positive_band: str,
+        negative_band: str,
+        index_name: str = "NDVI",
+        layer_name: Optional[str] = None,
+        asset_type: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        bbox: Optional[str] = None,
+        cloud_cover: Optional[int] = None,
+        cloud_property: Optional[str] = None,
+        reducer: str = "median",
+        min_value: float = -1.0,
+        max_value: float = 1.0,
+        palette: Optional[str] = None,
+        clip_collection_asset_id: Optional[str] = None,
+        clip_filter_property: Optional[str] = None,
+        clip_filter_value: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Calculate and load a normalized difference index image.
+
+        The index is computed server-side as
+        ``ee.Image.normalizedDifference([positive_band, negative_band])`` and
+        renamed to ``index_name`` before display.
+
+        Args:
+            asset_id: Earth Engine Image or ImageCollection asset id.
+            positive_band: Numerator-positive band. NDVI example: NIR band.
+            negative_band: Numerator-negative band. NDVI example: red band.
+            index_name: Output band/index name, such as NDVI, NDWI, MNDWI, NBR.
+            layer_name: Optional QGIS layer name.
+            asset_type: Optional explicit type: Image or ImageCollection.
+            start_date: Optional ImageCollection start date in YYYY-MM-DD.
+            end_date: Optional ImageCollection end date in YYYY-MM-DD.
+            bbox: Optional WGS84 west,south,east,north ImageCollection filter.
+            cloud_cover: Optional maximum cloud-cover value.
+            cloud_property: Optional cloud-cover property name.
+            reducer: ImageCollection reducer: mosaic, median, mean, min, max, first.
+            min_value: Visualization minimum. Defaults to -1.
+            max_value: Visualization maximum. Defaults to 1.
+            palette: Optional comma-separated colors. Defaults by index type.
+            clip_collection_asset_id: Optional FeatureCollection asset id used
+                to clip the index image with ``ee.Image.clipToCollection``.
+            clip_filter_property: Optional property to filter the clipping
+                FeatureCollection before clipping. Example: NAME.
+            clip_filter_value: Optional value for ``clip_filter_property``.
+                Example: Tennessee.
+
+        Common band examples:
+            Sentinel-2 or HLS S30 NDVI: positive_band=B8, negative_band=B4.
+            Landsat 8/9 NDVI: positive_band=SR_B5, negative_band=SR_B4.
+            Sentinel-2 NDWI: positive_band=B3, negative_band=B8.
+            Sentinel-2 MNDWI: positive_band=B3, negative_band=B11.
+            Sentinel-2 NBR: positive_band=B8, negative_band=B12.
+        """
+
+        def _run() -> dict[str, Any]:
+            import ee
+
+            from gee_data_catalogs.core.ee_utils import (
+                add_ee_layer,
+                detect_asset_type,
+                filter_image_collection,
+                initialize_ee,
+                is_ee_initialized,
+            )
+
+            if not is_ee_initialized():
+                initialize_ee(project=_project_id_from_settings())
+
+            resolved_type = asset_type or detect_asset_type(asset_id)
+            if resolved_type == "FeatureCollection":
+                raise ValueError(
+                    "Normalized difference indexes require an Image or ImageCollection."
+                )
+
+            parsed_bbox = _parse_bbox(bbox)
+            clip_collection = None
+            if clip_collection_asset_id:
+                clip_collection = ee.FeatureCollection(clip_collection_asset_id)
+                if clip_filter_property and clip_filter_value is not None:
+                    clip_collection = clip_collection.filter(
+                        ee.Filter.eq(
+                            clip_filter_property,
+                            _coerce_filter_value(clip_filter_value),
+                        )
+                    )
+
+            if resolved_type == "ImageCollection":
+                collection = ee.ImageCollection(asset_id)
+                if start_date or end_date or parsed_bbox or cloud_cover is not None:
+                    collection = filter_image_collection(
+                        collection,
+                        start_date=start_date,
+                        end_date=end_date,
+                        bbox=parsed_bbox,
+                        cloud_cover=cloud_cover,
+                        cloud_property=cloud_property or "CLOUDY_PIXEL_PERCENTAGE",
+                    )
+                method = reducer.lower().strip()
+                if method not in {"mosaic", "median", "mean", "min", "max", "first"}:
+                    method = "median"
+                source_image = getattr(collection, method)()
+                resolved_type = "ImageCollection"
+            else:
+                source_image = ee.Image(asset_id)
+                resolved_type = "Image"
+
+            output_name = index_name.strip() or "ND"
+            index_image = source_image.normalizedDifference(
+                [positive_band, negative_band]
+            ).rename(output_name)
+            if clip_collection is not None:
+                index_image = ee.Image(index_image).clipToCollection(clip_collection)
+
+            vis_params = _build_vis_params(
+                bands=output_name,
+                min_value=min_value,
+                max_value=max_value,
+                palette=palette or _default_index_palette(output_name),
+            )
+            name = layer_name or f"{asset_id.split('/')[-1]} {output_name}"
+            add_ee_layer(index_image, vis_params, name[:50])
+            try:
+                iface.mapCanvas().refresh()
+            except Exception:
+                pass
+            return {
+                "success": True,
+                "asset_id": asset_id,
+                "asset_type": resolved_type,
+                "layer_name": name[:50],
+                "index_name": output_name,
+                "formula": f"({positive_band} - {negative_band}) / "
+                f"({positive_band} + {negative_band})",
+                "bands": [positive_band, negative_band],
+                "reducer": reducer if resolved_type == "ImageCollection" else None,
+                "vis_params": vis_params,
+                "clip": (
+                    {
+                        "collection_asset_id": clip_collection_asset_id,
+                        "filter_property": clip_filter_property,
+                        "filter_value": clip_filter_value,
+                        "method": "ee.Image.clipToCollection",
+                    }
+                    if clip_collection_asset_id
+                    else None
+                ),
             }
 
         return _on_gui(_run)
@@ -395,6 +615,7 @@ def gee_data_catalogs_tools(
         summarize_gee_catalog,
         initialize_earth_engine,
         load_gee_dataset,
+        calculate_gee_normalized_difference,
         open_gee_catalog_panel,
         configure_gee_dataset_load,
     ]

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -1,0 +1,407 @@
+"""Tool adapters for the QGIS GEE Data Catalogs plugin.
+
+The module is import-safe outside QGIS and outside the plugin. Tool bodies
+resolve ``gee_data_catalogs`` lazily so GeoAgent can be imported in ordinary
+Python environments.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+
+def _on_gui(fn: Any) -> Any:
+    """Run ``fn`` on the Qt GUI thread when QGIS is available."""
+    return run_on_qt_gui_thread(fn)
+
+
+def _project_id_from_settings() -> str | None:
+    """Return the configured Earth Engine project id, if any."""
+    try:
+        from qgis.PyQt.QtCore import QSettings  # type: ignore[import-not-found]
+
+        project_id = QSettings().value("GeeDataCatalogs/ee_project", "", type=str)
+        project_id = project_id.strip() if project_id else ""
+        if project_id:
+            return project_id
+    except Exception:
+        pass
+    return os.environ.get("EE_PROJECT_ID") or None
+
+
+def _compact_dataset(dataset: dict[str, Any]) -> dict[str, Any]:
+    """Return a concise, JSON-friendly catalog record."""
+    keys = [
+        "id",
+        "name",
+        "title",
+        "type",
+        "category",
+        "provider",
+        "start_date",
+        "end_date",
+        "source",
+        "url",
+        "license",
+        "bigquery_table",
+    ]
+    out = {key: dataset.get(key) for key in keys if dataset.get(key)}
+    description = str(dataset.get("description", "")).strip()
+    if description:
+        out["description"] = description[:500]
+    keywords = dataset.get("keywords")
+    if keywords:
+        out["keywords"] = keywords[:15] if isinstance(keywords, list) else keywords
+    return out
+
+
+def _parse_list(value: str | list[str] | None) -> list[str] | None:
+    """Parse comma-separated UI-style values into a list."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def _parse_bbox(
+    bbox: str | list[float] | tuple[float, ...] | None,
+) -> list[float] | None:
+    """Parse west,south,east,north bounds."""
+    if bbox is None or bbox == "":
+        return None
+    values = list(bbox) if isinstance(bbox, (list, tuple)) else str(bbox).split(",")
+    if len(values) != 4:
+        raise ValueError("bbox must contain west,south,east,north")
+    west, south, east, north = [float(value) for value in values]
+    if west >= east or south >= north:
+        raise ValueError("bbox coordinates must satisfy west < east and south < north")
+    return [west, south, east, north]
+
+
+def _build_vis_params(
+    *,
+    bands: str | list[str] | None = None,
+    min_value: float | int | None = None,
+    max_value: float | int | None = None,
+    palette: str | list[str] | None = None,
+    for_feature_collection: bool = False,
+) -> dict[str, Any]:
+    """Build Earth Engine visualization parameters from scalar inputs."""
+    vis_params: dict[str, Any] = {}
+    parsed_bands = _parse_list(bands)
+    if parsed_bands and not for_feature_collection:
+        vis_params["bands"] = parsed_bands
+    if min_value is not None and not for_feature_collection:
+        vis_params["min"] = float(min_value)
+    if max_value is not None and not for_feature_collection:
+        vis_params["max"] = float(max_value)
+    parsed_palette = _parse_list(palette)
+    if parsed_palette:
+        if for_feature_collection:
+            vis_params["color"] = parsed_palette[0]
+        else:
+            vis_params["palette"] = parsed_palette
+    return vis_params
+
+
+def gee_data_catalogs_tools(
+    iface: Any,
+    project: Optional[Any] = None,
+    plugin: Optional[Any] = None,
+) -> list[Any]:
+    """Return GeoAgent tools for the QGIS GEE Data Catalogs plugin."""
+    if iface is None:
+        return []
+
+    def _project() -> Any:
+        """Return the bound or singleton QGIS project."""
+        if project is not None:
+            return project
+        from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+        return QgsProject.instance()
+
+    def _ensure_plugin_catalog_dock() -> Any | None:
+        """Return a live plugin catalog dock when a plugin instance was supplied."""
+        if plugin is None:
+            return None
+
+        def _run() -> Any | None:
+            dock = getattr(plugin, "_catalog_dock", None)
+            if dock is None and hasattr(plugin, "_create_catalog_dock"):
+                plugin._create_catalog_dock()
+                dock = getattr(plugin, "_catalog_dock", None)
+            if dock is not None:
+                dock.show()
+                dock.raise_()
+            return dock
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="search_gee_datasets",
+        available_in=("full", "fast"),
+    )
+    def search_gee_datasets(
+        query: str = "",
+        category: Optional[str] = None,
+        data_type: Optional[str] = None,
+        source: Optional[str] = None,
+        max_results: int = 20,
+        include_community: bool = True,
+    ) -> dict[str, Any]:
+        """Search official and community Google Earth Engine data catalogs."""
+        from gee_data_catalogs.core.catalog_data import search_datasets
+
+        results = search_datasets(
+            query=query,
+            category=category,
+            data_type=data_type,
+            source=source,
+            include_community=include_community,
+        )
+        count = max(1, int(max_results))
+        return {
+            "count": len(results),
+            "shown": min(len(results), count),
+            "datasets": [_compact_dataset(item) for item in results[:count]],
+        }
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="get_gee_dataset_info",
+        available_in=("full", "fast"),
+    )
+    def get_gee_dataset_info(
+        asset_id: str,
+        include_community: bool = True,
+    ) -> dict[str, Any]:
+        """Return catalog metadata for a Google Earth Engine asset id."""
+        from gee_data_catalogs.core.catalog_data import get_dataset_info
+
+        dataset = get_dataset_info(asset_id, include_community=include_community)
+        if dataset is None:
+            return {"asset_id": asset_id, "found": False}
+        out = _compact_dataset(dataset)
+        out["found"] = True
+        return out
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="summarize_gee_catalog",
+        available_in=("full", "fast"),
+    )
+    def summarize_gee_catalog(include_community: bool = True) -> dict[str, Any]:
+        """Summarize dataset counts by catalog category."""
+        from gee_data_catalogs.core.catalog_data import get_catalog_data
+
+        catalog = get_catalog_data(include_community=include_community)
+        categories = []
+        total = 0
+        for category, payload in catalog.items():
+            datasets = payload.get("datasets", [])
+            total += len(datasets)
+            categories.append({"category": category, "count": len(datasets)})
+        return {"total_count": total, "categories": categories}
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="initialize_earth_engine",
+        requires_confirmation=True,
+    )
+    def initialize_earth_engine(project_id: Optional[str] = None) -> dict[str, Any]:
+        """Initialize Earth Engine using the plugin utility and saved project id."""
+        from gee_data_catalogs.core.ee_utils import initialize_ee, is_ee_initialized
+
+        project_to_use = project_id or _project_id_from_settings()
+        initialize_ee(project=project_to_use)
+        return {
+            "success": is_ee_initialized(),
+            "project_id": project_to_use,
+        }
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="load_gee_dataset",
+        requires_confirmation=True,
+        long_running=True,
+    )
+    def load_gee_dataset(
+        asset_id: str,
+        layer_name: Optional[str] = None,
+        asset_type: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        bbox: Optional[str] = None,
+        cloud_cover: Optional[int] = None,
+        cloud_property: Optional[str] = None,
+        reducer: str = "mosaic",
+        bands: Optional[str] = None,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+        palette: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Load a GEE Image, ImageCollection, or FeatureCollection into QGIS.
+
+        Args:
+            asset_id: Earth Engine asset id.
+            layer_name: Optional QGIS layer name.
+            asset_type: Optional explicit type: Image, ImageCollection, or
+                FeatureCollection. When omitted, the plugin detects the type.
+            start_date: Optional ImageCollection start date in YYYY-MM-DD.
+            end_date: Optional ImageCollection end date in YYYY-MM-DD.
+            bbox: Optional WGS84 west,south,east,north filter.
+            cloud_cover: Optional maximum cloud-cover value.
+            cloud_property: Optional cloud-cover property name.
+            reducer: ImageCollection reducer: mosaic, median, mean, min, max, first.
+            bands: Optional comma-separated visualization bands.
+            min_value: Optional visualization minimum.
+            max_value: Optional visualization maximum.
+            palette: Optional comma-separated colors or palette entries.
+        """
+
+        def _run() -> dict[str, Any]:
+            import ee
+
+            from gee_data_catalogs.core.ee_utils import (
+                add_ee_layer,
+                detect_asset_type,
+                filter_image_collection,
+                initialize_ee,
+                is_ee_initialized,
+            )
+
+            if not is_ee_initialized():
+                initialize_ee(project=_project_id_from_settings())
+
+            resolved_type = asset_type or detect_asset_type(asset_id)
+            name = layer_name or asset_id.split("/")[-1]
+            parsed_bbox = _parse_bbox(bbox)
+
+            if resolved_type == "ImageCollection":
+                collection = ee.ImageCollection(asset_id)
+                if start_date or end_date or parsed_bbox or cloud_cover is not None:
+                    collection = filter_image_collection(
+                        collection,
+                        start_date=start_date,
+                        end_date=end_date,
+                        bbox=parsed_bbox,
+                        cloud_cover=cloud_cover,
+                        cloud_property=cloud_property or "CLOUDY_PIXEL_PERCENTAGE",
+                    )
+                method = reducer.lower().strip()
+                if method not in {"mosaic", "median", "mean", "min", "max", "first"}:
+                    method = "mosaic"
+                ee_object = getattr(collection, method)()
+                vis_params = _build_vis_params(
+                    bands=bands,
+                    min_value=min_value,
+                    max_value=max_value,
+                    palette=palette,
+                )
+            elif resolved_type == "FeatureCollection":
+                ee_object = ee.FeatureCollection(asset_id)
+                vis_params = _build_vis_params(
+                    palette=palette,
+                    for_feature_collection=True,
+                )
+            else:
+                ee_object = ee.Image(asset_id)
+                resolved_type = "Image"
+                vis_params = _build_vis_params(
+                    bands=bands,
+                    min_value=min_value,
+                    max_value=max_value,
+                    palette=palette,
+                )
+
+            layer = add_ee_layer(ee_object, vis_params, name[:50])
+            try:
+                iface.mapCanvas().refresh()
+            except Exception:
+                pass
+            return {
+                "success": True,
+                "asset_id": asset_id,
+                "asset_type": resolved_type,
+                "layer_name": name[:50],
+                "vis_params": vis_params,
+            }
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="open_gee_catalog_panel",
+        available_in=("full", "fast"),
+    )
+    def open_gee_catalog_panel(tab: str = "Search") -> dict[str, Any]:
+        """Open the GEE Data Catalogs panel and optionally select a tab."""
+        dock = _ensure_plugin_catalog_dock()
+        if dock is None:
+            return {"success": False, "error": "Plugin instance is not available."}
+
+        def _run() -> dict[str, Any]:
+            names = []
+            tab_widget = getattr(dock, "tab_widget", None)
+            if tab_widget is not None:
+                for i in range(tab_widget.count()):
+                    names.append(tab_widget.tabText(i))
+                    if tab_widget.tabText(i).lower() == tab.lower():
+                        tab_widget.setCurrentIndex(i)
+            return {"success": True, "tabs": names}
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="configure_gee_dataset_load",
+        available_in=("full", "fast"),
+    )
+    def configure_gee_dataset_load(
+        asset_id: str,
+        layer_name: Optional[str] = None,
+        bands: Optional[str] = None,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+        palette: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Populate the plugin Load tab for a dataset without loading it."""
+        dock = _ensure_plugin_catalog_dock()
+        if dock is None:
+            return {"success": False, "error": "Plugin instance is not available."}
+
+        def _run() -> dict[str, Any]:
+            dock.dataset_id_input.setText(asset_id)
+            dock.layer_name_input.setText(layer_name or asset_id.split("/")[-1])
+            if bands is not None:
+                dock.bands_input.setText(bands)
+            if min_value is not None:
+                dock.vis_min_input.setText(str(min_value))
+            if max_value is not None:
+                dock.vis_max_input.setText(str(max_value))
+            if palette is not None:
+                dock.palette_input.setText(palette)
+            dock.tab_widget.setCurrentIndex(3)
+            return {"success": True, "asset_id": asset_id}
+
+        return _on_gui(_run)
+
+    return [
+        search_gee_datasets,
+        get_gee_dataset_info,
+        summarize_gee_catalog,
+        initialize_earth_engine,
+        load_gee_dataset,
+        open_gee_catalog_panel,
+        configure_gee_dataset_load,
+    ]
+
+
+__all__ = ["gee_data_catalogs_tools"]

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -36,6 +36,8 @@ DEFAULT_MODELS = {
     "litellm": "openai/gpt-5.5",
 }
 PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama", "litellm"]
+MAX_CONTEXT_MESSAGES = 12
+MAX_CONTEXT_CHARS = 12000
 SAMPLE_PROMPTS = [
     "Summarize the current QGIS project layers, CRS, extents, and feature counts.",
     "Zoom to the active layer and describe what it contains.",
@@ -444,6 +446,7 @@ class ChatDockWidget(QDockWidget):
         model_id = self.model_input.text().strip()
         fast = self.fast_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        prompt_with_context = self._build_prompt_with_context(prompt)
 
         self._append_message("You", prompt, markdown=False)
         self.prompt_input.clear()
@@ -452,10 +455,44 @@ class ChatDockWidget(QDockWidget):
         self.send_btn.setEnabled(False)
 
         self._worker = ChatWorker(
-            self.iface, prompt, provider, model_id, fast, max_tokens, self
+            self.iface,
+            prompt_with_context,
+            provider,
+            model_id,
+            fast,
+            max_tokens,
+            self,
         )
         self._worker.finished.connect(self._on_worker_finished)
         self._worker.start()
+
+    def _build_prompt_with_context(self, prompt):
+        """Include recent chat transcript so follow-up turns have context."""
+        if not self._messages:
+            return prompt
+
+        history_lines = []
+        for msg in self._messages[-MAX_CONTEXT_MESSAGES:]:
+            body = msg.get("body", "").strip()
+            if not body:
+                continue
+            role = "User" if msg.get("sender") == "You" else "Assistant"
+            history_lines.append(f"{role}: {body}")
+
+        if not history_lines:
+            return prompt
+
+        history = "\n\n".join(history_lines)
+        if len(history) > MAX_CONTEXT_CHARS:
+            history = history[-MAX_CONTEXT_CHARS:]
+            history = f"[Earlier history truncated]\n{history}"
+
+        return (
+            "Use the recent conversation history for context. The current user "
+            "request is the authoritative request to answer now.\n\n"
+            f"Recent conversation:\n{history}\n\n"
+            f"Current user request:\n{prompt}"
+        )
 
     def _select_sample_prompt(self, prompt):
         """Copy the selected sample prompt into the editor."""

--- a/tests/test_gee_data_catalogs_tools.py
+++ b/tests/test_gee_data_catalogs_tools.py
@@ -1,0 +1,59 @@
+"""Tests for the GEE Data Catalogs GeoAgent tool factory."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from geoagent import for_gee_data_catalogs
+from geoagent.testing import MockQGISIface, MockQGISProject
+from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
+
+
+class _MockModel:
+    """Provide a test double for MockModel."""
+
+    stateful = False
+
+
+def test_gee_data_catalogs_module_imports_without_qgis() -> None:
+    """Verify GEE Data Catalogs tools are import-safe outside QGIS."""
+    if "qgis" in sys.modules:
+        pytest.skip("qgis is already imported in this environment.")
+    assert "geoagent.tools.gee_data_catalogs" in sys.modules
+    assert "qgis" not in sys.modules
+    assert "gee_data_catalogs" not in sys.modules
+
+
+def test_gee_data_catalogs_tools_returns_empty_for_none_iface() -> None:
+    """Verify the GEE Data Catalogs factory returns no tools without iface."""
+    assert gee_data_catalogs_tools(None) == []
+
+
+def test_gee_data_catalogs_tools_expose_catalog_surface() -> None:
+    """Verify the plugin-specific tool surface is registered."""
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(object())}
+
+    assert "search_gee_datasets" in tools
+    assert "get_gee_dataset_info" in tools
+    assert "summarize_gee_catalog" in tools
+    assert "initialize_earth_engine" in tools
+    assert "load_gee_dataset" in tools
+    assert "open_gee_catalog_panel" in tools
+    assert "configure_gee_dataset_load" in tools
+
+
+def test_for_gee_data_catalogs_registers_catalog_and_qgis_tools() -> None:
+    """Verify the GEE factory combines catalog and QGIS tool surfaces."""
+    agent = for_gee_data_catalogs(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    names = set(agent.strands_agent.tool_names)
+
+    assert "search_gee_datasets" in names
+    assert "load_gee_dataset" in names
+    assert "list_project_layers" in names
+    assert agent.context.metadata["integration"] == "gee_data_catalogs"

--- a/tests/test_gee_data_catalogs_tools.py
+++ b/tests/test_gee_data_catalogs_tools.py
@@ -53,7 +53,7 @@ def test_for_gee_data_catalogs_registers_catalog_and_qgis_tools() -> None:
     )
     names = set(agent.strands_agent.tool_names)
 
-    assert "search_gee_datasets" in names
-    assert "load_gee_dataset" in names
+    assert "open_gee_catalog_panel" in names
+    assert "configure_gee_dataset_load" in names
     assert "list_project_layers" in names
     assert agent.context.metadata["integration"] == "gee_data_catalogs"

--- a/tests/test_gee_data_catalogs_tools.py
+++ b/tests/test_gee_data_catalogs_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from types import ModuleType
 
 import pytest
 
@@ -40,6 +41,7 @@ def test_gee_data_catalogs_tools_expose_catalog_surface() -> None:
     assert "summarize_gee_catalog" in tools
     assert "initialize_earth_engine" in tools
     assert "load_gee_dataset" in tools
+    assert "calculate_gee_normalized_difference" in tools
     assert "open_gee_catalog_panel" in tools
     assert "configure_gee_dataset_load" in tools
 
@@ -57,3 +59,197 @@ def test_for_gee_data_catalogs_registers_catalog_and_qgis_tools() -> None:
     assert "configure_gee_dataset_load" in names
     assert "list_project_layers" in names
     assert agent.context.metadata["integration"] == "gee_data_catalogs"
+
+
+def test_load_gee_dataset_clips_raster_to_feature_collection(monkeypatch) -> None:
+    """Verify raster clipping uses ee.Image.clipToCollection."""
+
+    class _Canvas:
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        def refresh(self) -> None:
+            self.refreshed = True
+
+    class _Iface:
+        def __init__(self) -> None:
+            self.canvas = _Canvas()
+
+        def mapCanvas(self) -> _Canvas:
+            return self.canvas
+
+    class _FakeFeatureCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.filters = []
+
+        def filter(self, filter_obj):
+            self.filters.append(filter_obj)
+            return self
+
+    class _FakeImage:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.clipped_to = None
+
+        def clipToCollection(self, feature_collection):
+            self.clipped_to = feature_collection
+            return self
+
+    class _FakeFilter:
+        @staticmethod
+        def eq(prop: str, value: object):
+            return ("eq", prop, value)
+
+    ee_module = ModuleType("ee")
+    ee_module.Filter = _FakeFilter
+    ee_module.FeatureCollection = _FakeFeatureCollection
+    ee_module.Image = lambda value: (
+        value if isinstance(value, _FakeImage) else _FakeImage(value)
+    )
+
+    captured = {}
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.add_ee_layer = lambda obj, vis, name: captured.update(
+        {"object": obj, "vis": vis, "name": name}
+    )
+    ee_utils.detect_asset_type = lambda asset_id: "Image"
+    ee_utils.filter_image_collection = lambda collection, **kwargs: collection
+    ee_utils.initialize_ee = lambda project=None: None
+    ee_utils.is_ee_initialized = lambda: True
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    iface = _Iface()
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(iface)}
+    result = tools["load_gee_dataset"].__wrapped__(
+        "JRC/GSW1_4/GlobalSurfaceWater",
+        bands="occurrence",
+        min_value=0,
+        max_value=100,
+        palette="white,blue",
+        clip_collection_asset_id="TIGER/2018/States",
+        clip_filter_property="NAME",
+        clip_filter_value="Tennessee",
+    )
+
+    loaded = captured["object"]
+    assert result["success"] is True
+    assert result["clip"]["method"] == "ee.Image.clipToCollection"
+    assert result["clip"]["collection_asset_id"] == "TIGER/2018/States"
+    assert loaded.clipped_to.asset_id == "TIGER/2018/States"
+    assert loaded.clipped_to.filters == [("eq", "NAME", "Tennessee")]
+    assert captured["vis"]["bands"] == ["occurrence"]
+    assert iface.canvas.refreshed is True
+
+
+def test_calculate_gee_normalized_difference_loads_index(monkeypatch) -> None:
+    """Verify normalized difference indexes use Earth Engine band math."""
+
+    class _Canvas:
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        def refresh(self) -> None:
+            self.refreshed = True
+
+    class _Iface:
+        def __init__(self) -> None:
+            self.canvas = _Canvas()
+
+        def mapCanvas(self) -> _Canvas:
+            return self.canvas
+
+    class _FakeFeatureCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.filters = []
+
+        def filter(self, filter_obj):
+            self.filters.append(filter_obj)
+            return self
+
+    class _FakeImage:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.normalized_bands = None
+            self.name = None
+            self.clipped_to = None
+
+        def normalizedDifference(self, bands):
+            self.normalized_bands = list(bands)
+            return self
+
+        def rename(self, name: str):
+            self.name = name
+            return self
+
+        def clipToCollection(self, feature_collection):
+            self.clipped_to = feature_collection
+            return self
+
+    class _FakeFilter:
+        @staticmethod
+        def eq(prop: str, value: object):
+            return ("eq", prop, value)
+
+    ee_module = ModuleType("ee")
+    ee_module.Filter = _FakeFilter
+    ee_module.FeatureCollection = _FakeFeatureCollection
+    ee_module.Image = lambda value: (
+        value if isinstance(value, _FakeImage) else _FakeImage(value)
+    )
+
+    captured = {}
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.add_ee_layer = lambda obj, vis, name: captured.update(
+        {"object": obj, "vis": vis, "name": name}
+    )
+    ee_utils.detect_asset_type = lambda asset_id: "Image"
+    ee_utils.filter_image_collection = lambda collection, **kwargs: collection
+    ee_utils.initialize_ee = lambda project=None: None
+    ee_utils.is_ee_initialized = lambda: True
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    iface = _Iface()
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(iface)}
+    result = tools["calculate_gee_normalized_difference"].__wrapped__(
+        "NASA/HLS/HLSS30/v002",
+        positive_band="B8",
+        negative_band="B4",
+        index_name="NDVI",
+        layer_name="HLS S2 NDVI",
+        clip_collection_asset_id="TIGER/2018/States",
+        clip_filter_property="NAME",
+        clip_filter_value="Tennessee",
+    )
+
+    loaded = captured["object"]
+    assert result["success"] is True
+    assert result["formula"] == "(B8 - B4) / (B8 + B4)"
+    assert result["bands"] == ["B8", "B4"]
+    assert loaded.normalized_bands == ["B8", "B4"]
+    assert loaded.name == "NDVI"
+    assert loaded.clipped_to.asset_id == "TIGER/2018/States"
+    assert captured["name"] == "HLS S2 NDVI"
+    assert captured["vis"]["bands"] == ["NDVI"]
+    assert captured["vis"]["min"] == -1.0
+    assert captured["vis"]["max"] == 1.0
+    assert iface.canvas.refreshed is True


### PR DESCRIPTION
## Summary
- Add `gee_data_catalogs_tools` for the QGIS Google Earth Engine Data Catalogs plugin (dataset search, metadata, EE init, layer loading).
- Add `for_gee_data_catalogs` factory that binds a `GeoAgent` to the GEE Data Catalogs plugin runtime, with QGIS map/project tools enabled by default.
- Wire the factory and tool module through `geoagent/__init__.py`, `geoagent/core/factory.py`, and `geoagent/tools/__init__.py`, and add unit coverage in `tests/test_gee_data_catalogs_tools.py`.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/ -q` (70 passed)