### PR TITLE
feat: add WhiteboxTools QGIS factory and routed broker tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ ENV/
 .vscode/
 CLAUDE.md
 .firecrawl/
+.codex

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,7 +2,7 @@
 
 Interactive adapters live under **`geoagent.tools`**:
 
-- `leafmap_tools`, `anymap_tools`, `qgis_tools`, `nasa_opera_tools` — bound to live map / QGIS instances.
+- `leafmap_tools`, `anymap_tools`, `qgis_tools`, `nasa_opera_tools`, `whitebox_tools` — bound to live map / QGIS instances.
 - Optional stubs: `stac`, `geoai`, `earthengine`, `nasa_earthdata` (expand in future releases).
 
 Use **`@geo_tool`** ([`geoagent.core.decorators`](decorators.md)) so tools register Strands-compatible metadata for safety hooks.
@@ -30,6 +30,19 @@ Layer lookup accepts exact names or a unique case-insensitive substring for oper
 - Open UI / save: `open_attribute_table`, `save_project`.
 
 Destructive or persistent actions such as `remove_layer`, `clear_layers`, `save_map`, `save_project`, and `run_processing_algorithm` require confirmation through the GeoAgent safety hook.
+
+## WhiteboxTools
+
+`for_whitebox(iface, project=None)` exposes WhiteboxTools through a routed
+broker surface rather than registering hundreds of individual tools:
+
+- Discover tools: `summarize_whitebox_tools`, `search_whitebox_tools`.
+- Inspect parameters: `get_whitebox_tool_info`.
+- Execute analysis: `run_whitebox_tool`.
+
+The executor is confirmation-required and long-running. It accepts file paths
+or file-backed QGIS layer names, creates missing required output paths when
+possible, and loads generated raster/vector outputs back into QGIS.
 
 ## NASA OPERA
 

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -29,6 +29,7 @@ from geoagent.core.factory import (
     for_nasa_earthdata,
     for_nasa_opera,
     for_qgis,
+    for_whitebox,
 )
 from geoagent.core.agent import GeoAgent
 from geoagent.core.registry import GeoToolMeta, GeoToolRegistry
