### PR TITLE
feat: add NASA Earthdata QGIS tool factory

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -26,6 +26,7 @@ from geoagent.core.factory import (
     for_anymap,
     for_gee_data_catalogs,
     for_leafmap,
+    for_nasa_earthdata,
     for_nasa_opera,
     for_qgis,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "for_anymap",
     "for_gee_data_catalogs",
     "for_leafmap",
+    "for_nasa_earthdata",
     "for_nasa_opera",
     "for_qgis",
     "geo_tool",

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -154,17 +154,29 @@ class GeoAgent:
             return other.chat(query)
 
         if (
-            self._context.metadata.get("integration") == "nasa_opera"
+            self._context.metadata.get("integration")
+            in {"nasa_earthdata", "nasa_opera"}
             and self._qgis_safe_mode
             and is_qt_gui_thread()
         ):
+            integration = self._context.metadata.get("integration")
+            label = (
+                "NASA Earthdata" if integration == "nasa_earthdata" else "NASA OPERA"
+            )
+            helper = (
+                "the NASA Earthdata AI Assistant panel"
+                if integration == "nasa_earthdata"
+                else (
+                    "the NASA OPERA AI Assistant panel or "
+                    "geoagent.tools.nasa_opera.submit_nasa_opera_search_task(...) "
+                    "for direct QGIS-console workflows"
+                )
+            )
             return GeoAgentResponse(
                 success=False,
                 error_message=(
-                    "NASA OPERA chat should be launched from a worker thread inside "
-                    "QGIS. Use the NASA OPERA AI Assistant panel or "
-                    "geoagent.tools.nasa_opera.submit_nasa_opera_search_task(...) "
-                    "for direct QGIS-console workflows."
+                    f"{label} chat should be launched from a worker thread inside "
+                    f"QGIS. Use {helper}."
                 ),
                 map=self._context.map_obj,
             )

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -16,8 +16,27 @@ from geoagent.core.agent import GeoAgent
 from geoagent.tools.anymap import anymap_tools
 from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
 from geoagent.tools.leafmap import leafmap_tools
+from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
+
+NASA_EARTHDATA_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS for the NASA Earthdata plugin.
+Use the NASA Earthdata tools to search the dataset catalog, search CMR
+granules, display footprints, and load raster assets into the current QGIS
+project.
+
+Workflow guidance:
+- Search the catalog first when the user names a topic rather than an exact
+  NASA Earthdata short name.
+- If the user gives no location, use the current QGIS map extent.
+- Search granules before displaying footprints or loading rasters.
+- For raster display, choose a specific COG or GeoTIFF data link from search
+  results. Loading data can download protected assets and requires user
+  confirmation.
+- Keep responses concise and include dataset short names, result counts,
+  date ranges, and relevant first-result identifiers when available.
+"""
 
 NASA_OPERA_SYSTEM_PROMPT = """\
 You are an AI assistant embedded in QGIS for NASA OPERA satellite data.
@@ -94,8 +113,10 @@ def assemble_tools(
     include_leafmap: bool = False,
     include_anymap: bool = False,
     include_qgis: bool = False,
+    include_nasa_earthdata: bool = False,
     include_nasa_opera: bool = False,
     include_gee_data_catalogs: bool = False,
+    nasa_earthdata_plugin: Any | None = None,
     gee_data_catalogs_plugin: Any | None = None,
     fast: bool = False,
 ) -> tuple[list[Any], GeoToolRegistry]:
@@ -114,6 +135,16 @@ def assemble_tools(
         qt = _filter_by_imports(qgis_tools(context.qgis_iface, context.qgis_project))
         register_all_tools(registry, qt)
         collected.extend(qt)
+    if include_nasa_earthdata:
+        earthdata_tool_list = _filter_by_imports(
+            earthdata_tools(
+                context.qgis_iface,
+                context.qgis_project,
+                plugin=nasa_earthdata_plugin,
+            )
+        )
+        register_all_tools(registry, earthdata_tool_list)
+        collected.extend(earthdata_tool_list)
     if include_nasa_opera:
         opera_tools = _filter_by_imports(
             nasa_opera_tools(context.qgis_iface, context.qgis_project)
@@ -336,6 +367,60 @@ def for_nasa_opera(
     )
 
 
+def for_nasa_earthdata(
+    iface: Any,
+    project: Any = None,
+    *,
+    plugin: Any | None = None,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+    include_qgis: bool = True,
+) -> GeoAgent:
+    """Bind an agent to the NASA Earthdata QGIS plugin runtime.
+
+    The factory exposes native NASA Earthdata tools and, by default, the
+    general QGIS map/project tools used for navigation and layer management.
+    """
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={
+            "integration": "nasa_earthdata",
+            "system_prompt": NASA_EARTHDATA_SYSTEM_PROMPT,
+        },
+    )
+    tools, registry = assemble_tools(
+        context=ctx,
+        include_qgis=include_qgis,
+        include_nasa_earthdata=True,
+        nasa_earthdata_plugin=plugin,
+        extra_tools=extra_tools,
+        fast=fast,
+    )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+        qgis_safe_mode=True,
+    )
+
+
 def for_gee_data_catalogs(
     iface: Any,
     project: Any = None,
@@ -396,6 +481,7 @@ __all__ = [
     "for_anymap",
     "for_gee_data_catalogs",
     "for_leafmap",
+    "for_nasa_earthdata",
     "for_nasa_opera",
     "for_qgis",
     "register_all_tools",

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -3,11 +3,13 @@
 from geoagent.tools.anymap import anymap_tools
 from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
 from geoagent.tools.leafmap import leafmap_tools
+from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 
 __all__ = [
     "anymap_tools",
+    "earthdata_tools",
     "gee_data_catalogs_tools",
     "leafmap_tools",
     "nasa_opera_tools",

--- a/geoagent/tools/nasa_earthdata.py
+++ b/geoagent/tools/nasa_earthdata.py
@@ -1,24 +1,554 @@
-"""Optional NASA Earthdata tools — placeholder.
+"""Tool adapters for the NASA Earthdata QGIS plugin.
 
-Earthdata integrations are deferred and will return in a later milestone.
-:func:`earthdata_tools` always returns ``[]`` regardless of whether
-``earthaccess`` is installed; the import probe is kept so the placeholder
-can be evolved into a real factory without changing the call site.
+The module is import-safe outside QGIS and outside the plugin. Tool bodies
+resolve QGIS, earthaccess, and plugin UI objects lazily so ordinary GeoAgent
+imports keep working in non-QGIS environments.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import csv
+import json
+import os
+import tempfile
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+NASA_DATA_URL = (
+    "https://github.com/opengeos/NASA-Earth-Data/raw/main/nasa_earth_data.tsv"
+)
 
 
-def earthdata_tools() -> list[Any]:
-    """Return ``[]`` (placeholder until Earthdata tools are reintroduced).
+def _on_gui(fn: Any) -> Any:
+    """Run ``fn`` on the Qt GUI thread when QGIS is available."""
+    return run_on_qt_gui_thread(fn)
 
-    The empty list is intentional even when ``earthaccess`` imports
-    successfully; treat this factory as a stub. See module docstring.
-    """
+
+def _catalog_url_from_settings() -> str:
+    """Return the plugin-configured catalog URL or the built-in default."""
     try:
-        import earthaccess  # noqa: F401
-    except ImportError:
+        from qgis.PyQt.QtCore import QSettings  # type: ignore[import-not-found]
+
+        value = QSettings().value("NASAEarthdata/catalog_url", "", type=str)
+        value = value.strip() if value else ""
+        if value:
+            return value
+    except Exception:
+        pass
+    return NASA_DATA_URL
+
+
+def _load_catalog_rows(catalog_url: str | None = None) -> list[dict[str, str]]:
+    """Load NASA Earthdata catalog rows from the TSV catalog."""
+    url = catalog_url or _catalog_url_from_settings()
+    if not str(url).lower().startswith("https://"):
+        raise ValueError("NASA Earthdata catalog URL must use HTTPS.")
+    with urlopen(url, timeout=30) as response:  # nosec B310 - HTTPS enforced above
+        text = response.read().decode("utf-8")
+    return list(csv.DictReader(text.splitlines(), delimiter="\t"))
+
+
+def _compact_catalog_row(row: dict[str, str]) -> dict[str, str]:
+    """Return a compact, JSON-friendly catalog row."""
+    keys = [
+        "ShortName",
+        "EntryTitle",
+        "Platform",
+        "Instrument",
+        "ProcessingLevel",
+        "Provider",
+        "StartTime",
+        "EndTime",
+        "OnlineAccessURLs",
+    ]
+    out = {key: row.get(key, "") for key in keys if row.get(key)}
+    summary = row.get("Summary") or row.get("Abstract") or row.get("Description")
+    if summary:
+        out["Summary"] = summary[:600]
+    return out
+
+
+def _earthdata_login(username: str | None = None, password: str | None = None) -> None:
+    """Authenticate with NASA Earthdata using explicit, env, or netrc credentials."""
+    import earthaccess
+
+    username = (username or os.environ.get("EARTHDATA_USERNAME", "")).strip()
+    password = (password or os.environ.get("EARTHDATA_PASSWORD", "")).strip()
+    if username and password:
+        os.environ["EARTHDATA_USERNAME"] = username
+        os.environ["EARTHDATA_PASSWORD"] = password
+        auth = earthaccess.login(strategy="environment")
+        if getattr(auth, "authenticated", bool(auth)):
+            return
+
+    for strategy in ("environment", "netrc"):
+        try:
+            auth = earthaccess.login(strategy=strategy)
+            if getattr(auth, "authenticated", bool(auth)):
+                return
+        except Exception:
+            continue
+    raise RuntimeError(
+        "NASA Earthdata authentication failed. Configure credentials in the "
+        "NASA Earthdata plugin settings, environment, or ~/.netrc."
+    )
+
+
+def _parse_bbox(bbox: str | list[float] | tuple[float, ...] | None) -> (
+    tuple[
+        float,
+        float,
+        float,
+        float,
+    ]
+    | None
+):
+    """Parse west,south,east,north bounds."""
+    if bbox is None or bbox == "":
+        return None
+    values = list(bbox) if isinstance(bbox, (list, tuple)) else str(bbox).split(",")
+    if len(values) != 4:
+        raise ValueError("bbox must contain west,south,east,north")
+    west, south, east, north = [float(value) for value in values]
+    if west >= east or south >= north:
+        raise ValueError("bbox coordinates must satisfy west < east and south < north")
+    return west, south, east, north
+
+
+def _current_bbox_wgs84(iface: Any) -> tuple[float, float, float, float]:
+    """Return the current QGIS canvas extent as WGS84 coordinates."""
+
+    def _run() -> tuple[float, float, float, float]:
+        canvas = iface.mapCanvas()
+        extent = canvas.extent()
+        crs = canvas.mapSettings().destinationCrs()
+        if crs.authid() != "EPSG:4326":
+            from qgis.core import (  # type: ignore[import-not-found]
+                QgsCoordinateReferenceSystem,
+                QgsCoordinateTransform,
+                QgsProject,
+            )
+
+            transform = QgsCoordinateTransform(
+                crs,
+                QgsCoordinateReferenceSystem("EPSG:4326"),
+                QgsProject.instance(),
+            )
+            extent = transform.transformBoundingBox(extent)
+        return (
+            float(extent.xMinimum()),
+            float(extent.yMinimum()),
+            float(extent.xMaximum()),
+            float(extent.yMaximum()),
+        )
+
+    return _on_gui(_run)
+
+
+def _granule_links(granule: Any) -> list[str]:
+    """Return data links from an earthaccess granule."""
+    if hasattr(granule, "data_links"):
+        try:
+            return list(granule.data_links())
+        except Exception:
+            return []
+    links = (
+        granule.get("umm", {}).get("RelatedUrls", []) if hasattr(granule, "get") else []
+    )
+    out: list[str] = []
+    for link in links:
+        url = link.get("URL") if isinstance(link, dict) else None
+        if url:
+            out.append(str(url))
+    return out
+
+
+def _granule_geometry(granule: Any) -> dict[str, Any] | None:
+    """Extract a GeoJSON geometry from an earthaccess granule."""
+    umm = granule.get("umm", {}) if hasattr(granule, "get") else {}
+    spatial = umm.get("SpatialExtent", {})
+    horizontal = spatial.get("HorizontalSpatialDomain", {})
+    geometry = horizontal.get("Geometry", {})
+
+    rects = geometry.get("BoundingRectangles", [])
+    if rects:
+        rect = rects[0]
+        west = rect.get("WestBoundingCoordinate", 0)
+        south = rect.get("SouthBoundingCoordinate", 0)
+        east = rect.get("EastBoundingCoordinate", 0)
+        north = rect.get("NorthBoundingCoordinate", 0)
+        return {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [west, south],
+                    [east, south],
+                    [east, north],
+                    [west, north],
+                    [west, south],
+                ]
+            ],
+        }
+
+    polygons = geometry.get("GPolygons", [])
+    if polygons:
+        points = polygons[0].get("Boundary", {}).get("Points", [])
+        coords = [[p.get("Longitude", 0), p.get("Latitude", 0)] for p in points]
+        if coords:
+            if coords[0] != coords[-1]:
+                coords.append(coords[0])
+            return {"type": "Polygon", "coordinates": [coords]}
+    return None
+
+
+def _granule_summary(granule: Any, *, max_links: int = 5) -> dict[str, Any]:
+    """Return a compact, JSON-serializable granule summary."""
+    meta = granule.get("meta", {}) if hasattr(granule, "get") else {}
+    umm = granule.get("umm", {}) if hasattr(granule, "get") else {}
+    temporal = umm.get("TemporalExtent", {}).get("RangeDateTime", {})
+    links = _granule_links(granule)
+    return {
+        "native_id": meta.get("native-id", ""),
+        "producer_granule_id": meta.get("producer-granule-id", ""),
+        "concept_id": meta.get("concept-id", ""),
+        "collection_concept_id": meta.get("collection-concept-id", ""),
+        "begin_date": temporal.get("BeginningDateTime", ""),
+        "end_date": temporal.get("EndingDateTime", ""),
+        "size_mb": meta.get("size-mb", ""),
+        "num_links": len(links),
+        "data_links": links[:max_links],
+    }
+
+
+def _safe_basename(value: str, *, fallback: str = "earthdata") -> str:
+    """Return a filesystem-safe basename."""
+    parsed = urlparse(value)
+    raw = os.path.basename(parsed.path) if parsed.scheme else os.path.basename(value)
+    cleaned = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in raw)
+    return cleaned.strip("._") or fallback
+
+
+def _add_qgis_raster_layer(
+    iface: Any,
+    project_getter: Any,
+    path_or_uri: str,
+    layer_name: str,
+) -> dict[str, Any]:
+    """Add a raster layer to QGIS on the GUI thread."""
+
+    def _run() -> dict[str, Any]:
+        from qgis.core import QgsRasterLayer  # type: ignore[import-not-found]
+
+        layer = QgsRasterLayer(path_or_uri, layer_name)
+        if not layer.isValid():
+            return {"error": f"Failed to load raster from {path_or_uri}."}
+        project_getter().addMapLayer(layer)
+        iface.mapCanvas().refresh()
+        return {"success": True, "layer_name": layer_name}
+
+    return _on_gui(_run)
+
+
+def earthdata_tools(
+    iface: Any | None = None,
+    project: Optional[Any] = None,
+    *,
+    plugin: Any | None = None,
+) -> list[Any]:
+    """Return GeoAgent tools for NASA Earthdata workflows in QGIS."""
+    if iface is None:
         return []
-    return []
+
+    state: dict[str, Any] = {}
+
+    def _project() -> Any:
+        if project is not None:
+            return project
+        from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+        return QgsProject.instance()
+
+    def _ensure_plugin_dock(kind: str) -> dict[str, Any]:
+        """Show a plugin dock if a plugin instance was supplied."""
+        if plugin is None:
+            return {"success": False, "error": "No NASA Earthdata plugin instance."}
+
+        def _run() -> dict[str, Any]:
+            if kind == "settings":
+                attr = "_settings_dock"
+                creator = "toggle_settings_dock"
+            else:
+                attr = "_earthdata_dock"
+                creator = "toggle_earthdata_dock"
+            dock = getattr(plugin, attr, None)
+            if dock is None and hasattr(plugin, creator):
+                getattr(plugin, creator)()
+                dock = getattr(plugin, attr, None)
+            if dock is None:
+                return {"success": False, "error": f"Could not create {kind} dock."}
+            dock.show()
+            dock.raise_()
+            return {"success": True, "dock": kind}
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="search_earthdata_catalog",
+        available_in=("full", "fast"),
+    )
+    def search_earthdata_catalog(
+        query: str = "",
+        max_results: int = 20,
+        catalog_url: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Search the NASA Earthdata dataset catalog by short name or title."""
+        rows = _load_catalog_rows(catalog_url)
+        q = query.strip().lower()
+        matches = []
+        for row in rows:
+            haystack = " ".join(
+                [
+                    row.get("ShortName", ""),
+                    row.get("EntryTitle", ""),
+                    row.get("Summary", ""),
+                    row.get("Platform", ""),
+                    row.get("Instrument", ""),
+                ]
+            ).lower()
+            if not q or q in haystack:
+                matches.append(_compact_catalog_row(row))
+        count = max(1, int(max_results))
+        return {
+            "count": len(matches),
+            "shown": min(len(matches), count),
+            "datasets": matches[:count],
+        }
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="get_earthdata_dataset_info",
+        available_in=("full", "fast"),
+    )
+    def get_earthdata_dataset_info(
+        short_name_or_query: str,
+        catalog_url: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Return NASA Earthdata catalog metadata for a dataset short name."""
+        rows = _load_catalog_rows(catalog_url)
+        q = short_name_or_query.strip().lower()
+        matches = []
+        for row in rows:
+            short_name = row.get("ShortName", "").lower()
+            title = row.get("EntryTitle", "").lower()
+            if q == short_name or q in short_name or q in title:
+                matches.append(_compact_catalog_row(row))
+        return {"found": bool(matches), "matches": matches[:10]}
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="search_earthdata_data",
+        requires_packages=("earthaccess",),
+    )
+    def search_earthdata_data(
+        short_name: str,
+        bbox: str | list[float] | None = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        max_results: int = 50,
+        provider: Optional[str] = None,
+        version: Optional[str] = None,
+        cloud_cover_min: Optional[float] = None,
+        cloud_cover_max: Optional[float] = None,
+        day_night: Optional[str] = None,
+        granule_id: Optional[str] = None,
+        orbit_number: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Search NASA Earthdata granules by dataset, bbox, and filters."""
+        import earthaccess
+
+        parsed_bbox = _parse_bbox(bbox)
+        if parsed_bbox is None:
+            parsed_bbox = _current_bbox_wgs84(iface)
+
+        _earthdata_login()
+        search_params: dict[str, Any] = {
+            "short_name": short_name,
+            "count": max(1, int(max_results)),
+            "bounding_box": parsed_bbox,
+        }
+        if start_date and end_date:
+            search_params["temporal"] = (start_date, end_date)
+        elif start_date:
+            search_params["temporal"] = (
+                start_date,
+                datetime.today().strftime("%Y-%m-%d"),
+            )
+        if provider:
+            search_params["provider"] = provider
+        if version:
+            search_params["version"] = version
+        if cloud_cover_min is not None or cloud_cover_max is not None:
+            search_params["cloud_cover"] = (
+                cloud_cover_min or 0,
+                cloud_cover_max if cloud_cover_max is not None else 100,
+            )
+        if day_night:
+            search_params["day_night_flag"] = day_night
+        if granule_id:
+            search_params["granule_ur"] = granule_id
+        if orbit_number is not None:
+            search_params["orbit_number"] = orbit_number
+
+        results = list(earthaccess.search_data(**search_params))
+        state["last_search_results"] = results
+        state["last_search_short_name"] = short_name
+        state["last_search_bbox"] = parsed_bbox
+
+        return {
+            "count": len(results),
+            "short_name": short_name,
+            "bbox": parsed_bbox,
+            "granules": [_granule_summary(granule) for granule in results],
+        }
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="display_earthdata_footprints",
+        requires_confirmation=True,
+    )
+    def display_earthdata_footprints(
+        layer_name: str = "NASA Earthdata Footprints",
+    ) -> dict[str, Any]:
+        """Display footprints for the most recent NASA Earthdata search."""
+
+        def _run() -> dict[str, Any]:
+            results = state.get("last_search_results")
+            if not results:
+                return {"error": "No NASA Earthdata search results are available."}
+
+            features: list[dict[str, Any]] = []
+            for granule in results:
+                geometry = _granule_geometry(granule)
+                if geometry is None:
+                    continue
+                features.append(
+                    {
+                        "type": "Feature",
+                        "geometry": geometry,
+                        "properties": _granule_summary(granule, max_links=0),
+                    }
+                )
+
+            if not features:
+                return {"error": "No valid footprint geometries found."}
+
+            path = os.path.join(
+                tempfile.gettempdir(),
+                f"geoagent_earthdata_footprints_{uuid.uuid4().hex}.geojson",
+            )
+            geojson = {
+                "type": "FeatureCollection",
+                "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
+                "features": features,
+            }
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(geojson, f)
+
+            from qgis.PyQt.QtGui import QColor  # type: ignore[import-not-found]
+            from qgis.core import QgsFillSymbol, QgsVectorLayer  # type: ignore
+
+            proj = _project()
+            for existing in proj.mapLayersByName(layer_name):
+                proj.removeMapLayer(existing.id())
+
+            layer = QgsVectorLayer(path, layer_name, "ogr")
+            if not layer.isValid():
+                return {"error": "Failed to create NASA Earthdata footprint layer."}
+
+            symbol = QgsFillSymbol.createSimple({})
+            fill = symbol.symbolLayer(0)
+            fill.setColor(QColor(11, 61, 145, 50))
+            fill.setStrokeColor(QColor(11, 61, 145, 220))
+            fill.setStrokeWidth(0.5)
+            layer.renderer().setSymbol(symbol)
+
+            proj.addMapLayer(layer)
+            iface.mapCanvas().refresh()
+            return {
+                "success": True,
+                "layer_name": layer_name,
+                "feature_count": len(features),
+                "path": path,
+            }
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="load_earthdata_raster",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("earthaccess",),
+    )
+    def load_earthdata_raster(
+        url: str,
+        layer_name: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Download a NASA Earthdata raster asset URL and load it into QGIS."""
+        import earthaccess
+
+        _earthdata_login()
+        target_dir = cache_dir or os.path.join(
+            os.path.expanduser("~"), "nasa_earthdata_cache"
+        )
+        os.makedirs(target_dir, exist_ok=True)
+        basename = _safe_basename(url, fallback="earthdata_raster")
+        local_path = os.path.join(target_dir, basename)
+        if not os.path.exists(local_path):
+            downloaded = earthaccess.download([url], local_path=target_dir, threads=1)
+            if downloaded:
+                local_path = str(downloaded[0])
+        name = layer_name or os.path.basename(local_path) or "NASA Earthdata Raster"
+        result = _add_qgis_raster_layer(iface, _project, local_path, name)
+        if result.get("success"):
+            result["path"] = local_path
+        return result
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="open_nasa_earthdata_search_panel",
+        requires_confirmation=True,
+    )
+    def open_nasa_earthdata_search_panel() -> dict[str, Any]:
+        """Open or focus the NASA Earthdata plugin search panel."""
+        return _ensure_plugin_dock("search")
+
+    @geo_tool(
+        category="nasa_earthdata",
+        name="open_nasa_earthdata_settings",
+        requires_confirmation=True,
+    )
+    def open_nasa_earthdata_settings() -> dict[str, Any]:
+        """Open or focus the NASA Earthdata plugin settings panel."""
+        return _ensure_plugin_dock("settings")
+
+    return [
+        search_earthdata_catalog,
+        get_earthdata_dataset_info,
+        search_earthdata_data,
+        display_earthdata_footprints,
+        load_earthdata_raster,
+        open_nasa_earthdata_search_panel,
+        open_nasa_earthdata_settings,
+    ]
+
+
+__all__ = ["earthdata_tools"]