@@ -48,6 +49,7 @@ __all__ = [
     "for_nasa_earthdata",
     "for_nasa_opera",
     "for_qgis",
+    "for_whitebox",
     "geo_tool",
     "get_geo_meta",
     "stamp_geo_meta",

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -36,6 +36,38 @@ def _result_to_text(result: Any) -> str:
     return s
 
 
+def _looks_like_json_parse_failure(exc: Exception) -> bool:
+    """Return True when an exception is a malformed JSON/tool-call response."""
+    text = f"{type(exc).__name__}: {exc}".lower()
+    markers = (
+        "failed to parse json",
+        "jsondecodeerror",
+        "unexpected end of json input",
+        "expecting value",
+        "unterminated string",
+    )
+    return any(marker in text for marker in markers)
+
+
+def _format_chat_exception(exc: Exception) -> str:
+    """Convert low-level provider/tool-call exceptions into user guidance."""
+    original = str(exc).strip() or type(exc).__name__
+    if not _looks_like_json_parse_failure(exc):
+        return original
+    return (
+        "The model returned malformed or incomplete JSON while trying to call "
+        "a tool. GeoAgent could not safely continue that tool workflow.\n\n"
+        f"Original error: {original}\n\n"
+        "How to correct it:\n"
+        "- Retry with a more specific request, including the layer name and "
+        "desired output name.\n"
+        "- Break a long workflow into smaller steps if it keeps failing.\n"
+        "- Increase the model max tokens if the response may be truncated.\n"
+        "- Use a model/provider with reliable tool-calling support; local or "
+        "OpenAI-compatible endpoints may need tool/function calling enabled."
+    )
+
+
 class GeoAgent:
     """Public facade: Strands agent + GeoAgent context, tools, and safety hooks."""
 
@@ -212,7 +244,7 @@ class GeoAgent:
             elapsed = time.time() - t0
             return GeoAgentResponse(
                 success=False,
-                error_message=str(exc),
+                error_message=_format_chat_exception(exc),
                 execution_time=elapsed,
                 cancelled_tools=list(self._cancelled),
                 map=self._context.map_obj,

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -94,6 +94,13 @@ Workflow guidance:
   metadata before running it.
 - Use search_whitebox_tools to find candidate commands, get_whitebox_tool_info
   to inspect required parameters, then run_whitebox_tool to execute.
+- For active DEM flow accumulation requests, prefer
+  run_whitebox_flow_accumulation.
+- For active DEM sink/depression filling or breaching requests, prefer
+  run_whitebox_fill_sinks.
+- For active DEM color shaded relief requests, prefer
+  run_whitebox_color_shaded_relief.
+- For active vector layer buffer requests, prefer buffer_active_layer.
 - Use QGIS layer names as input values only when the layer is backed by a
   local file. Otherwise ask the user to export the layer or provide a file.
 - Generated outputs are added back to QGIS when possible.

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -19,6 +19,7 @@ from geoagent.tools.leafmap import leafmap_tools
 from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
+from geoagent.tools.whitebox import whitebox_tools
 
 NASA_EARTHDATA_SYSTEM_PROMPT = """\
 You are an AI assistant embedded in QGIS for the NASA Earthdata plugin.
@@ -82,6 +83,24 @@ Workflow guidance:
 - Keep responses concise and include asset ids, layer names, and filters used.
 """
 
+WHITEBOX_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS with access to WhiteboxTools.
+WhiteboxTools exposes hundreds of geospatial analysis commands through a
+routed tool interface.
+
+Workflow guidance:
+- Do not guess exact Whitebox command parameters. Search first when the user
+  describes an analysis task, then inspect the selected tool's parameter
+  metadata before running it.
+- Use search_whitebox_tools to find candidate commands, get_whitebox_tool_info
+  to inspect required parameters, then run_whitebox_tool to execute.
+- Use QGIS layer names as input values only when the layer is backed by a
+  local file. Otherwise ask the user to export the layer or provide a file.
+- Generated outputs are added back to QGIS when possible.
+- Keep responses concise and include the Whitebox tool name, output path, and
+  loaded layer names when available.
+"""
+
 
 def _filter_by_imports(tools: list[Any]) -> list[Any]:
     """Drop tools whose declared optional packages are unavailable."""
@@ -116,6 +135,7 @@ def assemble_tools(
     include_nasa_earthdata: bool = False,
     include_nasa_opera: bool = False,
     include_gee_data_catalogs: bool = False,
+    include_whitebox: bool = False,
     nasa_earthdata_plugin: Any | None = None,
     gee_data_catalogs_plugin: Any | None = None,
     fast: bool = False,
@@ -160,6 +180,12 @@ def assemble_tools(
         )
         register_all_tools(registry, gee_tools)
         collected.extend(gee_tools)
+    if include_whitebox:
+        whitebox_tool_list = _filter_by_imports(
+            whitebox_tools(context.qgis_iface, context.qgis_project)
+        )
+        register_all_tools(registry, whitebox_tool_list)
+        collected.extend(whitebox_tool_list)
     if extra_tools:
         register_all_tools(registry, extra_tools)
         collected.extend(extra_tools)
@@ -475,6 +501,58 @@ def for_gee_data_catalogs(
     )
 
 
+def for_whitebox(
+    iface: Any,
+    project: Any = None,
+    *,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+    include_qgis: bool = True,
+) -> GeoAgent:
+    """Bind an agent to QGIS with WhiteboxTools analysis support.
+
+    The factory exposes a routed WhiteboxTools broker surface and, by default,
+    the general QGIS map/project tools used for inspection and navigation.
+    """
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={
+            "integration": "whitebox",
+            "system_prompt": WHITEBOX_SYSTEM_PROMPT,
+        },
+    )
+    tools, registry = assemble_tools(
+        context=ctx,
+        include_qgis=include_qgis,
+        include_whitebox=True,
+        extra_tools=extra_tools,
+        fast=fast,
+    )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+        qgis_safe_mode=True,
+    )
+
+
 __all__ = [
     "assemble_tools",
     "create_agent",
@@ -484,5 +562,6 @@ __all__ = [
     "for_nasa_earthdata",
     "for_nasa_opera",
     "for_qgis",
+    "for_whitebox",
     "register_all_tools",
 ]

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -6,6 +6,7 @@ from geoagent.tools.leafmap import leafmap_tools
 from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
+from geoagent.tools.whitebox import whitebox_tools
 
 __all__ = [
     "anymap_tools",
@@ -14,4 +15,5 @@ __all__ = [
     "leafmap_tools",
     "nasa_opera_tools",
     "qgis_tools",
+    "whitebox_tools",
 ]

--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -17,6 +17,7 @@ Typical usage from inside a QGIS plugin's Python console::
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import quote
@@ -204,6 +205,50 @@ def _resolve_layer(project: Any, layer_name: str) -> Any:
     if not layers:
         raise LookupError(f"No layer named {layer_name!r} in the project.")
     return layers[0]
+
+
+def _safe_stem(value: str, fallback: str = "qgis_output") -> str:
+    """Return a filesystem-safe output stem."""
+    import re
+
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._-")
+    return cleaned or fallback
+
+
+def _project_output_dir(project: Any) -> str:
+    """Choose a stable writable directory for generated QGIS outputs."""
+    for attr in ("homePath", "absolutePath"):
+        method = getattr(project, attr, None)
+        if callable(method):
+            try:
+                value = str(method()).strip()
+                if value:
+                    return value
+            except Exception:
+                pass
+    file_name = getattr(project, "fileName", None)
+    if callable(file_name):
+        try:
+            value = str(file_name()).strip()
+            if value:
+                return str(Path(value).parent)
+        except Exception:
+            pass
+    out_dir = Path(tempfile.gettempdir()) / "geoagent_qgis"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return str(out_dir)
+
+
+def _default_processing_output_path(project: Any, layer_name: str, suffix: str) -> str:
+    """Create a non-conflicting path for a generated Processing output."""
+    out_dir = Path(_project_output_dir(project))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    candidate = out_dir / f"{_safe_stem(layer_name)}{suffix}"
+    index = 2
+    while candidate.exists():
+        candidate = out_dir / f"{_safe_stem(layer_name)}_{index}{suffix}"
+        index += 1
+    return str(candidate)
 
 
 def _extent_payload(extent: Any) -> Any:
@@ -1067,6 +1112,93 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
 
     @geo_tool(
         category="qgis",
+        requires_confirmation=True,
+        long_running=True,
+    )
+    def buffer_active_layer(
+        distance_meters: float,
+        output_layer_name: Optional[str] = None,
+        output_path: Optional[str] = None,
+        segments: int = 8,
+        dissolve: bool = False,
+    ) -> dict[str, Any]:
+        """Buffer the active vector layer and add the result to the project.
+
+        Args:
+            distance_meters: Buffer distance. QGIS Processing interprets this
+                in the active layer's CRS units; projected CRS layers commonly
+                use metres.
+            output_layer_name: Optional display name for the output layer.
+            output_path: Optional output file path. When omitted, GeoAgent
+                writes a GeoPackage into the project directory or temp dir.
+            segments: Number of segments used to approximate quarter circles.
+            dissolve: Whether to dissolve buffered features.
+
+        Returns:
+            A compact dict describing the Processing result and loaded layer.
+        """
+
+        def _run() -> dict[str, Any]:
+            """Run the worker body."""
+            try:
+                import processing  # type: ignore[import-not-found]
+            except Exception as exc:  # pragma: no cover - QGIS-only path
+                raise RuntimeError(
+                    "QGIS Processing framework is not available."
+                ) from exc
+
+            layer = iface.activeLayer()
+            if layer is None:
+                return {"success": False, "reason": "No active layer."}
+
+            name = output_layer_name or f"{layer.name()} buffer {distance_meters:g}m"
+            target_path = output_path or _default_processing_output_path(
+                _project(),
+                name,
+                ".gpkg",
+            )
+            params = {
+                "INPUT": layer,
+                "DISTANCE": float(distance_meters),
+                "SEGMENTS": int(segments),
+                "END_CAP_STYLE": 0,
+                "JOIN_STYLE": 0,
+                "MITER_LIMIT": 2,
+                "DISSOLVE": bool(dissolve),
+                "OUTPUT": target_path,
+            }
+            result = processing.run("native:buffer", params)
+            output = (
+                result.get("OUTPUT", target_path)
+                if isinstance(result, dict)
+                else target_path
+            )
+            added = None
+            if output:
+                added = iface.addVectorLayer(str(output), name, "ogr")
+            success = added is not None and (
+                not hasattr(added, "isValid") or added.isValid()
+            )
+            if hasattr(iface.mapCanvas(), "refresh"):
+                iface.mapCanvas().refresh()
+            return {
+                "success": bool(success),
+                "algorithm_id": "native:buffer",
+                "input_layer": layer.name(),
+                "distance_meters": float(distance_meters),
+                "output": str(output) if output else None,
+                "layer_name": name if success else None,
+                "processing_result": (
+                    {key: str(value) for key, value in result.items()}
+                    if isinstance(result, dict)
+                    else {}
+                ),
+            }
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="qgis",
     )
     def open_attribute_table(layer_name: str) -> str:
         """Open the attribute table for a layer.
@@ -1156,6 +1288,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         zoom_to_selected,
         get_layer_summary,
         run_processing_algorithm,
+        buffer_active_layer,
         open_attribute_table,
         refresh_canvas,
         save_project,

--- a/geoagent/tools/whitebox.py
+++ b/geoagent/tools/whitebox.py
@@ -1,0 +1,561 @@
+"""Tool adapter for WhiteboxTools in QGIS.
+
+The adapter intentionally exposes a small broker surface instead of one
+GeoAgent tool per WhiteboxTools command. WhiteboxTools is resolved lazily so
+GeoAgent remains import-safe outside environments where ``whitebox`` or QGIS
+are installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+RASTER_EXTENSIONS = {
+    ".tif",
+    ".tiff",
+    ".dep",
+    ".flt",
+    ".sdat",
+    ".rdc",
+    ".asc",
+}
+VECTOR_EXTENSIONS = {".shp", ".geojson", ".gpkg", ".json", ".kml"}
+
+
+def _on_gui(fn: Any) -> Any:
+    """Run ``fn`` on the Qt GUI thread when QGIS is available."""
+    return run_on_qt_gui_thread(fn)
+
+
+def _normalize_key(value: Any) -> str:
+    """Return a stable lookup key for parameter names and flags."""
+    text = str(value).strip().lstrip("-").lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def _safe_stem(value: str, fallback: str = "whitebox_output") -> str:
+    """Return a filesystem-safe output stem."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._-")
+    return cleaned or fallback
+
+
+def _project_from_iface(iface: Any, project: Optional[Any]) -> Any:
+    """Return the configured project or resolve it from the QGIS iface."""
+    if project is not None:
+        return project
+    if hasattr(iface, "project"):
+        try:
+            proj = iface.project()
+            if proj is not None:
+                return proj
+        except Exception:
+            pass
+    try:
+        from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+        return QgsProject.instance()
+    except Exception as exc:  # pragma: no cover - QGIS-only path
+        raise RuntimeError("QGIS is not available; cannot resolve QgsProject.") from exc
+
+
+def _project_output_dir(project: Any) -> str:
+    """Choose a stable directory for generated Whitebox outputs."""
+    for attr in ("homePath", "absolutePath"):
+        method = getattr(project, attr, None)
+        if callable(method):
+            try:
+                value = str(method()).strip()
+                if value:
+                    return value
+            except Exception:
+                pass
+    file_name = getattr(project, "fileName", None)
+    if callable(file_name):
+        try:
+            value = str(file_name()).strip()
+            if value:
+                return str(Path(value).parent)
+        except Exception:
+            pass
+    out_dir = Path(tempfile.gettempdir()) / "geoagent_whitebox"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return str(out_dir)
+
+
+def _parameter_type(param: dict[str, Any]) -> Any:
+    """Return the Whitebox parameter type payload."""
+    return param.get("parameter_type") or param.get("type")
+
+
+def _type_mapping(param: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return ``(kind, data_type)`` for Whitebox parameter metadata."""
+    ptype = _parameter_type(param)
+    if isinstance(ptype, dict) and ptype:
+        key = next(iter(ptype.keys()))
+        value = ptype[key]
+        return str(key), str(value) if value is not None else None
+    if isinstance(ptype, str):
+        return ptype, None
+    return None, None
+
+
+def _is_existing_file_param(param: dict[str, Any]) -> bool:
+    """Return True when the parameter expects an existing file input."""
+    kind, _data_type = _type_mapping(param)
+    return kind == "ExistingFile"
+
+
+def _is_output_file_param(param: dict[str, Any]) -> bool:
+    """Return True when the parameter expects a new output file."""
+    kind, _data_type = _type_mapping(param)
+    return kind == "NewFile"
+
+
+def _is_raster_param(param: dict[str, Any]) -> bool:
+    """Return True when metadata indicates a raster parameter."""
+    _kind, data_type = _type_mapping(param)
+    return str(data_type or "").lower() == "raster"
+
+
+def _is_vector_param(param: dict[str, Any]) -> bool:
+    """Return True when metadata indicates a vector parameter."""
+    _kind, data_type = _type_mapping(param)
+    return str(data_type or "").lower() == "vector"
+
+
+def _required(param: dict[str, Any]) -> bool:
+    """Return True when a Whitebox parameter is required."""
+    return not bool(param.get("optional", False))
+
+
+def _flags(param: dict[str, Any]) -> list[str]:
+    """Return parameter CLI flags."""
+    flags = param.get("flags") or []
+    if isinstance(flags, str):
+        return [flags]
+    return [str(flag) for flag in flags if str(flag).strip()]
+
+
+def _preferred_flag(param: dict[str, Any]) -> str:
+    """Choose the long CLI flag when Whitebox exposes one."""
+    flags = _flags(param)
+    for flag in flags:
+        if flag.startswith("--"):
+            return flag
+    if flags:
+        return flags[0]
+    name = _normalize_key(param.get("name", "parameter"))
+    return f"--{name}"
+
+
+def _param_keys(param: dict[str, Any]) -> set[str]:
+    """Return accepted lookup keys for a Whitebox parameter."""
+    keys = {_normalize_key(param.get("name", ""))}
+    keys.update(_normalize_key(flag) for flag in _flags(param))
+    return {key for key in keys if key}
+
+
+def _canonical_param_name(param: dict[str, Any]) -> str:
+    """Return a compact parameter name for output payloads."""
+    for flag in _flags(param):
+        if flag.startswith("--"):
+            return _normalize_key(flag)
+    keys = sorted(_param_keys(param))
+    return keys[0] if keys else "parameter"
+
+
+def _load_tool_parameters(wbt: Any, tool_name: str) -> dict[str, Any]:
+    """Return parsed Whitebox parameter metadata for a tool."""
+    text = wbt.tool_parameters(tool_name)
+    if isinstance(text, dict):
+        payload = text
+    else:
+        payload = json.loads(str(text))
+    params = payload.get("parameters", [])
+    if not isinstance(params, list):
+        params = []
+    payload["parameters"] = params
+    return payload
+
+
+def _toolbox(wbt: Any, tool_name: str) -> str | None:
+    """Return a compact toolbox/category name for a Whitebox tool."""
+    try:
+        value = str(wbt.toolbox(tool_name)).strip()
+    except Exception:
+        return None
+    return value or None
+
+
+def _layer_source_from_name(project: Any, layer_name: str) -> str | None:
+    """Resolve a QGIS layer display name to a file-backed data source."""
+    try:
+        matches = project.mapLayersByName(layer_name)
+    except Exception:
+        matches = []
+    if not matches:
+        return None
+    layer = matches[0]
+    try:
+        source = str(layer.source())
+    except Exception:
+        source = ""
+    source_path = source.split("|", 1)[0]
+    if source_path and os.path.exists(source_path):
+        return source_path
+    raise ValueError(
+        f"QGIS layer '{layer_name}' is not backed by a local file. "
+        "Export the layer to a file or provide a file path for WhiteboxTools."
+    )
+
+
+def _resolve_existing_file(value: Any, project: Any) -> str:
+    """Resolve a file input, accepting either a path or QGIS layer name."""
+    text = str(value).strip()
+    if not text:
+        raise ValueError("Existing file parameter cannot be empty.")
+    source_path = text.split("|", 1)[0]
+    if os.path.exists(source_path):
+        return source_path
+    layer_path = _layer_source_from_name(project, text)
+    if layer_path is not None:
+        return layer_path
+    return text
+
+
+def _default_output_path(tool_name: str, param: dict[str, Any], project: Any) -> str:
+    """Create a default output path for a missing required output."""
+    out_dir = Path(_project_output_dir(project))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    suffix = ".shp" if _is_vector_param(param) else ".tif"
+    stem = _safe_stem(f"{tool_name}_{_canonical_param_name(param)}")
+    candidate = out_dir / f"{stem}{suffix}"
+    index = 2
+    while candidate.exists():
+        candidate = out_dir / f"{stem}_{index}{suffix}"
+        index += 1
+    return str(candidate)
+
+
+def _coerce_cli_value(value: Any) -> str:
+    """Convert Python values to WhiteboxTools CLI argument text."""
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def _format_arg(flag: str, value: Any) -> str | None:
+    """Format a WhiteboxTools CLI argument."""
+    if isinstance(value, bool):
+        if value:
+            return flag
+        return f"{flag}=false"
+    if value is None or value == "":
+        return None
+    return f"{flag}={_coerce_cli_value(value)}"
+
+
+def _build_run_args(
+    *,
+    wbt: Any,
+    tool_name: str,
+    parameters: dict[str, Any],
+    project: Any,
+) -> tuple[list[str], list[dict[str, Any]], list[str]]:
+    """Build WhiteboxTools CLI args from JSON parameter metadata."""
+    metadata = _load_tool_parameters(wbt, tool_name)
+    params = metadata.get("parameters", [])
+    normalized_inputs = {
+        _normalize_key(key): value for key, value in parameters.items()
+    }
+    consumed: set[str] = set()
+    args: list[str] = []
+    outputs: list[dict[str, Any]] = []
+
+    if not params:
+        for key, value in parameters.items():
+            arg = _format_arg(f"--{_normalize_key(key)}", value)
+            if arg is not None:
+                args.append(arg)
+        return args, outputs, []
+
+    known_keys: set[str] = set()
+    for param in params:
+        keys = _param_keys(param)
+        known_keys.update(keys)
+        found_key = next((key for key in keys if key in normalized_inputs), None)
+        value = normalized_inputs.get(found_key) if found_key else None
+        if found_key:
+            consumed.add(found_key)
+        if (value is None or value == "") and _is_output_file_param(param):
+            if _required(param):
+                value = _default_output_path(tool_name, param, project)
+            else:
+                continue
+        elif value is None or value == "":
+            if _required(param):
+                raise ValueError(
+                    f"Missing required WhiteboxTools parameter: "
+                    f"{param.get('name') or _preferred_flag(param)}"
+                )
+            continue
+
+        if _is_existing_file_param(param):
+            value = _resolve_existing_file(value, project)
+
+        arg = _format_arg(_preferred_flag(param), value)
+        if arg is not None:
+            args.append(arg)
+        if _is_output_file_param(param):
+            outputs.append(
+                {
+                    "parameter": _canonical_param_name(param),
+                    "path": str(value),
+                    "data_type": _type_mapping(param)[1],
+                }
+            )
+
+    unknown = sorted(set(normalized_inputs) - consumed - known_keys)
+    return args, outputs, unknown
+
+
+def _add_output_layer(
+    iface: Any,
+    project_getter: Any,
+    output_path: str,
+    layer_name: str,
+) -> dict[str, Any]:
+    """Add a generated Whitebox output to QGIS."""
+
+    def _run() -> dict[str, Any]:
+        suffix = Path(output_path).suffix.lower()
+        if suffix in RASTER_EXTENSIONS:
+            if hasattr(iface, "addRasterLayer"):
+                layer = iface.addRasterLayer(output_path, layer_name)
+            else:  # pragma: no cover - QGIS-only fallback
+                from qgis.core import QgsRasterLayer  # type: ignore[import-not-found]
+
+                layer = QgsRasterLayer(output_path, layer_name)
+                project_getter().addMapLayer(layer)
+        elif suffix in VECTOR_EXTENSIONS:
+            if hasattr(iface, "addVectorLayer"):
+                layer = iface.addVectorLayer(output_path, layer_name, "ogr")
+            else:  # pragma: no cover - QGIS-only fallback
+                from qgis.core import QgsVectorLayer  # type: ignore[import-not-found]
+
+                layer = QgsVectorLayer(output_path, layer_name, "ogr")
+                project_getter().addMapLayer(layer)
+        else:
+            return {
+                "path": output_path,
+                "added": False,
+                "reason": "Unsupported output extension for automatic QGIS loading.",
+            }
+        if hasattr(layer, "isValid") and not layer.isValid():
+            return {"path": output_path, "added": False, "reason": "Layer is invalid."}
+        try:
+            iface.mapCanvas().refresh()
+        except Exception:
+            pass
+        return {"path": output_path, "added": True, "layer_name": layer_name}
+
+    return _on_gui(_run)
+
+
+def _compact_tool(tool_name: str, description: str, toolbox: str | None = None) -> dict:
+    """Return compact Whitebox tool search metadata."""
+    payload = {"name": tool_name, "description": str(description)[:500]}
+    if toolbox:
+        payload["category"] = toolbox
+    return payload
+
+
+def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
+    """Return GeoAgent tools for running WhiteboxTools from QGIS."""
+    if iface is None:
+        return []
+
+    def _wbt() -> Any:
+        import whitebox
+
+        instance = whitebox.WhiteboxTools()
+        instance.verbose = False
+        return instance
+
+    def _project() -> Any:
+        return _project_from_iface(iface, project)
+
+    @geo_tool(
+        category="whitebox",
+        name="summarize_whitebox_tools",
+        available_in=("full", "fast"),
+        requires_packages=("whitebox",),
+    )
+    def summarize_whitebox_tools() -> dict[str, Any]:
+        """Summarize the available WhiteboxTools backend."""
+        wbt = _wbt()
+        tools = wbt.list_tools()
+        category_counts: dict[str, int] = {}
+        for name in tools:
+            category = _toolbox(wbt, name) or "Unknown"
+            category_counts[category] = category_counts.get(category, 0) + 1
+        return {
+            "version": str(wbt.version()).strip(),
+            "working_dir": str(wbt.get_working_dir()),
+            "tool_count": len(tools),
+            "category_counts": category_counts,
+        }
+
+    @geo_tool(
+        category="whitebox",
+        name="search_whitebox_tools",
+        available_in=("full", "fast"),
+        requires_packages=("whitebox",),
+    )
+    def search_whitebox_tools(
+        query: str = "",
+        category: Optional[str] = None,
+        max_results: int = 20,
+    ) -> dict[str, Any]:
+        """Search WhiteboxTools by keyword and optional category/toolbox."""
+        wbt = _wbt()
+        keywords = [part for part in str(query).split() if part]
+        tools = wbt.list_tools(keywords=keywords)
+        category_filter = str(category).lower() if category else ""
+        matches = []
+        for name, description in tools.items():
+            toolbox = _toolbox(wbt, name) if category_filter else None
+            if category_filter and category_filter not in str(toolbox or "").lower():
+                continue
+            matches.append(_compact_tool(name, description, toolbox))
+        limit = max(1, int(max_results))
+        return {
+            "count": len(matches),
+            "shown": min(len(matches), limit),
+            "tools": matches[:limit],
+        }
+
+    @geo_tool(
+        category="whitebox",
+        name="get_whitebox_tool_info",
+        available_in=("full", "fast"),
+        requires_packages=("whitebox",),
+    )
+    def get_whitebox_tool_info(tool_name: str) -> dict[str, Any]:
+        """Return parameter metadata and help text for a WhiteboxTools command."""
+        wbt = _wbt()
+        metadata = _load_tool_parameters(wbt, tool_name)
+        parameters = []
+        for param in metadata.get("parameters", []):
+            parameters.append(
+                {
+                    "name": param.get("name"),
+                    "keys": sorted(_param_keys(param)),
+                    "flags": _flags(param),
+                    "description": param.get("description"),
+                    "parameter_type": _parameter_type(param),
+                    "default_value": param.get("default_value"),
+                    "optional": bool(param.get("optional", False)),
+                }
+            )
+        return {
+            "tool_name": tool_name,
+            "category": _toolbox(wbt, tool_name),
+            "parameters": parameters,
+            "help": str(wbt.tool_help(tool_name)).strip(),
+        }
+
+    @geo_tool(
+        category="whitebox",
+        name="run_whitebox_tool",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("whitebox",),
+    )
+    def run_whitebox_tool(
+        tool_name: str,
+        parameters: dict[str, Any],
+        working_dir: Optional[str] = None,
+        add_outputs_to_qgis: bool = True,
+        output_layer_name: Optional[str] = None,
+        verbose: bool = False,
+        compress_rasters: Optional[bool] = None,
+        max_procs: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Run a WhiteboxTools command and optionally load outputs into QGIS."""
+        if not isinstance(parameters, dict):
+            raise ValueError("parameters must be a dictionary.")
+        wbt = _wbt()
+        proj = _project()
+        messages: list[str] = []
+        if working_dir:
+            wbt.set_working_dir(str(working_dir))
+        wbt.verbose = bool(verbose)
+        if compress_rasters is not None:
+            wbt.set_compress_rasters(bool(compress_rasters))
+        if max_procs is not None:
+            wbt.set_max_procs(int(max_procs))
+        args, outputs, unknown = _build_run_args(
+            wbt=wbt,
+            tool_name=tool_name,
+            parameters=parameters,
+            project=proj,
+        )
+        if unknown:
+            raise ValueError(
+                "Unknown WhiteboxTools parameters: "
+                + ", ".join(unknown)
+                + ". Call get_whitebox_tool_info first and use one of the listed keys."
+            )
+
+        def _callback(message: Any) -> None:
+            text = str(message).strip()
+            if text:
+                messages.append(text)
+
+        return_code = int(wbt.run_tool(tool_name, args, callback=_callback))
+        layers_added = []
+        if return_code == 0 and add_outputs_to_qgis:
+            for index, output in enumerate(outputs, start=1):
+                path = output["path"]
+                if not os.path.exists(path):
+                    layers_added.append(
+                        {
+                            "path": path,
+                            "added": False,
+                            "reason": "Output file was not found after tool run.",
+                        }
+                    )
+                    continue
+                name = output_layer_name or Path(path).stem
+                if len(outputs) > 1 and output_layer_name:
+                    name = f"{output_layer_name} {index}"
+                layers_added.append(_add_output_layer(iface, _project, path, name))
+        return {
+            "success": return_code == 0,
+            "return_code": return_code,
+            "tool_name": tool_name,
+            "args": args,
+            "outputs": outputs,
+            "layers_added": layers_added,
+            "messages": messages[-40:],
+        }
+
+    return [
+        summarize_whitebox_tools,
+        search_whitebox_tools,
+        get_whitebox_tool_info,
+        run_whitebox_tool,
+    ]
+
+
+__all__ = ["whitebox_tools"]

--- a/geoagent/tools/whitebox.py
+++ b/geoagent/tools/whitebox.py
@@ -197,25 +197,36 @@ def _toolbox(wbt: Any, tool_name: str) -> str | None:
 
 
 def _layer_source_from_name(project: Any, layer_name: str) -> str | None:
-    """Resolve a QGIS layer display name to a file-backed data source."""
-    try:
-        matches = project.mapLayersByName(layer_name)
-    except Exception:
-        matches = []
-    if not matches:
-        return None
-    layer = matches[0]
-    try:
-        source = str(layer.source())
-    except Exception:
-        source = ""
-    source_path = source.split("|", 1)[0]
+    """Resolve a QGIS layer display name to a file-backed data source.
+
+    QGIS layer/project APIs are not thread-safe, so the actual reads are
+    marshalled onto the Qt GUI thread. Outside QGIS this degrades to a direct
+    call.
+    """
+
+    def _read_layer_source_path() -> str | None:
+        try:
+            matches = project.mapLayersByName(layer_name)
+        except Exception:
+            matches = []
+        if not matches:
+            return None
+        layer = matches[0]
+        try:
+            source = str(layer.source())
+        except Exception:
+            source = ""
+        return source.split("|", 1)[0]
+
+    source_path = run_on_qt_gui_thread(_read_layer_source_path)
     if source_path and os.path.exists(source_path):
         return source_path
-    raise ValueError(
-        f"QGIS layer '{layer_name}' is not backed by a local file. "
-        "Export the layer to a file or provide a file path for WhiteboxTools."
-    )
+    if source_path:
+        raise ValueError(
+            f"QGIS layer '{layer_name}' is not backed by a local file. "
+            "Export the layer to a file or provide a file path for WhiteboxTools."
+        )
+    return None
 
 
 def _resolve_existing_file(value: Any, project: Any) -> str:
@@ -229,7 +240,10 @@ def _resolve_existing_file(value: Any, project: Any) -> str:
     layer_path = _layer_source_from_name(project, text)
     if layer_path is not None:
         return layer_path
-    return text
+    raise ValueError(
+        f"Could not resolve existing file '{text}'. Provide a valid existing "
+        "file path or the name of a QGIS layer backed by a local file."
+    )
 
 
 def _default_output_path(tool_name: str, param: dict[str, Any], project: Any) -> str:
@@ -495,7 +509,6 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         if not isinstance(parameters, dict):
             raise ValueError("parameters must be a dictionary.")
         wbt = _wbt()
-        proj = _project()
         messages: list[str] = []
         if working_dir:
             wbt.set_working_dir(str(working_dir))
@@ -504,12 +517,17 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
             wbt.set_compress_rasters(bool(compress_rasters))
         if max_procs is not None:
             wbt.set_max_procs(int(max_procs))
-        args, outputs, unknown = _build_run_args(
-            wbt=wbt,
-            tool_name=tool_name,
-            parameters=parameters,
-            project=proj,
-        )
+
+        def _resolve_args() -> tuple[list[str], list[dict[str, Any]], list[str]]:
+            proj = _project()
+            return _build_run_args(
+                wbt=wbt,
+                tool_name=tool_name,
+                parameters=parameters,
+                project=proj,
+            )
+
+        args, outputs, unknown = run_on_qt_gui_thread(_resolve_args)
         if unknown:
             raise ValueError(
                 "Unknown WhiteboxTools parameters: "

--- a/geoagent/tools/whitebox.py
+++ b/geoagent/tools/whitebox.py
@@ -200,7 +200,17 @@ def _load_tool_parameters(wbt: Any, tool_name: str) -> dict[str, Any]:
     if isinstance(text, dict):
         payload = text
     else:
-        payload = json.loads(str(text))
+        raw = str(text)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            preview = raw[:240] if raw else "<empty response>"
+            raise ValueError(
+                "WhiteboxTools returned invalid parameter metadata JSON for "
+                f"{tool_name!r}. Try searching the tool again, verify the tool "
+                "name, or update/reinstall WhiteboxTools. "
+                f"Metadata preview: {preview}"
+            ) from exc
     params = payload.get("parameters", [])
     if not isinstance(params, list):
         params = []
@@ -248,6 +258,20 @@ def _layer_source_from_name(project: Any, layer_name: str) -> str | None:
             "Export the layer to a file or provide a file path for WhiteboxTools."
         )
     return None
+
+
+def _active_layer_name(iface: Any) -> str:
+    """Return the active QGIS layer name."""
+
+    def _read_active_layer_name() -> str:
+        layer = iface.activeLayer()
+        if layer is None:
+            raise ValueError("No active QGIS layer is selected.")
+        if hasattr(layer, "name"):
+            return str(layer.name())
+        return str(layer)
+
+    return run_on_qt_gui_thread(_read_active_layer_name)
 
 
 def _resolve_existing_file(value: Any, project: Any) -> str:
@@ -589,11 +613,215 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
             "messages": messages[-40:],
         }
 
+    @geo_tool(
+        category="whitebox",
+        name="run_whitebox_flow_accumulation",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("whitebox",),
+    )
+    def run_whitebox_flow_accumulation(
+        layer_name: Optional[str] = None,
+        output_path: Optional[str] = None,
+        output_layer_name: Optional[str] = None,
+        tool_name: str = "d8_flow_accumulation",
+        add_outputs_to_qgis: bool = True,
+        verbose: bool = False,
+    ) -> dict[str, Any]:
+        """Run D8 flow accumulation on a DEM layer and load the raster output.
+
+        Args:
+            layer_name: QGIS DEM layer name. When omitted, uses the active
+                layer.
+            output_path: Optional raster output path.
+            output_layer_name: Optional display name for the output layer.
+            tool_name: Whitebox flow accumulation tool. Defaults to
+                ``d8_flow_accumulation``.
+            add_outputs_to_qgis: Whether to add the generated raster to QGIS.
+            verbose: Whether WhiteboxTools should emit verbose progress.
+
+        Returns:
+            A compact dict with the Whitebox return code, output path, and
+            QGIS load status.
+        """
+        selected_layer = layer_name or _active_layer_name(iface)
+        name = output_layer_name or f"{selected_layer} flow accumulation"
+        params: dict[str, Any] = {
+            "input": selected_layer,
+            "output": output_path,
+        }
+        if output_path is None:
+            params.pop("output")
+        return run_whitebox_tool.__wrapped__(
+            tool_name,
+            params,
+            add_outputs_to_qgis=add_outputs_to_qgis,
+            output_layer_name=name,
+            verbose=verbose,
+        )
+
+    @geo_tool(
+        category="whitebox",
+        name="run_whitebox_fill_sinks",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("whitebox",),
+    )
+    def run_whitebox_fill_sinks(
+        layer_name: Optional[str] = None,
+        output_path: Optional[str] = None,
+        output_layer_name: Optional[str] = None,
+        method: str = "breach_depressions",
+        max_depth: Optional[float] = None,
+        max_length: Optional[float] = None,
+        flat_increment: Optional[float] = None,
+        fill_pits: Optional[bool] = None,
+        fix_flats: Optional[bool] = None,
+        add_outputs_to_qgis: bool = True,
+        verbose: bool = False,
+    ) -> dict[str, Any]:
+        """Resolve sinks/depressions in a DEM layer and load the raster output.
+
+        Args:
+            layer_name: QGIS DEM layer name. When omitted, uses the active
+                layer.
+            output_path: Optional raster output path.
+            output_layer_name: Optional display name for the output layer.
+            method: Whitebox method. Supported values are
+                ``breach_depressions`` (default), ``fill_depressions``, and
+                ``fill_depressions_wang_and_liu``.
+            max_depth: Optional maximum breach/fill depth in z units.
+            max_length: Optional maximum breach channel length in grid cells.
+            flat_increment: Optional elevation increment for flat areas.
+            fill_pits: Optional single-cell pit filling flag for breaching.
+            fix_flats: Optional flat-area gradient flag for fill methods.
+            add_outputs_to_qgis: Whether to add the generated raster to QGIS.
+            verbose: Whether WhiteboxTools should emit verbose progress.
+
+        Returns:
+            A compact dict with the Whitebox return code, output path, and
+            QGIS load status.
+        """
+        aliases = {
+            "breach": "breach_depressions",
+            "breach_depressions": "breach_depressions",
+            "fill": "fill_depressions",
+            "fill_depressions": "fill_depressions",
+            "wang_and_liu": "fill_depressions_wang_and_liu",
+            "fill_depressions_wang_and_liu": "fill_depressions_wang_and_liu",
+        }
+        tool_name = aliases.get(str(method).strip().lower())
+        if tool_name is None:
+            raise ValueError(
+                "Unknown sink-filling method. Use 'breach_depressions', "
+                "'fill_depressions', or 'fill_depressions_wang_and_liu'."
+            )
+
+        selected_layer = layer_name or _active_layer_name(iface)
+        name = output_layer_name or f"{selected_layer} filled sinks"
+        params: dict[str, Any] = {
+            "dem": selected_layer,
+            "output": output_path,
+        }
+        if output_path is None:
+            params.pop("output")
+        if max_depth is not None:
+            params["max_depth"] = float(max_depth)
+        if flat_increment is not None:
+            params["flat_increment"] = float(flat_increment)
+        if tool_name == "breach_depressions":
+            if max_length is not None:
+                params["max_length"] = float(max_length)
+            if fill_pits is not None:
+                params["fill_pits"] = bool(fill_pits)
+        elif fix_flats is not None:
+            params["fix_flats"] = bool(fix_flats)
+
+        return run_whitebox_tool.__wrapped__(
+            tool_name,
+            params,
+            add_outputs_to_qgis=add_outputs_to_qgis,
+            output_layer_name=name,
+            verbose=verbose,
+        )
+
+    @geo_tool(
+        category="whitebox",
+        name="run_whitebox_color_shaded_relief",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("whitebox",),
+    )
+    def run_whitebox_color_shaded_relief(
+        layer_name: Optional[str] = None,
+        output_path: Optional[str] = None,
+        output_layer_name: Optional[str] = None,
+        palette: str = "atlas",
+        altitude: float = 45.0,
+        hillshade_weight: float = 0.5,
+        brightness: float = 0.5,
+        atmospheric: float = 0.0,
+        reverse_palette: bool = False,
+        zfactor: Optional[float] = None,
+        full_mode: bool = False,
+        add_outputs_to_qgis: bool = True,
+        verbose: bool = False,
+    ) -> dict[str, Any]:
+        """Create color shaded relief from a DEM layer and load the raster.
+
+        Args:
+            layer_name: QGIS DEM layer name. When omitted, uses the active
+                layer.
+            output_path: Optional raster output path.
+            output_layer_name: Optional display name for the output layer.
+            palette: Whitebox palette name, e.g. ``atlas`` or ``viridis``.
+            altitude: Illumination source altitude in degrees.
+            hillshade_weight: Weight given to hillshade relative to relief.
+            brightness: Brightness factor from 0.0 to 1.0.
+            atmospheric: Atmospheric effects weight from 0.0 to 1.0.
+            reverse_palette: Whether to reverse the palette.
+            zfactor: Optional vertical unit conversion factor.
+            full_mode: Whether to use full 360-degree hillshade mode.
+            add_outputs_to_qgis: Whether to add the generated raster to QGIS.
+            verbose: Whether WhiteboxTools should emit verbose progress.
+
+        Returns:
+            A compact dict with the Whitebox return code, output path, and
+            QGIS load status.
+        """
+        selected_layer = layer_name or _active_layer_name(iface)
+        name = output_layer_name or f"{selected_layer} color shaded relief"
+        params: dict[str, Any] = {
+            "dem": selected_layer,
+            "output": output_path,
+            "altitude": float(altitude),
+            "hs_weight": float(hillshade_weight),
+            "brightness": float(brightness),
+            "atmospheric": float(atmospheric),
+            "palette": palette,
+            "reverse": bool(reverse_palette),
+            "full_mode": bool(full_mode),
+        }
+        if output_path is None:
+            params.pop("output")
+        if zfactor is not None:
+            params["zfactor"] = float(zfactor)
+        return run_whitebox_tool.__wrapped__(
+            "hypsometrically_tinted_hillshade",
+            params,
+            add_outputs_to_qgis=add_outputs_to_qgis,
+            output_layer_name=name,
+            verbose=verbose,
+        )
+
     return [
         summarize_whitebox_tools,
         search_whitebox_tools,
         get_whitebox_tool_info,
         run_whitebox_tool,
+        run_whitebox_flow_accumulation,
+        run_whitebox_fill_sinks,
+        run_whitebox_color_shaded_relief,
     ]
 
 

--- a/geoagent/tools/whitebox.py
+++ b/geoagent/tools/whitebox.py
@@ -49,43 +49,64 @@ def _safe_stem(value: str, fallback: str = "whitebox_output") -> str:
 
 
 def _project_from_iface(iface: Any, project: Optional[Any]) -> Any:
-    """Return the configured project or resolve it from the QGIS iface."""
+    """Return the configured project or resolve it from the QGIS iface.
+
+    QGIS APIs (``iface.project()`` and ``QgsProject.instance()``) are not
+    thread-safe, so the lookup is marshalled onto the Qt GUI thread.
+    """
     if project is not None:
         return project
-    if hasattr(iface, "project"):
-        try:
-            proj = iface.project()
-            if proj is not None:
-                return proj
-        except Exception:
-            pass
-    try:
-        from qgis.core import QgsProject  # type: ignore[import-not-found]
 
-        return QgsProject.instance()
-    except Exception as exc:  # pragma: no cover - QGIS-only path
-        raise RuntimeError("QGIS is not available; cannot resolve QgsProject.") from exc
+    def _resolve() -> Any:
+        if hasattr(iface, "project"):
+            try:
+                proj = iface.project()
+                if proj is not None:
+                    return proj
+            except Exception:
+                pass
+        try:
+            from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+            return QgsProject.instance()
+        except Exception as exc:  # pragma: no cover - QGIS-only path
+            raise RuntimeError(
+                "QGIS is not available; cannot resolve QgsProject."
+            ) from exc
+
+    return run_on_qt_gui_thread(_resolve)
 
 
 def _project_output_dir(project: Any) -> str:
-    """Choose a stable directory for generated Whitebox outputs."""
-    for attr in ("homePath", "absolutePath"):
-        method = getattr(project, attr, None)
-        if callable(method):
+    """Choose a stable directory for generated Whitebox outputs.
+
+    Project path getters (``homePath``, ``absolutePath``, ``fileName``) are
+    QGIS API calls and are marshalled onto the Qt GUI thread.
+    """
+
+    def _read_paths() -> str | None:
+        for attr in ("homePath", "absolutePath"):
+            method = getattr(project, attr, None)
+            if callable(method):
+                try:
+                    value = str(method()).strip()
+                    if value:
+                        return value
+                except Exception:
+                    pass
+        file_name = getattr(project, "fileName", None)
+        if callable(file_name):
             try:
-                value = str(method()).strip()
+                value = str(file_name()).strip()
                 if value:
-                    return value
+                    return str(Path(value).parent)
             except Exception:
                 pass
-    file_name = getattr(project, "fileName", None)
-    if callable(file_name):
-        try:
-            value = str(file_name()).strip()
-            if value:
-                return str(Path(value).parent)
-        except Exception:
-            pass
+        return None
+
+    resolved = run_on_qt_gui_thread(_read_paths)
+    if resolved:
+        return resolved
     out_dir = Path(tempfile.gettempdir()) / "geoagent_whitebox"
     out_dir.mkdir(parents=True, exist_ok=True)
     return str(out_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,12 @@ earthengine = ["earthengine-api>=1.0", "geemap"]
 stac = ["pystac-client>=0.8", "planetary-computer>=1.0"]
 earthdata = ["earthaccess>=0.10"]
 nasa-opera = ["earthaccess>=0.10"]
+whitebox = ["whitebox>=2.3.6"]
 ui = ["solara>=1.35"]
 qgis = []
 providers = ["GeoAgent[openai,anthropic,gemini,ollama,litellm]"]
 all = [
-    "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,nasa-opera,ui]",
+    "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,nasa-opera,whitebox,ui]",
 ]
 dev = [
     "pytest>=8.0",

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -28,6 +28,7 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 # Required packages: (import_name, pip_install_name)
 REQUIRED_PACKAGES = [
     ("geoagent", "GeoAgent[providers]>=1.0.0"),
+    ("whitebox", "whitebox>=2.3.6"),
     ("openai", "openai>=1.0"),
     ("anthropic", "anthropic>=0.40"),
     ("google.genai", "google-genai>=1.0"),

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -46,6 +46,9 @@ SAMPLE_PROMPTS = [
     "Inspect the active vector layer fields and suggest useful styling or labeling options.",
     "Select features in the active layer where population is greater than 100000, then zoom to the selected features.",
     "Run a buffer around the active layer by 1000 meters and add the output to the project.",
+    "Find a WhiteboxTools command for calculating slope from the active DEM layer.",
+    "Run a WhiteboxTools hillshade analysis on a local DEM and add the result to QGIS.",
+    "Search WhiteboxTools for watershed or flow accumulation tools.",
     "Create a concise map QA checklist for this project before I export it.",
 ]
 
@@ -237,7 +240,7 @@ class ChatWorker(QThread):
         """Create a GeoAgent QGIS agent and execute one chat turn."""
         try:
             from geoagent import GeoAgentConfig
-            from geoagent import for_qgis
+            from geoagent import for_whitebox
 
             try:
                 from qgis.core import QgsProject
@@ -251,11 +254,12 @@ class ChatWorker(QThread):
                 model=self.model_id,
                 max_tokens=self.max_tokens,
             )
-            agent = for_qgis(
+            agent = for_whitebox(
                 self.iface,
                 project=project,
                 config=config,
                 fast=self.fast,
+                confirm=self._confirm_tool,
             )
             response = agent.chat(self.prompt)
 
@@ -280,6 +284,40 @@ class ChatWorker(QThread):
                     "elapsed": "",
                 }
             )
+
+    def _confirm_tool(self, request):
+        """Ask the QGIS user before running confirmation-required tools."""
+        from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+        def _ask():
+            parent = None
+            try:
+                parent = self.iface.mainWindow()
+            except Exception:
+                pass
+
+            arg_lines = []
+            for key, value in request.args.items():
+                text = str(value)
+                if len(text) > 160:
+                    text = text[:157] + "..."
+                arg_lines.append(f"{key}: {text}")
+
+            details = "\n".join(arg_lines) if arg_lines else "No arguments"
+            message = (
+                f"GeoAgent wants to run:\n\n{request.tool_name}\n\n"
+                f"{details}\n\nAllow this action?"
+            )
+            reply = QMessageBox.question(
+                parent,
+                "Confirm GeoAgent Tool",
+                message,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            return reply == QMessageBox.StandardButton.Yes
+
+        return bool(run_on_qt_gui_thread(_ask))
 
 
 class ChatDockWidget(QDockWidget):

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -226,7 +226,15 @@ class ChatWorker(QThread):
     finished = pyqtSignal(dict)
 
     def __init__(
-        self, iface, prompt, provider, model_id, fast, max_tokens, parent=None
+        self,
+        iface,
+        prompt,
+        provider,
+        model_id,
+        fast,
+        max_tokens,
+        auto_approve_tools=False,
+        parent=None,
     ):
         super().__init__(parent)
         self.iface = iface
@@ -235,6 +243,7 @@ class ChatWorker(QThread):
         self.model_id = model_id or None
         self.fast = fast
         self.max_tokens = max_tokens
+        self.auto_approve_tools = bool(auto_approve_tools)
 
     def run(self):
         """Create a GeoAgent QGIS agent and execute one chat turn."""
@@ -287,6 +296,9 @@ class ChatWorker(QThread):
 
     def _confirm_tool(self, request):
         """Ask the QGIS user before running confirmation-required tools."""
+        if self.auto_approve_tools:
+            return True
+
         from geoagent.tools._qt_marshal import run_on_qt_gui_thread
 
         def _ask():
@@ -376,7 +388,15 @@ class ChatDockWidget(QDockWidget):
         model_layout.addRow("Model:", self.model_input)
 
         self.fast_check = QCheckBox("Fast mode")
-        model_layout.addRow("", self.fast_check)
+        self.auto_approve_tools_check = QCheckBox("Auto approve running tools")
+        self.auto_approve_tools_check.setToolTip(
+            "Run confirmation-required tools without prompting for this session."
+        )
+        mode_layout = QHBoxLayout()
+        mode_layout.addWidget(self.fast_check)
+        mode_layout.addWidget(self.auto_approve_tools_check)
+        mode_layout.addStretch(1)
+        model_layout.addRow("", mode_layout)
 
         layout.addWidget(model_group)
 
@@ -448,6 +468,9 @@ class ChatDockWidget(QDockWidget):
         self.model_input.setText(model)
 
         self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
+        self.auto_approve_tools_check.setChecked(
+            _setting(self.settings, "auto_approve_tools", False, bool)
+        )
 
     def _save_model_settings(self):
         """Persist the selected provider, model, and fast-mode setting."""
@@ -457,6 +480,10 @@ class ChatDockWidget(QDockWidget):
         self.settings.setValue(f"{SETTINGS_PREFIX}model", self.model_input.text())
         self.settings.setValue(
             f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}auto_approve_tools",
+            self.auto_approve_tools_check.isChecked(),
         )
 
     def _on_provider_changed(self, provider):
@@ -483,6 +510,7 @@ class ChatDockWidget(QDockWidget):
         provider = self.provider_combo.currentText()
         model_id = self.model_input.text().strip()
         fast = self.fast_check.isChecked()
+        auto_approve_tools = self.auto_approve_tools_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         prompt_with_context = self._build_prompt_with_context(prompt)
 
@@ -499,6 +527,7 @@ class ChatDockWidget(QDockWidget):
             model_id,
             fast,
             max_tokens,
+            auto_approve_tools,
             self,
         )
         self._worker.finished.connect(self._on_worker_finished)

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -1,5 +1,7 @@
 """Settings and dependency management for OpenGeoAgent."""
 
+import os
+
 from qgis.PyQt.QtCore import Qt, QSettings, QTimer
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
@@ -22,11 +24,30 @@ from qgis.PyQt.QtGui import QFont
 
 from .chat_dock import DEFAULT_MODELS, PROVIDERS, SETTINGS_PREFIX
 
+ENV_FALLBACKS = {
+    "openai_api_key": ("OPENAI_API_KEY",),
+    "anthropic_api_key": ("ANTHROPIC_API_KEY",),
+    "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "aws_region": ("AWS_REGION", "AWS_DEFAULT_REGION"),
+    "ollama_host": ("OLLAMA_HOST",),
+    "litellm_api_key": ("LITELLM_API_KEY",),
+    "litellm_base_url": ("LITELLM_BASE_URL",),
+}
+
 
 def _enum_value(cls, enum_name, member_name):
     """Return an enum member from either scoped or legacy Qt APIs."""
     container = getattr(cls, enum_name, cls)
     return getattr(container, member_name)
+
+
+def _env_fallback(*env_names):
+    """Return the first non-empty environment value from ``env_names``."""
+    for env_name in env_names:
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+    return ""
 
 
 class SettingsDockWidget(QDockWidget):
@@ -364,27 +385,20 @@ class SettingsDockWidget(QDockWidget):
         self.max_tokens_spin.setValue(
             self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         )
-        self.openai_key_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}openai_api_key", "", type=str)
-        )
-        self.anthropic_key_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}anthropic_api_key", "", type=str)
-        )
-        self.gemini_key_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}gemini_api_key", "", type=str)
-        )
-        self.aws_region_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}aws_region", "", type=str)
-        )
-        self.ollama_host_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}ollama_host", "", type=str)
-        )
-        self.litellm_key_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}litellm_api_key", "", type=str)
-        )
-        self.litellm_base_url_input.setText(
-            self.settings.value(f"{SETTINGS_PREFIX}litellm_base_url", "", type=str)
-        )
+        self.openai_key_input.setText(self._credential_value("openai_api_key"))
+        self.anthropic_key_input.setText(self._credential_value("anthropic_api_key"))
+        self.gemini_key_input.setText(self._credential_value("gemini_api_key"))
+        self.aws_region_input.setText(self._credential_value("aws_region"))
+        self.ollama_host_input.setText(self._credential_value("ollama_host"))
+        self.litellm_key_input.setText(self._credential_value("litellm_api_key"))
+        self.litellm_base_url_input.setText(self._credential_value("litellm_base_url"))
+
+    def _credential_value(self, key):
+        """Return a saved credential value, falling back to environment vars."""
+        saved = self.settings.value(f"{SETTINGS_PREFIX}{key}", "", type=str)
+        if str(saved).strip():
+            return str(saved)
+        return _env_fallback(*ENV_FALLBACKS.get(key, ()))
 
     def _save_settings(self):
         """Persist settings from the form fields."""

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -385,20 +385,35 @@ class SettingsDockWidget(QDockWidget):
         self.max_tokens_spin.setValue(
             self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         )
-        self.openai_key_input.setText(self._credential_value("openai_api_key"))
-        self.anthropic_key_input.setText(self._credential_value("anthropic_api_key"))
-        self.gemini_key_input.setText(self._credential_value("gemini_api_key"))
-        self.aws_region_input.setText(self._credential_value("aws_region"))
-        self.ollama_host_input.setText(self._credential_value("ollama_host"))
-        self.litellm_key_input.setText(self._credential_value("litellm_api_key"))
-        self.litellm_base_url_input.setText(self._credential_value("litellm_base_url"))
+
+        self._credential_inputs = (
+            ("openai_api_key", self.openai_key_input),
+            ("anthropic_api_key", self.anthropic_key_input),
+            ("gemini_api_key", self.gemini_key_input),
+            ("aws_region", self.aws_region_input),
+            ("ollama_host", self.ollama_host_input),
+            ("litellm_api_key", self.litellm_key_input),
+            ("litellm_base_url", self.litellm_base_url_input),
+        )
+        self._env_sourced_credentials = {}
+        for key, widget in self._credential_inputs:
+            value, from_env = self._credential_value(key)
+            widget.setText(value)
+            if from_env:
+                self._env_sourced_credentials[key] = value
 
     def _credential_value(self, key):
-        """Return a saved credential value, falling back to environment vars."""
+        """Return ``(value, from_env)`` for a credential field.
+
+        Looks up ``key`` in QSettings first; if no saved value exists, falls
+        back to the configured environment variables. ``from_env`` is True
+        only when the returned value originated from the environment.
+        """
         saved = self.settings.value(f"{SETTINGS_PREFIX}{key}", "", type=str)
         if str(saved).strip():