--- a/geoagent/tools/nasa_earthdata.py
+++ b/geoagent/tools/nasa_earthdata.py
@@ -78,14 +78,26 @@ def _earthdata_login(username: str | None = None, password: str | None = None) -
     """Authenticate with NASA Earthdata using explicit, env, or netrc credentials."""
     import earthaccess
 
-    username = (username or os.environ.get("EARTHDATA_USERNAME", "")).strip()
-    password = (password or os.environ.get("EARTHDATA_PASSWORD", "")).strip()
-    if username and password:
-        os.environ["EARTHDATA_USERNAME"] = username
-        os.environ["EARTHDATA_PASSWORD"] = password
-        auth = earthaccess.login(strategy="environment")
-        if getattr(auth, "authenticated", bool(auth)):
-            return
+    explicit_username = (username or "").strip()
+    explicit_password = (password or "").strip()
+    if explicit_username and explicit_password:
+        previous_username = os.environ.get("EARTHDATA_USERNAME")
+        previous_password = os.environ.get("EARTHDATA_PASSWORD")
+        try:
+            os.environ["EARTHDATA_USERNAME"] = explicit_username
+            os.environ["EARTHDATA_PASSWORD"] = explicit_password
+            auth = earthaccess.login(strategy="environment")
+            if getattr(auth, "authenticated", bool(auth)):
+                return
+        finally:
+            if previous_username is None:
+                os.environ.pop("EARTHDATA_USERNAME", None)
+            else:
+                os.environ["EARTHDATA_USERNAME"] = previous_username
+            if previous_password is None:
+                os.environ.pop("EARTHDATA_PASSWORD", None)
+            else:
+                os.environ["EARTHDATA_PASSWORD"] = previous_password
 
     for strategy in ("environment", "netrc"):
         try:
@@ -95,8 +107,8 @@ def _earthdata_login(username: str | None = None, password: str | None = None) -
         except Exception:
             continue
     raise RuntimeError(
-        "NASA Earthdata authentication failed. Configure credentials in the "
-        "NASA Earthdata plugin settings, environment, or ~/.netrc."
+        "NASA Earthdata authentication failed. Provide credentials explicitly, "
+        "set EARTHDATA_USERNAME and EARTHDATA_PASSWORD, or configure ~/.netrc."
     )
 
 

--- a/tests/test_nasa_earthdata_tools.py
+++ b/tests/test_nasa_earthdata_tools.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import sys
 import types
 
+import pytest
+
 from geoagent import for_nasa_earthdata
+from geoagent.tools import nasa_earthdata as nasa_earthdata_module
 from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.testing import MockQGISIface, MockQGISProject
 
@@ -105,3 +109,64 @@ def test_for_nasa_earthdata_chat_on_gui_thread_fails_closed(monkeypatch) -> None
     assert "NASA Earthdata chat should be launched from a worker thread" in str(
         resp.error_message
     )
+
+
+_FAKE_TSV = (
+    "ShortName\tEntryTitle\tSummary\tPlatform\tInstrument\n"
+    "MOD11A1\tMODIS Land Surface Temperature\tDaily LST product\tTerra\tMODIS\n"
+    "HLSL30\tHarmonized Landsat Sentinel-2 Landsat\tSurface reflectance\tLandsat\tOLI\n"
+    "GPM_3IMERGDF\tGPM IMERG Daily\tPrecipitation\tGPM\tIMERG\n"
+)
+
+
+def _patched_urlopen(monkeypatch, payload: str = _FAKE_TSV) -> None:
+    """Replace urlopen in the NASA Earthdata module with a fake TSV response."""
+
+    class _FakeResponse(io.BytesIO):
+        def __enter__(self):  # type: ignore[override]
+            return self
+
+        def __exit__(self, *exc) -> None:  # type: ignore[override]
+            self.close()
+
+    def _fake_urlopen(url, *args, **kwargs):
+        assert str(url).lower().startswith("https://")
+        return _FakeResponse(payload.encode("utf-8"))
+
+    monkeypatch.setattr(nasa_earthdata_module, "urlopen", _fake_urlopen)
+
+
+def test_search_earthdata_catalog_filters_and_max_results(monkeypatch) -> None:
+    """Verify catalog search filters rows and honors max_results."""
+    _patched_urlopen(monkeypatch)
+    tools = {tool.tool_name: tool for tool in earthdata_tools(object())}
+    search = tools["search_earthdata_catalog"]
+
+    result = search(
+        query="modis",
+        max_results=10,
+        catalog_url="https://example.com/catalog.tsv",
+    )
+    assert result["count"] == 1
+    assert result["datasets"][0]["ShortName"] == "MOD11A1"
+
+    capped = search(
+        query="",
+        max_results=2,
+        catalog_url="https://example.com/catalog.tsv",
+    )
+    assert capped["count"] == 3
+    assert capped["shown"] == 2
+    assert len(capped["datasets"]) == 2
+
+
+def test_load_catalog_rows_rejects_non_https(monkeypatch) -> None:
+    """Verify the catalog loader refuses non-HTTPS URLs."""
+
+    def _should_not_be_called(*_args, **_kwargs):
+        raise AssertionError("urlopen must not be invoked for non-HTTPS URLs")
+
+    monkeypatch.setattr(nasa_earthdata_module, "urlopen", _should_not_be_called)
+
+    with pytest.raises(ValueError, match="HTTPS"):
+        nasa_earthdata_module._load_catalog_rows("http://example.com/catalog.tsv")