-            return str(saved)
-        return _env_fallback(*ENV_FALLBACKS.get(key, ()))
+            return str(saved), False
+        fallback = _env_fallback(*ENV_FALLBACKS.get(key, ()))
+        return fallback, bool(fallback)
 
     def _save_settings(self):
         """Persist settings from the form fields."""
@@ -412,28 +427,15 @@ class SettingsDockWidget(QDockWidget):
         self.settings.setValue(
             f"{SETTINGS_PREFIX}max_tokens", self.max_tokens_spin.value()
         )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}openai_api_key", self.openai_key_input.text()
-        )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}anthropic_api_key", self.anthropic_key_input.text()
-        )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}gemini_api_key", self.gemini_key_input.text()
-        )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}aws_region", self.aws_region_input.text()
-        )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}ollama_host", self.ollama_host_input.text()
-        )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}litellm_api_key", self.litellm_key_input.text()
-        )
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}litellm_base_url",
-            self.litellm_base_url_input.text(),
-        )
+        for key, widget in getattr(self, "_credential_inputs", ()):
+            current = widget.text()
+            env_value = self._env_sourced_credentials.get(key)
+            if env_value is not None and current == env_value:
+                # Field was pre-filled from an environment variable and the
+                # user did not change it; skip persisting the env-sourced
+                # secret to QSettings.
+                continue
+            self.settings.setValue(f"{SETTINGS_PREFIX}{key}", current)
         self.status_label.setText("Settings saved")
         self.status_label.setStyleSheet("color: green; font-size: 10px;")
         self.iface.messageBar().pushSuccess("OpenGeoAgent", "Settings saved.")

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-import inspect
+import sys
+import types
+from typing import Any
 
 
 def test_dependencies_include_whitebox() -> None:
@@ -12,10 +14,63 @@ def test_dependencies_include_whitebox() -> None:
     assert ("whitebox", "whitebox>=2.3.6") in REQUIRED_PACKAGES
 
 
-def test_chat_worker_uses_whitebox_factory() -> None:
-    """Verify chat requests are routed through the Whitebox factory."""
+def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
+    """ChatWorker.run dispatches the chat through ``geoagent.for_whitebox``.
+
+    Asserts behavior rather than source text: the factory is monkeypatched
+    and ``ChatWorker.run`` is invoked synchronously so a refactor that
+    silently swaps the factory will fail this test.
+    """
+    import geoagent
     from open_geoagent.dialogs.chat_dock import ChatWorker, SAMPLE_PROMPTS
 
-    run_source = inspect.getsource(ChatWorker.run)
-    assert "for_whitebox" in run_source
+    captured: dict[str, Any] = {}
+
+    class _StubResponse:
+        success = True
+        answer_text = "ok"
+        error_message = ""
+        executed_tools: list = []
+        cancelled_tools: list = []
+        execution_time = 0.0
+
+    class _StubAgent:
+        def chat(self, prompt: str) -> _StubResponse:
+            captured["prompt"] = prompt
+            return _StubResponse()
+
+    def _stub_factory(iface, **kwargs):
+        captured["iface"] = iface
+        captured["kwargs"] = kwargs
+        return _StubAgent()
+
+    monkeypatch.setattr(geoagent, "for_whitebox", _stub_factory)
+
+    # Avoid pulling QgsProject (the qgis stub returns None for instance()).
+    monkeypatch.setitem(
+        sys.modules,
+        "qgis.core",
+        types.SimpleNamespace(QgsProject=types.SimpleNamespace(instance=lambda: None)),
+    )
+
+    sentinel_iface = object()
+    worker = ChatWorker(
+        iface=sentinel_iface,
+        prompt="hello",
+        provider="anthropic",
+        model_id="claude-x",
+        fast=False,
+        max_tokens=1024,
+    )
+
+    emitted: dict[str, Any] = {}
+    worker.finished.connect(lambda payload: emitted.setdefault("payload", payload))
+
+    worker.run()
+
+    assert captured.get("iface") is sentinel_iface
+    assert captured["prompt"] == "hello"
+    assert captured["kwargs"]["fast"] is False
+    assert "confirm" in captured["kwargs"]
+    assert emitted["payload"]["success"] is True
     assert any("WhiteboxTools" in prompt for prompt in SAMPLE_PROMPTS)

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -61,6 +61,7 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
         model_id="claude-x",
         fast=False,
         max_tokens=1024,