--- a/tests/test_nasa_earthdata_tools.py
+++ b/tests/test_nasa_earthdata_tools.py
@@ -1,0 +1,107 @@
+"""Tests for the NASA Earthdata GeoAgent tool factory."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from geoagent import for_nasa_earthdata
+from geoagent.tools.nasa_earthdata import earthdata_tools
+from geoagent.testing import MockQGISIface, MockQGISProject
+
+
+class _MockModel:
+    """Provide a test double for MockModel."""
+
+    stateful = False
+
+
+def test_nasa_earthdata_module_imports_without_qgis() -> None:
+    """Verify NASA Earthdata tools are import-safe outside QGIS."""
+    assert "geoagent.tools.nasa_earthdata" in sys.modules
+    assert "qgis" not in sys.modules
+
+
+def test_earthdata_tools_returns_empty_for_none_iface() -> None:
+    """Verify the Earthdata factory returns no tools without a QGIS iface."""
+    assert earthdata_tools(None) == []
+
+
+def test_earthdata_tools_expose_expected_surface() -> None:
+    """Verify NASA Earthdata tool names are available without QGIS imports."""
+    tools = {tool.tool_name: tool for tool in earthdata_tools(object())}
+
+    assert "search_earthdata_catalog" in tools
+    assert "get_earthdata_dataset_info" in tools
+    assert "search_earthdata_data" in tools
+    assert "display_earthdata_footprints" in tools
+    assert "load_earthdata_raster" in tools
+
+
+def test_for_nasa_earthdata_registers_earthdata_and_qgis_tools() -> None:
+    """Verify the factory combines NASA Earthdata and QGIS tool surfaces."""
+    agent = for_nasa_earthdata(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    names = set(agent.strands_agent.tool_names)
+
+    assert "search_earthdata_catalog" in names
+    assert "get_earthdata_dataset_info" in names
+    assert "list_project_layers" in names
+    assert agent.context.metadata["integration"] == "nasa_earthdata"
+
+
+def test_for_nasa_earthdata_chat_on_gui_thread_fails_closed(monkeypatch) -> None:
+    """Verify synchronous Earthdata chat is blocked on the QGIS GUI thread."""
+
+    class _FakeThread:
+        """Provide a test double for FakeThread."""
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, _FakeThread)
+
+    class _QThread:
+        """Provide a test double for QThread."""
+
+        @staticmethod
+        def currentThread():
+            """Return current thread."""
+            return _FakeThread()
+
+    class _App:
+        """Provide a test double for App."""
+
+        def thread(self):
+            """Return GUI thread."""
+            return _FakeThread()
+
+    class _QApplication:
+        """Provide a test double for QApplication."""
+
+        @staticmethod
+        def instance():
+            """Return app instance."""
+            return _App()
+
+    fake_qt_core = types.SimpleNamespace(QThread=_QThread)
+    fake_qt_widgets = types.SimpleNamespace(QApplication=_QApplication)
+    fake_pyqt = types.SimpleNamespace(QtCore=fake_qt_core, QtWidgets=fake_qt_widgets)
+    fake_qgis = types.SimpleNamespace(PyQt=fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis", fake_qgis)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt", fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtCore", fake_qt_core)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtWidgets", fake_qt_widgets)
+
+    agent = for_nasa_earthdata(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    resp = agent.chat("search Earthdata")
+
+    assert resp.success is False
+    assert "NASA Earthdata chat should be launched from a worker thread" in str(
+        resp.error_message
+    )


### PR DESCRIPTION
## Summary
- Add `for_nasa_earthdata` factory and `earthdata_tools` adapter exposing catalog search, CMR granule search, footprint display, raster loading, and plugin-dock helpers.
- Extend the QGIS GUI-thread guard in `GeoAgent.chat` so synchronous chat is blocked for the `nasa_earthdata` integration as well as `nasa_opera`.
- Add tests covering import safety, the empty-iface case, the registered tool surface, and the GUI-thread guard.

## Test plan
- [x] `pytest tests/test_nasa_earthdata_tools.py -q`
- [x] `pre-commit run --all-files`