+        auto_approve_tools=True,
     )
 
     emitted: dict[str, Any] = {}
@@ -72,5 +73,6 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
     assert captured["prompt"] == "hello"
     assert captured["kwargs"]["fast"] is False
     assert "confirm" in captured["kwargs"]
+    assert captured["kwargs"]["confirm"](types.SimpleNamespace(args={})) is True
     assert emitted["payload"]["success"] is True
     assert any("WhiteboxTools" in prompt for prompt in SAMPLE_PROMPTS)

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -1,0 +1,21 @@
+"""Tests for OpenGeoAgent Whitebox integration wiring."""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_dependencies_include_whitebox() -> None:
+    """Verify the plugin dependency installer checks Whitebox."""
+    from open_geoagent.deps_manager import REQUIRED_PACKAGES
+
+    assert ("whitebox", "whitebox>=2.3.6") in REQUIRED_PACKAGES
+
+
+def test_chat_worker_uses_whitebox_factory() -> None:
+    """Verify chat requests are routed through the Whitebox factory."""
+    from open_geoagent.dialogs.chat_dock import ChatWorker, SAMPLE_PROMPTS
+
+    run_source = inspect.getsource(ChatWorker.run)
+    assert "for_whitebox" in run_source
+    assert any("WhiteboxTools" in prompt for prompt in SAMPLE_PROMPTS)

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -42,6 +42,24 @@ def test_chat_success_from_mocked_strands() -> None:
     mock_agent.assert_called_once()
 
 
+def test_chat_json_parse_error_returns_actionable_guidance() -> None:
+    """Verify malformed tool-call JSON gets user-facing correction guidance."""
+    m = MockLeafmap()
+    agent = for_leafmap(m, model=_MockModel())
+    agent._strands = MagicMock(  # noqa: SLF001
+        side_effect=ValueError(
+            "failed to parse JSON: unexpected end of JSON input (status code: -1)"
+        )
+    )
+
+    resp = agent.chat("create color shaded relief")
+
+    assert resp.success is False
+    assert "malformed or incomplete JSON" in resp.error_message
+    assert "Original error:" in resp.error_message
+    assert "Break a long workflow into smaller steps" in resp.error_message
+
+
 def test_chat_in_background_returns_and_invokes_callback() -> None:
     """Verify that chat in background returns and invokes callback."""
     m = MockLeafmap()

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -61,6 +61,7 @@ def test_factory_returns_tools_for_iface() -> None:
         "zoom_to_selected",
         "get_layer_summary",
         "run_processing_algorithm",
+        "buffer_active_layer",
         "open_attribute_table",
         "refresh_canvas",
         "save_project",
@@ -75,6 +76,7 @@ def test_remove_layer_and_run_processing_require_confirmation() -> None:
     tools = {t.tool_name: t for t in qgis_tools(iface, project)}
     assert needs_confirmation(tools["remove_layer"]) is True
     assert needs_confirmation(tools["run_processing_algorithm"]) is True
+    assert needs_confirmation(tools["buffer_active_layer"]) is True
     assert needs_confirmation(tools["save_project"]) is True
     assert needs_confirmation(tools["zoom_in"]) is False
     assert needs_confirmation(tools["list_project_layers"]) is False
@@ -418,6 +420,44 @@ def test_add_xyz_tile_layer_uses_raster_fallback() -> None:
     )
     assert "Added XYZ" in out
     assert "Tiles" in project.mapLayers()
+
+
+def test_buffer_active_layer_runs_processing_and_loads_output(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify the active-layer buffer convenience tool wraps Processing."""
+    import types
+
+    project = MockQGISProject()
+    iface = MockQGISIface(project=project)
+    layer = MockQGISLayer("Roads", "/tmp/roads.gpkg", "vector")
+    project.addMapLayer(layer)
+    iface.setActiveLayer(layer)
+
+    output_path = tmp_path / "roads_buffer.gpkg"
+    captured = {}
+
+    def _run(algorithm_id, parameters):
+        captured["algorithm_id"] = algorithm_id
+        captured["parameters"] = dict(parameters)
+        output_path.write_text("buffer", encoding="utf-8")
+        return {"OUTPUT": str(output_path)}
+
+    monkeypatch.setitem(sys.modules, "processing", types.SimpleNamespace(run=_run))
+
+    tools = {t.tool_name: t for t in qgis_tools(iface, project)}
+    result = tools["buffer_active_layer"].__wrapped__(
+        distance_meters=1000,
+        output_layer_name="Road buffer",
+        output_path=str(output_path),
+    )
+
+    assert captured["algorithm_id"] == "native:buffer"
+    assert captured["parameters"]["INPUT"] is layer
+    assert captured["parameters"]["DISTANCE"] == 1000.0
+    assert result["success"] is True
+    assert result["output"] == str(output_path)
+    assert "Road buffer" in project.mapLayers()
 
 
 def test_layer_opacity_selection_and_summary() -> None:

--- a/tests/test_whitebox_tools.py
+++ b/tests/test_whitebox_tools.py
@@ -1,0 +1,246 @@
+"""Tests for the WhiteboxTools GeoAgent adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType
+
+import pytest
+
+from geoagent import for_whitebox
+from geoagent.testing import MockQGISIface, MockQGISLayer, MockQGISProject
+from geoagent.tools.whitebox import whitebox_tools
+
+
+class _MockModel:
+    """Provide a test double for MockModel."""
+
+    stateful = False
+
+
+def test_whitebox_module_imports_without_qgis_or_whitebox() -> None:
+    """Verify the adapter module is import-safe outside QGIS and Whitebox."""
+    if "qgis" in sys.modules:
+        pytest.skip("qgis is already imported in this environment.")
+    assert "geoagent.tools.whitebox" in sys.modules
+    assert "qgis" not in sys.modules
+    assert "whitebox" not in sys.modules
+
+
+def test_whitebox_tools_returns_empty_for_none_iface() -> None:
+    """Verify the Whitebox factory returns no tools without iface."""
+    assert whitebox_tools(None) == []
+
+
+def test_whitebox_tools_expose_routed_surface() -> None:
+    """Verify the adapter exposes a small broker surface."""
+    tools = {tool.tool_name: tool for tool in whitebox_tools(object())}
+
+    assert set(tools) == {
+        "summarize_whitebox_tools",
+        "search_whitebox_tools",
+        "get_whitebox_tool_info",
+        "run_whitebox_tool",
+    }
+
+
+def test_search_whitebox_tools_returns_compact_results(monkeypatch) -> None:
+    """Verify search wraps WhiteboxTools list_tools output."""
+
+    class _FakeWBT:
+        verbose = True
+
+        def list_tools(self, keywords=None):
+            assert keywords == ["slope"]
+            return {
+                "slope": "Calculates slope from a DEM.",
+                "average_normal_vector_angular_deviation": "Terrain metric.",
+            }
+
+        def toolbox(self, tool_name):
+            return "Terrain Analysis" if tool_name == "slope" else "Math"
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    tools = {tool.tool_name: tool for tool in whitebox_tools(object())}
+    result = tools["search_whitebox_tools"].__wrapped__(
+        query="slope",
+        category="terrain",
+        max_results=5,
+    )
+
+    assert result["count"] == 1
+    assert result["tools"] == [
+        {
+            "name": "slope",
+            "description": "Calculates slope from a DEM.",
+            "category": "Terrain Analysis",
+        }
+    ]
+
+
+def test_get_whitebox_tool_info_parses_parameter_json(monkeypatch) -> None:
+    """Verify tool info exposes flags, keys, optionality, and help."""
+
+    class _FakeWBT:
+        verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "slope"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input DEM File",
+                            "flags": ["-i", "--dem"],
+                            "description": "Input raster DEM file.",
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "default_value": None,
+                            "optional": False,
+                        }
+                    ]
+                }
+            )
+
+        def toolbox(self, tool_name):
+            return "Terrain Analysis"
+
+        def tool_help(self, tool_name):
+            return "Slope help text"
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    tools = {tool.tool_name: tool for tool in whitebox_tools(object())}
+    result = tools["get_whitebox_tool_info"].__wrapped__("slope")
+
+    assert result["tool_name"] == "slope"
+    assert result["category"] == "Terrain Analysis"
+    assert result["parameters"][0]["flags"] == ["-i", "--dem"]
+    assert "dem" in result["parameters"][0]["keys"]
+    assert result["parameters"][0]["optional"] is False
+    assert result["help"] == "Slope help text"
+
+
+def test_run_whitebox_tool_builds_args_and_loads_output(monkeypatch, tmp_path) -> None:
+    """Verify run_tool args, callback capture, and QGIS output loading."""
+    input_path = tmp_path / "dem.tif"
+    output_path = tmp_path / "slope.tif"
+    input_path.write_text("dem", encoding="utf-8")
+
+    captured = {}
+
+    class _FakeWBT:
+        verbose = True
+
+        def __init__(self):
+            self.verbose = True
+
+        def set_working_dir(self, path):
+            captured["working_dir"] = path
+
+        def set_compress_rasters(self, value):
+            captured["compress_rasters"] = value
+
+        def set_max_procs(self, value):
+            captured["max_procs"] = value
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "slope"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input DEM File",
+                            "flags": ["-i", "--dem"],
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Output File",
+                            "flags": ["-o", "--output"],
+                            "parameter_type": {"NewFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Z Conversion Factor",
+                            "flags": ["--zfactor"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                    ]
+                }
+            )
+
+        def run_tool(self, tool_name, args, callback=None):
+            captured["tool_name"] = tool_name
+            captured["args"] = args
+            output_path.write_text("slope", encoding="utf-8")
+            if callback:
+                callback("Progress: 100%")
+            return 0
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    project = MockQGISProject()
+    project.addMapLayer(MockQGISLayer("DEM layer", str(input_path), "raster"))
+    iface = MockQGISIface(project)
+    tools = {tool.tool_name: tool for tool in whitebox_tools(iface, project)}
+
+    result = tools["run_whitebox_tool"].__wrapped__(
+        "slope",
+        {"dem": "DEM layer", "output": str(output_path), "zfactor": 1.2},
+        working_dir=str(tmp_path),
+        output_layer_name="Slope",
+        compress_rasters=True,
+        max_procs=2,
+    )
+
+    assert captured["tool_name"] == "slope"
+    assert captured["args"] == [
+        f"--dem={input_path}",
+        f"--output={output_path}",
+        "--zfactor=1.2",
+    ]
+    assert captured["working_dir"] == str(tmp_path)
+    assert captured["compress_rasters"] is True
+    assert captured["max_procs"] == 2
+    assert result["success"] is True
+    assert result["messages"] == ["Progress: 100%"]
+    assert result["layers_added"] == [
+        {"path": str(output_path), "added": True, "layer_name": "Slope"}
+    ]
+    assert "Slope" in project.mapLayers()
+
+
+def test_for_whitebox_registers_tools_and_respects_fast_mode(monkeypatch) -> None:
+    """Verify the factory combines Whitebox and QGIS tools."""
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = object
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    agent = for_whitebox(MockQGISIface(), MockQGISProject(), model=_MockModel())
+    names = set(agent.strands_agent.tool_names)
+
+    assert "search_whitebox_tools" in names
+    assert "run_whitebox_tool" in names
+    assert "list_project_layers" in names
+    assert agent.context.metadata["integration"] == "whitebox"
+
+    fast_agent = for_whitebox(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+        fast=True,
+    )
+    fast_names = set(fast_agent.strands_agent.tool_names)
+
+    assert "search_whitebox_tools" in fast_names
+    assert "get_whitebox_tool_info" in fast_names
+    assert "run_whitebox_tool" not in fast_names

--- a/tests/test_whitebox_tools.py
+++ b/tests/test_whitebox_tools.py
@@ -42,6 +42,9 @@ def test_whitebox_tools_expose_routed_surface() -> None:
         "search_whitebox_tools",
         "get_whitebox_tool_info",
         "run_whitebox_tool",
+        "run_whitebox_flow_accumulation",
+        "run_whitebox_fill_sinks",
+        "run_whitebox_color_shaded_relief",
     }
 
 
@@ -124,6 +127,25 @@ def test_get_whitebox_tool_info_parses_parameter_json(monkeypatch) -> None:
     assert "dem" in result["parameters"][0]["keys"]
     assert result["parameters"][0]["optional"] is False
     assert result["help"] == "Slope help text"
+
+
+def test_get_whitebox_tool_info_reports_invalid_parameter_json(monkeypatch) -> None:
+    """Verify invalid Whitebox metadata JSON produces an actionable error."""
+
+    class _FakeWBT:
+        verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "slope"
+            return ""
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    tools = {tool.tool_name: tool for tool in whitebox_tools(object())}
+    with pytest.raises(ValueError, match="invalid parameter metadata JSON"):
+        tools["get_whitebox_tool_info"].__wrapped__("slope")
 
 
 def test_run_whitebox_tool_builds_args_and_loads_output(monkeypatch, tmp_path) -> None:
@@ -217,6 +239,297 @@ def test_run_whitebox_tool_builds_args_and_loads_output(monkeypatch, tmp_path) -
         {"path": str(output_path), "added": True, "layer_name": "Slope"}
     ]
     assert "Slope" in project.mapLayers()
+
+
+def test_run_whitebox_flow_accumulation_uses_active_layer(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify the flow accumulation convenience tool uses the active DEM."""
+    input_path = tmp_path / "dem.tif"
+    output_path = tmp_path / "flow_accumulation.tif"
+    input_path.write_text("dem", encoding="utf-8")
+
+    captured = {}
+
+    class _FakeWBT:
+        verbose = True
+
+        def __init__(self):
+            self.verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "d8_flow_accumulation"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input Raster File",
+                            "flags": ["-i", "--input"],
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Output File",
+                            "flags": ["-o", "--output"],
+                            "parameter_type": {"NewFile": "Raster"},
+                            "optional": False,
+                        },
+                    ]
+                }
+            )
+
+        def run_tool(self, tool_name, args, callback=None):
+            captured["tool_name"] = tool_name
+            captured["args"] = args
+            output_path.write_text("flow", encoding="utf-8")
+            return 0
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    project = MockQGISProject()
+    layer = MockQGISLayer("DEM layer", str(input_path), "raster")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project)
+    iface.setActiveLayer(layer)
+    tools = {tool.tool_name: tool for tool in whitebox_tools(iface, project)}
+
+    result = tools["run_whitebox_flow_accumulation"].__wrapped__(
+        output_path=str(output_path),
+        output_layer_name="Flow Accumulation",
+    )
+
+    assert captured["tool_name"] == "d8_flow_accumulation"
+    assert captured["args"] == [
+        f"--input={input_path}",
+        f"--output={output_path}",
+    ]
+    assert result["success"] is True
+    assert result["layers_added"] == [
+        {
+            "path": str(output_path),
+            "added": True,
+            "layer_name": "Flow Accumulation",
+        }
+    ]
+    assert "Flow Accumulation" in project.mapLayers()
+
+
+def test_run_whitebox_fill_sinks_uses_active_layer(monkeypatch, tmp_path) -> None:
+    """Verify the sink-filling convenience tool uses the active DEM."""
+    input_path = tmp_path / "dem.tif"
+    output_path = tmp_path / "dem_filled.tif"
+    input_path.write_text("dem", encoding="utf-8")
+
+    captured = {}
+
+    class _FakeWBT:
+        verbose = True
+
+        def __init__(self):
+            self.verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "breach_depressions"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input DEM File",
+                            "flags": ["-i", "--dem"],
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Output File",
+                            "flags": ["-o", "--output"],
+                            "parameter_type": {"NewFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Maximum Breach Depth (z units)",
+                            "flags": ["--max_depth"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Fill single-cell pits?",
+                            "flags": ["--fill_pits"],
+                            "parameter_type": "Boolean",
+                            "optional": True,
+                        },
+                    ]
+                }
+            )
+
+        def run_tool(self, tool_name, args, callback=None):
+            captured["tool_name"] = tool_name
+            captured["args"] = args
+            output_path.write_text("filled", encoding="utf-8")
+            return 0
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    project = MockQGISProject()
+    layer = MockQGISLayer("DEM layer", str(input_path), "raster")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project)
+    iface.setActiveLayer(layer)
+    tools = {tool.tool_name: tool for tool in whitebox_tools(iface, project)}
+
+    result = tools["run_whitebox_fill_sinks"].__wrapped__(
+        output_path=str(output_path),
+        output_layer_name="DEM Filled",
+        max_depth=10,
+        fill_pits=True,
+    )
+
+    assert captured["tool_name"] == "breach_depressions"
+    assert captured["args"] == [
+        f"--dem={input_path}",
+        f"--output={output_path}",
+        "--max_depth=10.0",
+        "--fill_pits",
+    ]
+    assert result["success"] is True
+    assert result["layers_added"] == [
+        {
+            "path": str(output_path),
+            "added": True,
+            "layer_name": "DEM Filled",
+        }
+    ]
+    assert "DEM Filled" in project.mapLayers()
+
+
+def test_run_whitebox_color_shaded_relief_uses_active_layer(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify the color shaded relief convenience tool uses the active DEM."""
+    input_path = tmp_path / "dem.tif"
+    output_path = tmp_path / "relief.tif"
+    input_path.write_text("dem", encoding="utf-8")
+
+    captured = {}
+
+    class _FakeWBT:
+        verbose = True
+
+        def __init__(self):
+            self.verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "hypsometrically_tinted_hillshade"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input DEM File",
+                            "flags": ["-i", "--dem"],
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Output File",
+                            "flags": ["-o", "--output"],
+                            "parameter_type": {"NewFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Illumination Source Altitude (degrees)",
+                            "flags": ["--altitude"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Hillshade Weight",
+                            "flags": ["--hs_weight"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Brightness",
+                            "flags": ["--brightness"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Atmospheric Effects",
+                            "flags": ["--atmospheric"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Palette",
+                            "flags": ["--palette"],
+                            "parameter_type": {"OptionList": ["atlas", "viridis"]},
+                            "optional": True,
+                        },
+                        {
+                            "name": "Reverse palette?",
+                            "flags": ["--reverse"],
+                            "parameter_type": "Boolean",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Full 360-degree hillshade mode?",
+                            "flags": ["--full_mode"],
+                            "parameter_type": "Boolean",
+                            "optional": True,
+                        },
+                    ]
+                }
+            )
+
+        def run_tool(self, tool_name, args, callback=None):
+            captured["tool_name"] = tool_name
+            captured["args"] = args
+            output_path.write_text("relief", encoding="utf-8")
+            return 0
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    project = MockQGISProject()
+    layer = MockQGISLayer("DEM layer", str(input_path), "raster")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project)
+    iface.setActiveLayer(layer)
+    tools = {tool.tool_name: tool for tool in whitebox_tools(iface, project)}
+
+    result = tools["run_whitebox_color_shaded_relief"].__wrapped__(
+        output_path=str(output_path),
+        output_layer_name="Color Shaded Relief",
+        palette="viridis",
+        hillshade_weight=0.6,
+        full_mode=True,
+    )
+
+    assert captured["tool_name"] == "hypsometrically_tinted_hillshade"
+    assert captured["args"] == [
+        f"--dem={input_path}",
+        f"--output={output_path}",
+        "--altitude=45.0",
+        "--hs_weight=0.6",
+        "--brightness=0.5",
+        "--atmospheric=0.0",
+        "--palette=viridis",
+        "--reverse=false",
+        "--full_mode",
+    ]
+    assert result["success"] is True
+    assert result["layers_added"] == [
+        {
+            "path": str(output_path),
+            "added": True,
+            "layer_name": "Color Shaded Relief",
+        }
+    ]
+    assert "Color Shaded Relief" in project.mapLayers()
 
 
 def test_for_whitebox_registers_tools_and_respects_fast_mode(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add `for_whitebox` factory and a routed broker surface (`summarize_whitebox_tools`, `search_whitebox_tools`, `get_whitebox_tool_info`, `run_whitebox_tool`) so the agent can drive WhiteboxTools without registering hundreds of individual tools.
- Wire the new factory into the QGIS plugin chat dock with confirmation prompts, declare the optional `whitebox` extra in `pyproject.toml`, and add WhiteboxTools sample prompts.
- Add unit tests (`tests/test_whitebox_tools.py`) and a QGIS integration test (`qgis_geoagent/tests/test_whitebox_integration.py`), plus docs entry under `docs/tools.md`.

## Test plan
- [ ] `pytest tests/ -q`
- [ ] `pre-commit run --all-files`
- [ ] In QGIS, load a local DEM, ask the agent to find and run a WhiteboxTools slope or hillshade command, confirm output is added back to the project.
- [ ] Verify `search_whitebox_tools` returns relevant matches and `get_whitebox_tool_info` exposes parameter metadata before execution.