### PR TITLE
feat: add ChatGPT/Codex OAuth provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Many geospatial libraries need the same agent features:
 
 - bind an agent to a live map, QGIS session, dataset, or workflow object;
 - expose package functions as structured tools with docstrings and metadata;
-- support OpenAI, Anthropic, Google Gemini, Bedrock, LiteLLM, and local
+- support OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Bedrock, LiteLLM, and local
   Ollama models;
 - keep optional geospatial stacks optional;
 - ask for confirmation before deleting layers, saving files, or running
@@ -91,11 +91,15 @@ specified:
 | Provider | Environment |
 | --- | --- |
 | OpenAI | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
+| ChatGPT/Codex OAuth | `OPENAI_CODEX_ACCESS_TOKEN`, optional `OPENAI_CODEX_MODEL` |
 | Anthropic | `ANTHROPIC_API_KEY`, optional `ANTHROPIC_MODEL` |
 | Google Gemini | `GEMINI_API_KEY` or `GOOGLE_API_KEY`, optional `GEMINI_MODEL` |
 | LiteLLM | `LITELLM_API_KEY`, optional `LITELLM_MODEL` and `LITELLM_BASE_URL` |
 | Ollama | `OLLAMA_HOST` or `USE_OLLAMA=1`, optional `OLLAMA_MODEL` |
 | Bedrock | AWS credential chain and model access, optional `BEDROCK_MODEL` |
+
+ChatGPT/Codex OAuth uses the Codex browser login flow and the Codex Responses
+backend.
 
 You can also configure providers explicitly:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ GeoAgent can infer a provider from environment variables:
 | Provider | Environment |
 | --- | --- |
 | OpenAI | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
+| ChatGPT/Codex OAuth | `OPENAI_CODEX_ACCESS_TOKEN`, optional `OPENAI_CODEX_MODEL` |
 | Anthropic | `ANTHROPIC_API_KEY`, optional `ANTHROPIC_MODEL` |
 | Google Gemini | `GEMINI_API_KEY` or `GOOGLE_API_KEY`, optional `GEMINI_MODEL` |
 | LiteLLM | `LITELLM_API_KEY`, optional `LITELLM_MODEL` and `LITELLM_BASE_URL` |

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -23,7 +23,7 @@ solara run geoagent/ui/pages
 - **Persistent map** — layers accumulate across queries on the same interactive MapLibre map
 - **Native widget rendering** — full bidirectional map interaction (zoom, pan, click)
 - **Chat interface** — type natural language queries with real-time status updates
-- **Provider selection** — switch between OpenAI, Anthropic, Google Gemini, Ollama, or LiteLLM
+- **Provider selection** — switch between OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, or LiteLLM
 - **Generated code** — toggle code display for transparency
 
 ## Python API

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -99,6 +99,7 @@ class GeoAgent:
         self._registry = registry or GeoToolRegistry()
         self._tool_list = list(tools or [])
         self._cancelled: list[str] = []
+        self._tool_calls: list[dict[str, Any]] = []
         self._confirm = confirm or auto_approve_safe_only
         self._model = model or resolve_model(self._config)
         self._rebuild_strands_agent()
@@ -110,7 +111,12 @@ class GeoAgent:
         extra_prompt = self._context.metadata.get("system_prompt")
         if extra_prompt:
             prompt = f"{prompt}\n\n{extra_prompt}"
-        hook = ConfirmationHookProvider(self._registry, self._confirm, self._cancelled)
+        hook = ConfirmationHookProvider(
+            self._registry,
+            self._confirm,
+            self._cancelled,
+            self._tool_calls,
+        )
 
         self._strands = Agent(
             model=self._model,
@@ -221,6 +227,7 @@ class GeoAgent:
     def _chat_impl(self, query: str) -> GeoAgentResponse:
         """Run a single user turn on the current thread."""
         self._cancelled.clear()
+        self._tool_calls.clear()
         t0 = time.time()
         try:
             result = self._strands(query)
@@ -236,6 +243,7 @@ class GeoAgent:
                 error_message=err,
                 execution_time=elapsed,
                 executed_tools=exec_names,
+                tool_calls=list(self._tool_calls),
                 cancelled_tools=list(self._cancelled),
                 map=self._context.map_obj,
                 raw=result,
@@ -246,6 +254,7 @@ class GeoAgent:
                 success=False,
                 error_message=_format_chat_exception(exc),
                 execution_time=elapsed,
+                tool_calls=list(self._tool_calls),
                 cancelled_tools=list(self._cancelled),
                 map=self._context.map_obj,
             )

--- a/geoagent/core/config.py
+++ b/geoagent/core/config.py
@@ -10,17 +10,22 @@ from pydantic import BaseModel, ConfigDict, Field
 ProviderName = Literal[
     "bedrock",
     "openai",
+    "openai-codex",
     "anthropic",
     "gemini",
     "ollama",
     "litellm",
 ]
 
+DEFAULT_PROVIDER: ProviderName = "openai-codex"
+
 
 def _default_provider_from_env() -> ProviderName:
     """Infer the default provider from available environment variables."""
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
+    if os.environ.get("OPENAI_CODEX_ACCESS_TOKEN"):
+        return "openai-codex"
     if os.environ.get("ANTHROPIC_API_KEY"):
         return "anthropic"
     if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
@@ -33,7 +38,7 @@ def _default_provider_from_env() -> ProviderName:
         return "litellm"
     if os.environ.get("OLLAMA_HOST") or os.environ.get("USE_OLLAMA") == "1":
         return "ollama"
-    return "bedrock"
+    return DEFAULT_PROVIDER
 
 
 class GeoAgentConfig(BaseModel):
@@ -41,6 +46,7 @@ class GeoAgentConfig(BaseModel):
 
     API keys and region defaults are read from the environment when not
     passed explicitly (``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``,
+    ``OPENAI_CODEX_ACCESS_TOKEN``,
     ``GEMINI_API_KEY`` / ``GOOGLE_API_KEY``, ``LITELLM_API_KEY``,
     ``AWS_REGION`` / default AWS credential chain for Bedrock, etc.).
 
@@ -50,6 +56,7 @@ class GeoAgentConfig(BaseModel):
         temperature: Sampling temperature.
         max_tokens: Maximum tokens in the model response.
         ollama_host: Ollama server base URL (e.g. ``http://127.0.0.1:11434``).
+        openai_codex_base_url: ChatGPT/Codex backend base URL.
         litellm_base_url: Optional LiteLLM proxy or OpenAI-compatible base URL.
     """
 
@@ -61,6 +68,10 @@ class GeoAgentConfig(BaseModel):
     max_tokens: int = 4096
     ollama_host: Optional[str] = Field(
         default=None, description="Ollama base URL, e.g. http://127.0.0.1:11434"
+    )
+    openai_codex_base_url: Optional[str] = Field(
+        default=None,
+        description="ChatGPT/Codex backend base URL.",
     )
     litellm_base_url: Optional[str] = Field(
         default=None,

--- a/geoagent/core/confirmation_hook.py
+++ b/geoagent/core/confirmation_hook.py
@@ -19,10 +19,12 @@ class ConfirmationHookProvider(HookProvider):
         registry: GeoToolRegistry,
         confirm: ConfirmCallback,
         cancelled: list[str],
+        tool_calls: list[dict[str, Any]] | None = None,
     ) -> None:
         self._registry = registry
         self._confirm = confirm
         self._cancelled = cancelled
+        self._tool_calls = tool_calls
 
     def register_hooks(
         self, registry: HookRegistry, **kwargs: Any
@@ -42,13 +44,15 @@ class ConfirmationHookProvider(HookProvider):
         """Handle the pre-tool execution hook."""
         use = event.tool_use
         name = str(use.get("name", ""))
+        inp = use.get("input")
+        args = inp if isinstance(inp, dict) else {}
+        if self._tool_calls is not None:
+            self._tool_calls.append({"name": name, "args": dict(args)})
+
         selected = event.selected_tool
         meta = self._resolve_meta(name, selected)
         if meta is None or not self._registry.needs_user_confirmation(meta):
             return
-
-        inp = use.get("input")
-        args = inp if isinstance(inp, dict) else {}
 
         description = ""
         if selected is not None:

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -96,8 +96,14 @@ Workflow guidance:
   to inspect required parameters, then run_whitebox_tool to execute.
 - For active DEM flow accumulation requests, prefer
   run_whitebox_flow_accumulation.
-- For active DEM sink/depression filling or breaching requests, prefer
-  run_whitebox_fill_sinks.
+- For active DEM sink/depression filling requests, prefer
+  run_whitebox_fill_sinks with method="fill_depressions"; this is the default
+  and is preferred before flow direction or flow accumulation.
+- Use run_whitebox_fill_sinks with method="breach_depressions" only when the
+  user explicitly asks to breach, carve, or channel depressions.
+- Run each long-running Whitebox command at most once per user request unless
+  the tool returns an error. Do not repeat an identical tool call after it has
+  already produced an output.
 - For active DEM color shaded relief requests, prefer
   run_whitebox_color_shaded_relief.
 - For active vector layer buffer requests, prefer buffer_active_layer.

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -41,6 +41,39 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
             params={"temperature": cfg.temperature, "max_tokens": cfg.max_tokens},
         )
 
+    if provider == "openai-codex":
+        from strands.models.openai_responses import OpenAIResponsesModel
+
+        model_id = cfg.model or os.environ.get("OPENAI_CODEX_MODEL", "gpt-5.5")
+        client_args = dict(cfg.client_args)
+        api_key = client_args.get("api_key") or os.environ.get(
+            "OPENAI_CODEX_ACCESS_TOKEN"
+        )
+        base_url = (
+            client_args.get("base_url")
+            or cfg.openai_codex_base_url
+            or os.environ.get("OPENAI_CODEX_BASE_URL")
+            or "https://chatgpt.com/backend-api/codex"
+        )
+        account_id = os.environ.get("OPENAI_CODEX_ACCOUNT_ID", "").strip()
+        if not api_key:
+            raise ValueError(
+                "OpenAI Codex provider requires a ChatGPT OAuth access token. "
+                "Login from OpenGeoAgent settings or set OPENAI_CODEX_ACCESS_TOKEN."
+            )
+        client_args["api_key"] = api_key
+        client_args["base_url"] = base_url
+        default_headers = dict(client_args.get("default_headers") or {})
+        default_headers.setdefault("User-Agent", "codex-cli")
+        if account_id:
+            default_headers["ChatGPT-Account-Id"] = account_id
+        client_args["default_headers"] = default_headers
+        return OpenAIResponsesModel(
+            client_args=client_args,
+            model_id=model_id,
+            params={},
+        )
+
     if provider == "anthropic":
         from strands.models.anthropic import AnthropicModel
 

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -1,6 +1,6 @@
 """Short system prompts for low-latency tool use."""
 
 DEFAULT_SYSTEM_PROMPT = """You are GeoAgent, a geospatial assistant. Use tools for map and GIS actions.
-Prefer calling the right tool immediately when the user's intent is clear. Keep replies concise."""
+Prefer calling the right tool immediately when the user's intent is clear. Use set_layer_symbology for QGIS layer color, fill, outline, opacity, and line-width changes. Keep replies concise."""
 
-FAST_SYSTEM_PROMPT = """You are GeoAgent (fast mode). Call the best tool immediately for map commands. After tool use, reply in one short sentence. Do not summarize, explain, or plan unless the user asks."""
+FAST_SYSTEM_PROMPT = """You are GeoAgent (fast mode). Call the best tool immediately for map commands, including set_layer_symbology for layer styling. After tool use, reply in one short sentence. Do not summarize, explain, or plan unless the user asks."""

--- a/geoagent/core/registry.py
+++ b/geoagent/core/registry.py
@@ -87,6 +87,7 @@ FAST_TOOL_FALLBACK: frozenset[str] = frozenset(
         "change_basemap",
         "set_layer_visibility",
         "set_layer_opacity",
+        "set_layer_symbology",
         "zoom_to_layer",
         # qgis (safe navigation / inspection)
         "list_project_layers",

--- a/geoagent/core/result.py
+++ b/geoagent/core/result.py
@@ -18,6 +18,7 @@ class GeoAgentResponse:
     error_message: Optional[str] = None
     execution_time: float = 0.0
     executed_tools: list[str] = field(default_factory=list)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
     cancelled_tools: list[str] = field(default_factory=list)
     map: Any = None
     raw: Any = None

--- a/geoagent/testing/_mocks.py
+++ b/geoagent/testing/_mocks.py
@@ -285,6 +285,8 @@ class MockQGISLayer:
         self._visible = True
         self._extent = tuple(extent) if extent else None
         self._opacity = 1.0
+        self.symbology: dict[str, Any] = {}
+        self.repaint_count = 0
 
     def name(self) -> str:
         """Return the object name."""
@@ -372,6 +374,10 @@ class MockQGISLayer:
     def setOpacity(self, opacity: float) -> None:
         """Set opacity."""
         self._opacity = float(opacity)
+
+    def triggerRepaint(self) -> None:
+        """Record layer repaint."""
+        self.repaint_count += 1
 
 
 class MockQGISCanvas:

--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -26,6 +26,66 @@ from geoagent.core.decorators import geo_tool
 from geoagent.tools._qt_marshal import run_on_qt_gui_thread
 
 
+def _qcolor(value: Any) -> Any:
+    """Return a QColor-like object for real QGIS, or the raw value in tests."""
+    if value is None:
+        return None
+    if not str(value).strip():
+        return None
+    try:
+        from qgis.PyQt.QtGui import QColor  # type: ignore[import-not-found]
+    except Exception:
+        return value
+
+    if isinstance(value, (list, tuple)):
+        channels = [int(float(channel)) for channel in value]
+        color = QColor(*channels)
+    else:
+        text = str(value).strip()
+        if "," in text and not text.startswith("#"):
+            channels = [int(float(part.strip())) for part in text.split(",")]
+            color = QColor(*channels)
+        else:
+            color = QColor(text)
+    if hasattr(color, "isValid") and not color.isValid():
+        raise ValueError(f"Invalid color value: {value!r}")
+    return color
+
+
+def _set_symbol_layer_attr(
+    symbol_layer: Any, names: tuple[str, ...], value: Any
+) -> bool:
+    """Set the first available symbol-layer setter."""
+    for name in names:
+        method = getattr(symbol_layer, name, None)
+        if callable(method):
+            method(value)
+            return True
+    return False
+
+
+def _set_symbol_width(symbol: Any, width: float) -> bool:
+    """Set line/stroke width on a QGIS symbol when supported."""
+    for obj in (symbol, getattr(symbol, "symbolLayer", lambda *_: None)(0)):
+        if obj is None:
+            continue
+        if _set_symbol_layer_attr(obj, ("setWidth", "setStrokeWidth"), width):
+            return True
+    return False
+
+
+def _set_symbol_outline_color(symbol: Any, color: Any) -> bool:
+    """Set an outline/stroke color when the symbol layer supports it."""
+    symbol_layer = getattr(symbol, "symbolLayer", lambda *_: None)(0)
+    if symbol_layer is None:
+        return False
+    return _set_symbol_layer_attr(
+        symbol_layer,
+        ("setStrokeColor", "setBorderColor", "setOutlineColor"),
+        color,
+    )
+
+
 def _transform_extent_to_canvas_crs(layer: Any, canvas: Any, extent: Any) -> Any:
     """Re-project a layer's extent into the canvas / project CRS.
 
@@ -874,6 +934,99 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
     @geo_tool(
         category="qgis",
     )
+    def set_layer_symbology(
+        layer_name: str,
+        color: Optional[str] = None,
+        line_width: Optional[float] = None,
+        fill_color: Optional[str] = None,
+        outline_color: Optional[str] = None,
+        opacity: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Change simple layer symbology such as color and line width.
+
+        Args:
+            layer_name: Display name of the target QGIS layer.
+            color: Main symbol color, e.g. ``"blue"`` or ``"#0066ff"``.
+            line_width: Line or outline width in QGIS symbol units.
+            fill_color: Polygon fill color. When omitted, ``color`` is used.
+            outline_color: Polygon outline/stroke color.
+            opacity: Optional layer opacity from 0.0 to 1.0.
+
+        Returns:
+            A dict describing the applied style changes.
+        """
+
+        def _run() -> dict[str, Any]:
+            """Run the worker body."""
+            layer = _resolve_layer(_project(), layer_name)
+            applied: dict[str, Any] = {"layer_name": layer_name}
+
+            main_color = _qcolor(color)
+            fill = _qcolor(fill_color) or main_color
+            outline = _qcolor(outline_color)
+
+            try:
+                renderer = layer.renderer() if hasattr(layer, "renderer") else None
+            except Exception:
+                renderer = None
+            symbol = (
+                renderer.symbol()
+                if renderer is not None and hasattr(renderer, "symbol")
+                else None
+            )
+            if symbol is not None:
+                if fill is not None and hasattr(symbol, "setColor"):
+                    symbol.setColor(fill)
+                    applied["color"] = str(color or fill_color)
+                if outline is not None and _set_symbol_outline_color(symbol, outline):
+                    applied["outline_color"] = str(outline_color)
+                if line_width is not None:
+                    width = max(0.0, float(line_width))
+                    if _set_symbol_width(symbol, width):
+                        applied["line_width"] = width
+            else:
+                style = getattr(layer, "symbology", None)
+                if not isinstance(style, dict):
+                    style = {}
+                    try:
+                        layer.symbology = style
+                    except Exception:
+                        pass
+                if fill is not None:
+                    style["color"] = str(color or fill_color)
+                    applied["color"] = str(color or fill_color)
+                if outline is not None:
+                    style["outline_color"] = str(outline_color)
+                    applied["outline_color"] = str(outline_color)
+                if line_width is not None:
+                    style["line_width"] = max(0.0, float(line_width))
+                    applied["line_width"] = style["line_width"]
+
+            if opacity is not None:
+                value = min(1.0, max(0.0, float(opacity)))
+                if hasattr(layer, "setOpacity"):
+                    layer.setOpacity(value)
+                    applied["opacity"] = value
+                elif renderer is not None and hasattr(renderer, "setOpacity"):
+                    renderer.setOpacity(value)
+                    applied["opacity"] = value
+
+            if hasattr(layer, "triggerRepaint"):
+                layer.triggerRepaint()
+            canvas = iface.mapCanvas()
+            if hasattr(canvas, "refresh"):
+                canvas.refresh()
+            if len(applied) == 1:
+                applied["message"] = "No supported symbology changes were applied."
+            else:
+                applied["message"] = f"Updated symbology for layer {layer_name!r}."
+            return applied
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="qgis",
+    )
     def inspect_layer_fields(layer_name: str) -> list[dict[str, Any]]:
         """List fields and types for a vector layer.
 
@@ -1281,6 +1434,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         remove_layer,
         set_layer_visibility,
         set_layer_opacity,
+        set_layer_symbology,
         inspect_layer_fields,
         get_selected_features,
         select_features_by_expression,

--- a/geoagent/tools/whitebox.py
+++ b/geoagent/tools/whitebox.py
@@ -312,6 +312,27 @@ def _coerce_cli_value(value: Any) -> str:
     return str(value)
 
 
+def _blank_to_none(value: Any) -> Any:
+    """Normalize model-supplied blank optional values to ``None``."""
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+def _optional_nonzero_float(value: Any) -> float | None:
+    """Return a float only when an optional numeric value is meaningful."""
+    value = _blank_to_none(value)
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number == 0:
+        return None
+    return number
+
+
 def _format_arg(flag: str, value: Any) -> str | None:
     """Format a WhiteboxTools CLI argument."""
     if isinstance(value, bool):
@@ -671,7 +692,7 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         layer_name: Optional[str] = None,
         output_path: Optional[str] = None,
         output_layer_name: Optional[str] = None,
-        method: str = "breach_depressions",
+        method: str = "fill_depressions",
         max_depth: Optional[float] = None,
         max_length: Optional[float] = None,
         flat_increment: Optional[float] = None,
@@ -680,7 +701,12 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         add_outputs_to_qgis: bool = True,
         verbose: bool = False,
     ) -> dict[str, Any]:
-        """Resolve sinks/depressions in a DEM layer and load the raster output.
+        """Fill sinks/depressions in a DEM layer and load the raster output.
+
+        The default method is ``fill_depressions``, which is the appropriate
+        preprocessing step for flow direction and flow accumulation workflows.
+        Use ``breach_depressions`` only when the user explicitly asks to breach
+        or carve depressions.
 
         Args:
             layer_name: QGIS DEM layer name. When omitted, uses the active
@@ -688,8 +714,9 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
             output_path: Optional raster output path.
             output_layer_name: Optional display name for the output layer.
             method: Whitebox method. Supported values are
-                ``breach_depressions`` (default), ``fill_depressions``, and
-                ``fill_depressions_wang_and_liu``.
+                ``fill_depressions`` (default),
+                ``fill_depressions_wang_and_liu``, and
+                ``breach_depressions``.
             max_depth: Optional maximum breach/fill depth in z units.
             max_length: Optional maximum breach channel length in grid cells.
             flat_increment: Optional elevation increment for flat areas.
@@ -706,6 +733,7 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
             "breach": "breach_depressions",
             "breach_depressions": "breach_depressions",
             "fill": "fill_depressions",
+            "fill_sinks": "fill_depressions",
             "fill_depressions": "fill_depressions",
             "wang_and_liu": "fill_depressions_wang_and_liu",
             "fill_depressions_wang_and_liu": "fill_depressions_wang_and_liu",
@@ -717,6 +745,9 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
                 "'fill_depressions', or 'fill_depressions_wang_and_liu'."
             )
 
+        layer_name = _blank_to_none(layer_name)
+        output_path = _blank_to_none(output_path)
+        output_layer_name = _blank_to_none(output_layer_name)
         selected_layer = layer_name or _active_layer_name(iface)
         name = output_layer_name or f"{selected_layer} filled sinks"
         params: dict[str, Any] = {
@@ -725,17 +756,20 @@ def whitebox_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         }
         if output_path is None:
             params.pop("output")
-        if max_depth is not None:
-            params["max_depth"] = float(max_depth)
-        if flat_increment is not None:
-            params["flat_increment"] = float(flat_increment)
+        max_depth_value = _optional_nonzero_float(max_depth)
+        flat_increment_value = _optional_nonzero_float(flat_increment)
+        max_length_value = _optional_nonzero_float(max_length)
+        if max_depth_value is not None:
+            params["max_depth"] = max_depth_value
+        if flat_increment_value is not None:
+            params["flat_increment"] = flat_increment_value
         if tool_name == "breach_depressions":
-            if max_length is not None:
-                params["max_length"] = float(max_length)
-            if fill_pits is not None:
-                params["fill_pits"] = bool(fill_pits)
-        elif fix_flats is not None:
-            params["fix_flats"] = bool(fix_flats)
+            if max_length_value is not None:
+                params["max_length"] = max_length_value
+            if bool(fill_pits):
+                params["fill_pits"] = True
+        elif bool(fix_flats):
+            params["fix_flats"] = True
 
         return run_whitebox_tool.__wrapped__(
             tool_name,

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -15,7 +15,7 @@ GitHub update checker.
 - Dockable OpenGeoAgent chat panel with Ctrl+Enter sending
 - Up/Down prompt history while the prompt editor is focused
 - Built-in sample prompt picker for common QGIS workflows
-- Provider and model controls for Bedrock, OpenAI, Anthropic, Google Gemini, Ollama, and LiteLLM
+- Provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, and LiteLLM
 - Settings panel for model defaults, API keys, hosts, and AWS region
 - Dependency installer that installs `GeoAgent[providers]` into
   `~/.open_geoagent/`
@@ -80,6 +80,8 @@ provider and model. API keys and host settings are stored in QGIS settings and
 applied to the current QGIS process before each chat request:
 
 - OpenAI: `OPENAI_API_KEY`
+- ChatGPT/Codex OAuth: choose `openai-codex` and click **Login with ChatGPT**
+  in the Model tab. Headless use can set `OPENAI_CODEX_ACCESS_TOKEN`.
 - Anthropic: `ANTHROPIC_API_KEY`
 - Google Gemini: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - Bedrock: `AWS_REGION` plus the normal AWS credential chain
@@ -92,6 +94,7 @@ Default models:
 | --- | --- |
 | Bedrock | `us.anthropic.claude-sonnet-4-6` |
 | OpenAI | `gpt-5.5` |
+| ChatGPT/Codex OAuth | `gpt-5.5` |
 | Anthropic | `claude-sonnet-4-6` |
 | Google Gemini | `gemini-3.1-pro-preview` |
 | Ollama | `qwen3.5:4b` |

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -297,6 +297,18 @@ def _format_tool_calls(tool_calls):
     return "\n".join(lines) if len(lines) > 1 else ""
 
 
+def _conversation_markdown(messages):
+    """Return the full chat transcript as Markdown."""
+    blocks = []
+    for msg in messages:
+        sender = str(msg.get("sender") or "").strip()
+        body = str(msg.get("body") or "").strip()
+        if not sender or not body:
+            continue
+        blocks.append(f"## {sender}\n\n{body}")
+    return "\n\n".join(blocks)
+
+
 class PromptTextEdit(QPlainTextEdit):
     """Prompt editor with chat-friendly keyboard shortcuts."""
 
@@ -454,7 +466,6 @@ class ChatDockWidget(QDockWidget):
         self._prompt_history = []
         self._history_index = None
         self._messages = []
-        self._last_assistant_markdown = ""
         self._status_started_at = None
         self._status_base_text = "Running"
         self._status_frame = 0
@@ -558,7 +569,7 @@ class ChatDockWidget(QDockWidget):
 
         self.copy_md_btn = QPushButton("Copy Markdown")
         self.copy_md_btn.setEnabled(False)
-        self.copy_md_btn.clicked.connect(self._copy_latest_markdown)
+        self.copy_md_btn.clicked.connect(self._copy_transcript_markdown)
         primary_button_layout.addWidget(self.copy_md_btn)
         layout.addLayout(primary_button_layout)
 
@@ -801,9 +812,7 @@ class ChatDockWidget(QDockWidget):
         """Append a chat message and refresh the transcript."""
         body = message.strip()
         self._messages.append({"sender": sender, "body": body, "markdown": markdown})
-        if markdown:
-            self._last_assistant_markdown = body
-            self.copy_md_btn.setEnabled(True)
+        self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
 
     def _render_transcript(self):
@@ -825,20 +834,20 @@ class ChatDockWidget(QDockWidget):
         end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
         self.transcript.moveCursor(end_cursor)
 
-    def _copy_latest_markdown(self):
-        """Copy the latest assistant Markdown response to the clipboard."""
-        if not self._last_assistant_markdown:
+    def _copy_transcript_markdown(self):
+        """Copy the full chat transcript to the clipboard as Markdown."""
+        transcript = _conversation_markdown(self._messages)
+        if not transcript:
             return
         clipboard = QGuiApplication.clipboard()
         if clipboard is not None:
-            clipboard.setText(self._last_assistant_markdown)
-            self.status_label.setText("Copied latest response as Markdown.")
+            clipboard.setText(transcript)
+            self.status_label.setText("Copied chat history as Markdown.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
     def _clear_transcript(self):
         """Clear all rendered chat messages."""
         self._messages = []
-        self._last_assistant_markdown = ""
         self.copy_md_btn.setEnabled(False)
         self.transcript.clear()
 

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -2,6 +2,7 @@
 
 import os
 import html
+import json
 import re
 import time
 import traceback
@@ -27,15 +28,25 @@ from qgis.PyQt.QtWidgets import (
 )
 
 SETTINGS_PREFIX = "OpenGeoAgent/"
+DEFAULT_PROVIDER = "openai-codex"
 DEFAULT_MODELS = {
     "bedrock": "us.anthropic.claude-sonnet-4-6",
     "openai": "gpt-5.5",
+    "openai-codex": "gpt-5.5",
     "anthropic": "claude-sonnet-4-6",
     "gemini": "gemini-3.1-pro-preview",
     "ollama": "qwen3.5:4b",
     "litellm": "openai/gpt-5.5",
 }
-PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama", "litellm"]
+PROVIDERS = [
+    "bedrock",
+    "openai",
+    "openai-codex",
+    "anthropic",
+    "gemini",
+    "ollama",
+    "litellm",
+]
 MAX_CONTEXT_MESSAGES = 12
 MAX_CONTEXT_CHARS = 12000
 SAMPLE_PROMPTS = [
@@ -51,6 +62,11 @@ SAMPLE_PROMPTS = [
     "Search WhiteboxTools for watershed or flow accumulation tools.",
     "Create a concise map QA checklist for this project before I export it.",
 ]
+
+
+def _default_model_for_provider(provider):
+    """Return the UI default model id for a provider."""
+    return DEFAULT_MODELS.get(provider, "")
 
 
 def _setting(settings, key, default="", value_type=str):
@@ -187,6 +203,100 @@ def _markdown_to_basic_html(markdown):
     return "\n".join(html_lines)
 
 
+def _format_tool_value(value, max_length=220):
+    """Format a tool argument value for compact display."""
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, sort_keys=True)
+        except TypeError:
+            text = str(value)
+    text = text.replace("\n", " ").strip()
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text
+
+
+def _tool_call_label_and_args(name, args):
+    """Return a display label plus args for a recorded tool call."""
+    display_args = dict(args)
+    routed_tool = str(display_args.pop("tool_name", "") or "").strip()
+    if name == "run_whitebox_tool" and routed_tool:
+        parameters = display_args.pop("parameters", None)
+        if isinstance(parameters, dict):
+            display_args.update(parameters)
+        return f"{name} -> {routed_tool}", display_args
+    if name == "get_whitebox_tool_info" and routed_tool:
+        return f"{name} -> {routed_tool}", display_args
+    return name, display_args
+
+
+def _clean_tool_display_args(args):
+    """Drop no-op optional values that make repeated calls look different."""
+    cleaned = {}
+    default_values = {
+        "add_outputs_to_qgis": True,
+        "category": "",
+        "fill_pits": False,
+        "fix_flats": False,
+        "flat_increment": 0,
+        "layer_name": "",
+        "max_depth": 0,
+        "max_length": 0,
+        "max_procs": None,
+        "output_path": "",
+        "verbose": False,
+    }
+    for key, value in args.items():
+        if key in default_values and value == default_values[key]:
+            continue
+        if value is None or value == "":
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def _format_tool_calls(tool_calls):
+    """Return Markdown lines describing tool input parameters."""
+    if not tool_calls:
+        return ""
+    lines = ["Tool inputs:"]
+    grouped = []
+    index_by_signature = {}
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        name = str(call.get("name") or "").strip()
+        args = call.get("args") if isinstance(call.get("args"), dict) else {}
+        if not name:
+            continue
+        label, args = _tool_call_label_and_args(name, args)
+        args = _clean_tool_display_args(args)
+        try:
+            args_key = json.dumps(args, sort_keys=True, default=str)
+        except TypeError:
+            args_key = str(sorted(args.items()))
+        signature = (label, args_key)
+        if signature in index_by_signature:
+            grouped[index_by_signature[signature]][2] += 1
+        else:
+            index_by_signature[signature] = len(grouped)
+            grouped.append([label, args, 1])
+
+    for label, args, count in grouped:
+        suffix = f" (repeated {count} times)" if count > 1 else ""
+        if args:
+            params = ", ".join(
+                f"`{key}={_format_tool_value(value)}`"
+                for key, value in sorted(args.items())
+            )
+            lines.append(f"- **`{label}`**{suffix}: {params}")
+        else:
+            lines.append(f"- **`{label}`**{suffix}")
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
 class PromptTextEdit(QPlainTextEdit):
     """Prompt editor with chat-friendly keyboard shortcuts."""
 
@@ -278,6 +388,7 @@ class ChatWorker(QThread):
                     "answer": response.answer_text or "",
                     "error": response.error_message or "",
                     "tools": ", ".join(response.executed_tools or []),
+                    "tool_calls": response.tool_calls or [],
                     "cancelled": ", ".join(response.cancelled_tools or []),
                     "elapsed": f"{response.execution_time:.2f}s",
                 }
@@ -458,13 +569,15 @@ class ChatDockWidget(QDockWidget):
 
     def _load_settings(self):
         """Load persisted model settings into the dock controls."""
-        provider = _setting(self.settings, "provider", "openai")
+        provider = _setting(self.settings, "provider", DEFAULT_PROVIDER)
         index = self.provider_combo.findText(provider)
-        self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
+        if index < 0:
+            index = self.provider_combo.findText(DEFAULT_PROVIDER)
+        self.provider_combo.setCurrentIndex(index if index >= 0 else 0)
 
         model = _setting(self.settings, "model", "")
         if not model:
-            model = DEFAULT_MODELS.get(self.provider_combo.currentText(), "")
+            model = _default_model_for_provider(self.provider_combo.currentText())
         self.model_input.setText(model)
 
         self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
@@ -474,10 +587,12 @@ class ChatDockWidget(QDockWidget):
 
     def _save_model_settings(self):
         """Persist the selected provider, model, and fast-mode setting."""
-        self.settings.setValue(
-            f"{SETTINGS_PREFIX}provider", self.provider_combo.currentText()
-        )
-        self.settings.setValue(f"{SETTINGS_PREFIX}model", self.model_input.text())
+        provider = self.provider_combo.currentText()
+        model = self.model_input.text().strip() or _default_model_for_provider(provider)
+        if model and not self.model_input.text().strip():
+            self.model_input.setText(model)
+        self.settings.setValue(f"{SETTINGS_PREFIX}provider", provider)
+        self.settings.setValue(f"{SETTINGS_PREFIX}model", model)
         self.settings.setValue(
             f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
         )
@@ -488,7 +603,7 @@ class ChatDockWidget(QDockWidget):
 
     def _on_provider_changed(self, provider):
         """Update the model field when the provider changes."""
-        self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
+        self.model_input.setText(_default_model_for_provider(provider))
 
     def _send_prompt(self):
         """Start a chat request for the current prompt."""
@@ -503,12 +618,31 @@ class ChatDockWidget(QDockWidget):
             )
             return
 
-        self._save_model_settings()
-        self._record_prompt(prompt)
-        _apply_environment_from_settings(self.settings)
-
         provider = self.provider_combo.currentText()
-        model_id = self.model_input.text().strip()
+        self._save_model_settings()
+        _apply_environment_from_settings(self.settings)
+        if provider == "openai-codex":
+            try:
+                from ..oauth import ensure_openai_oauth_environment
+
+                ensure_openai_oauth_environment(
+                    self.settings,
+                    codex=True,
+                )
+            except Exception as exc:
+                QMessageBox.critical(
+                    self,
+                    "OpenGeoAgent",
+                    f"OpenAI OAuth is not ready:\n\n{exc}",
+                )
+                return
+
+        self._record_prompt(prompt)
+        model_id = self.model_input.text().strip() or _default_model_for_provider(
+            provider
+        )
+        if model_id and not self.model_input.text().strip():
+            self.model_input.setText(model_id)
         fast = self.fast_check.isChecked()
         auto_approve_tools = self.auto_approve_tools_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
@@ -604,6 +738,9 @@ class ChatDockWidget(QDockWidget):
         if result.get("success"):
             answer = result.get("answer") or "(No text response.)"
             details = []
+            tool_inputs = _format_tool_calls(result.get("tool_calls") or [])
+            if tool_inputs:
+                details.append(tool_inputs)
             if result.get("tools"):
                 details.append(f"Tools: {result['tools']}")
             if result.get("elapsed"):

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -1,8 +1,9 @@
 """Settings and dependency management for OpenGeoAgent."""
 
 import os
+import time
 
-from qgis.PyQt.QtCore import Qt, QSettings, QTimer
+from qgis.PyQt.QtCore import Qt, QSettings, QThread, QTimer, QUrl, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -20,9 +21,18 @@ from qgis.PyQt.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qgis.PyQt.QtGui import QFont
+from qgis.PyQt.QtGui import QDesktopServices, QFont
 
-from .chat_dock import DEFAULT_MODELS, PROVIDERS, SETTINGS_PREFIX
+from .chat_dock import DEFAULT_MODELS, DEFAULT_PROVIDER, PROVIDERS, SETTINGS_PREFIX
+from ..oauth import (
+    CODEX_DEFAULT_CONFIG,
+    OAUTH_CONFIG_KEYS,
+    OPENAI_CODEX_AUTH_EXTRA_PARAMS,
+    OPENAI_CODEX_CALLBACK_PATH,
+    OPENAI_CODEX_CALLBACK_PORT,
+    clear_token_payload,
+    store_token_payload,
+)
 
 ENV_FALLBACKS = {
     "openai_api_key": ("OPENAI_API_KEY",),
@@ -50,6 +60,69 @@ def _env_fallback(*env_names):
     return ""
 
 
+class OAuthLoginWorker(QThread):
+    """Run an OpenAI OAuth login flow without blocking QGIS."""
+
+    auth_url = pyqtSignal(str)
+    finished = pyqtSignal(dict)
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self.config = dict(config)
+
+    def run(self):
+        """Open a loopback OAuth flow and exchange the callback code."""
+        try:
+            from ..oauth import complete_loopback_flow, start_loopback_flow
+
+            is_codex = bool(self.config.get("codex"))
+            flow = start_loopback_flow(
+                self.config["authorization_url"],
+                client_id=self.config["client_id"],
+                scope=self.config.get("scope", ""),
+                redirect_host="localhost" if is_codex else "127.0.0.1",
+                port=OPENAI_CODEX_CALLBACK_PORT if is_codex else 0,
+                callback_path=OPENAI_CODEX_CALLBACK_PATH if is_codex else "/callback",
+                extra_params=OPENAI_CODEX_AUTH_EXTRA_PARAMS if is_codex else None,
+                fallback_port=not is_codex,
+            )
+            self.auth_url.emit(flow.authorization_url)
+            token = complete_loopback_flow(
+                flow,
+                token_url=self.config["token_url"],
+                client_id=self.config["client_id"],
+            )
+            self.finished.emit({"success": True, "token": token, "error": ""})
+        except Exception as exc:
+            self.finished.emit({"success": False, "token": {}, "error": str(exc)})
+
+
+class OAuthRefreshWorker(QThread):
+    """Refresh OpenAI OAuth tokens without blocking QGIS."""
+
+    finished = pyqtSignal(dict)
+
+    def __init__(self, config, refresh_token, parent=None):
+        super().__init__(parent)
+        self.config = dict(config)
+        self.refresh_token = refresh_token
+
+    def run(self):
+        """Refresh the OAuth token."""
+        try:
+            from ..oauth import refresh_oauth_token
+
+            token = refresh_oauth_token(
+                self.config["token_url"],
+                client_id=self.config["client_id"],
+                refresh_token=self.refresh_token,
+                scope=self.config.get("scope", ""),
+            )
+            self.finished.emit({"success": True, "token": token, "error": ""})
+        except Exception as exc:
+            self.finished.emit({"success": False, "token": {}, "error": str(exc)})
+
+
 class SettingsDockWidget(QDockWidget):
     """Dock widget for configuring OpenGeoAgent."""
 
@@ -58,6 +131,7 @@ class SettingsDockWidget(QDockWidget):
         self.iface = iface
         self.settings = QSettings()
         self._deps_worker = None
+        self._oauth_worker = None
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -256,9 +330,41 @@ class SettingsDockWidget(QDockWidget):
 
         layout.addWidget(credentials_group)
 
+        oauth_group = QGroupBox("ChatGPT Login")
+        oauth_form = QFormLayout(oauth_group)
+
+        oauth_note = QLabel(
+            "Login opens ChatGPT in your browser using the Codex OAuth flow."
+        )
+        oauth_note.setWordWrap(True)
+        oauth_note.setStyleSheet("font-size: 10px; color: gray;")
+        oauth_form.addRow(oauth_note)
+
+        oauth_button_layout = QHBoxLayout()
+        self.openai_oauth_login_btn = QPushButton("Login with ChatGPT")
+        self.openai_oauth_login_btn.clicked.connect(self._login_openai_oauth)
+        oauth_button_layout.addWidget(self.openai_oauth_login_btn)
+
+        self.openai_oauth_refresh_btn = QPushButton("Refresh")
+        self.openai_oauth_refresh_btn.clicked.connect(self._refresh_openai_oauth)
+        oauth_button_layout.addWidget(self.openai_oauth_refresh_btn)
+
+        self.openai_oauth_logout_btn = QPushButton("Logout")
+        self.openai_oauth_logout_btn.clicked.connect(self._logout_openai_oauth)
+        oauth_button_layout.addWidget(self.openai_oauth_logout_btn)
+        oauth_form.addRow("", oauth_button_layout)
+
+        self.openai_oauth_status_label = QLabel("Not logged in")
+        self.openai_oauth_status_label.setWordWrap(True)
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: gray;")
+        oauth_form.addRow("Status:", self.openai_oauth_status_label)
+
+        layout.addWidget(oauth_group)
+
         note = QLabel(
             "Credential values are saved in QGIS settings and applied to the "
-            "current QGIS process when a chat request runs."
+            "current QGIS process when a chat request runs. ChatGPT login tokens "
+            "are stored in QGIS Auth Manager."
         )
         note.setWordWrap(True)
         note.setStyleSheet("font-size: 10px; color: gray;")
@@ -367,15 +473,141 @@ class SettingsDockWidget(QDockWidget):
         """Switch the settings dock to the dependencies tab."""
         self.tab_widget.setCurrentIndex(0)
 
+    def _oauth_config(self):
+        """Return the built-in ChatGPT/Codex login settings."""
+        config = dict(CODEX_DEFAULT_CONFIG)
+        config["codex"] = True
+        return config
+
+    def _set_oauth_buttons_enabled(self, enabled):
+        """Enable or disable OAuth action buttons."""
+        self.openai_oauth_login_btn.setEnabled(enabled)
+        self.openai_oauth_refresh_btn.setEnabled(enabled)
+        self.openai_oauth_logout_btn.setEnabled(enabled)
+
+    def _login_openai_oauth(self):
+        """Start OpenAI OAuth login."""
+        if self._oauth_worker is not None:
+            return
+        try:
+            config = self._oauth_config()
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+
+        self.openai_oauth_status_label.setText("Waiting for browser login...")
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: #1976D2;")
+        self._set_oauth_buttons_enabled(False)
+        self._oauth_worker = OAuthLoginWorker(config, self)
+        self._oauth_worker.auth_url.connect(self._open_oauth_browser)
+        self._oauth_worker.finished.connect(self._on_oauth_worker_finished)
+        self._oauth_worker.start()
+
+    def _refresh_openai_oauth(self):
+        """Refresh the stored OpenAI OAuth token."""
+        if self._oauth_worker is not None:
+            return
+        try:
+            config = self._oauth_config()
+            from ..oauth import load_token_payload
+
+            payload = load_token_payload(self.settings)
+            refresh_token = str(payload.get("refresh_token", "")).strip()
+            if not refresh_token:
+                raise ValueError("No refresh token is stored. Login again.")
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+
+        self.openai_oauth_status_label.setText("Refreshing token...")
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: #1976D2;")
+        self._set_oauth_buttons_enabled(False)
+        self._oauth_worker = OAuthRefreshWorker(config, refresh_token, self)
+        self._oauth_worker.finished.connect(self._on_oauth_worker_finished)
+        self._oauth_worker.start()
+
+    def _logout_openai_oauth(self):
+        """Clear stored OpenAI OAuth tokens."""
+        try:
+            clear_token_payload(self.settings)
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+        self._refresh_oauth_status()
+        self.iface.messageBar().pushSuccess("OpenGeoAgent", "ChatGPT logged out.")
+
+    def _open_oauth_browser(self, url):
+        """Open the OAuth authorization URL in the user's browser."""
+        QDesktopServices.openUrl(QUrl(url))
+
+    def _on_oauth_worker_finished(self, result):
+        """Persist OAuth tokens from the login or refresh worker."""
+        self._set_oauth_buttons_enabled(True)
+        self._oauth_worker = None
+        if not result.get("success"):
+            self.openai_oauth_status_label.setText("Login failed")
+            self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: red;")
+            QMessageBox.critical(self, "ChatGPT Login", result.get("error", "Failed"))
+            return
+        try:
+            store_token_payload(self.settings, result["token"])
+            index = self.provider_combo.findText("openai-codex")
+            if index >= 0:
+                self.provider_combo.setCurrentIndex(index)
+                self.settings.setValue(f"{SETTINGS_PREFIX}provider", "openai-codex")
+                model = self.model_input.text().strip() or DEFAULT_MODELS.get(
+                    "openai-codex", ""
+                )
+                if model:
+                    self.model_input.setText(model)
+                    self.settings.setValue(f"{SETTINGS_PREFIX}model", model)
+        except Exception as exc:
+            self.openai_oauth_status_label.setText("Token storage failed")
+            self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: red;")
+            QMessageBox.critical(self, "ChatGPT Login", str(exc))
+            return
+        self._refresh_oauth_status()
+        self.iface.messageBar().pushSuccess("OpenGeoAgent", "ChatGPT connected.")
+
+    def _refresh_oauth_status(self):
+        """Update the OAuth login status label."""
+        authcfg = self.settings.value(f"{SETTINGS_PREFIX}openai_oauth_authcfg", "")
+        expires_at = self.settings.value(
+            f"{SETTINGS_PREFIX}openai_oauth_expires_at", "", type=str
+        )
+        if not str(authcfg).strip():
+            self.openai_oauth_status_label.setText("Not logged in")
+            self.openai_oauth_status_label.setStyleSheet(
+                "font-size: 10px; color: gray;"
+            )
+            return
+        if expires_at:
+            try:
+                expiry = time.strftime(
+                    "%Y-%m-%d %H:%M:%S",
+                    time.localtime(float(expires_at)),
+                )
+                text = f"Logged in. Access token expires at {expiry}."
+            except (TypeError, ValueError):
+                text = "Logged in. Access token expiry is unknown."
+        else:
+            text = "Logged in. Access token expiry is unknown."
+        self.openai_oauth_status_label.setText(text)
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: green;")
+
     def _on_provider_changed(self, provider):
         """Update the model field when the provider changes."""
         self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
 
     def _load_settings(self):
         """Load persisted settings into the form fields."""
-        provider = self.settings.value(f"{SETTINGS_PREFIX}provider", "openai", type=str)
+        provider = self.settings.value(
+            f"{SETTINGS_PREFIX}provider", DEFAULT_PROVIDER, type=str
+        )
         index = self.provider_combo.findText(provider)
-        self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
+        if index < 0:
+            index = self.provider_combo.findText(DEFAULT_PROVIDER)
+        self.provider_combo.setCurrentIndex(index if index >= 0 else 0)
 
         model = self.settings.value(f"{SETTINGS_PREFIX}model", "", type=str)
         self.model_input.setText(model or DEFAULT_MODELS.get(provider, ""))
@@ -401,6 +633,8 @@ class SettingsDockWidget(QDockWidget):
             widget.setText(value)
             if from_env:
                 self._env_sourced_credentials[key] = value
+
+        self._refresh_oauth_status()
 
     def _credential_value(self, key):
         """Return ``(value, from_env)`` for a credential field.
@@ -451,6 +685,12 @@ class SettingsDockWidget(QDockWidget):
         if reply != QMessageBox.StandardButton.Yes:
             return
 
+        try:
+            clear_token_payload(self.settings)
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+
         for key in [
             "provider",
             "model",
@@ -463,6 +703,10 @@ class SettingsDockWidget(QDockWidget):
             "ollama_host",
             "litellm_api_key",
             "litellm_base_url",
+            *OAUTH_CONFIG_KEYS,
+            "openai_oauth_authcfg",
+            "openai_oauth_expires_at",
+            "openai_oauth_token_type",
         ]:
             self.settings.remove(f"{SETTINGS_PREFIX}{key}")
         self._load_settings()

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -12,7 +12,7 @@ about=OpenGeoAgent provides a dockable chatbot interface for QGIS that builds on
     Features:
     - Dockable chat panel for asking questions about the current QGIS project
     - QGIS-safe GeoAgent tools for layer inspection, map navigation, data loading, selection, processing, and project operations
-    - Provider and model controls for Bedrock, OpenAI, Anthropic, Google Gemini, Ollama, and LiteLLM
+    - Provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, and LiteLLM
     - Sample prompts, prompt history with Up/Down, and Ctrl+Enter sending
     - Settings panel for API keys, hosts, model defaults, and dependency status
     - One-click dependency installer using uv with an isolated virtual environment

--- a/qgis_geoagent/open_geoagent/oauth.py
+++ b/qgis_geoagent/open_geoagent/oauth.py
@@ -1,0 +1,536 @@
+"""OAuth helpers for the OpenGeoAgent QGIS plugin.
+
+The plugin supports OAuth through an external OpenAI-compatible proxy. Direct
+OpenAI API calls still use API keys.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+SETTINGS_PREFIX = "OpenGeoAgent/"
+OPENAI_CODEX_AUTHORIZATION_URL = "https://auth.openai.com/oauth/authorize"
+OPENAI_CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_SCOPE = "openid profile email offline_access"
+OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+OPENAI_CODEX_CALLBACK_PORT = 1455
+OPENAI_CODEX_CALLBACK_PATH = "/auth/callback"
+OPENAI_CODEX_AUTH_EXTRA_PARAMS = {
+    "id_token_add_organizations": "true",
+    "codex_cli_simplified_flow": "true",
+    "originator": "pi",
+}
+AUTHCFG_KEY = "openai_oauth_authcfg"
+EXPIRES_AT_KEY = "openai_oauth_expires_at"
+TOKEN_TYPE_KEY = "openai_oauth_token_type"
+REFRESH_SKEW_SECONDS = 300
+
+OAUTH_CONFIG_KEYS = (
+    "openai_oauth_authorization_url",
+    "openai_oauth_token_url",
+    "openai_oauth_client_id",
+    "openai_oauth_scope",
+    "openai_oauth_base_url",
+)
+OAUTH_TOKEN_SETTING_KEYS = (
+    AUTHCFG_KEY,
+    EXPIRES_AT_KEY,
+    TOKEN_TYPE_KEY,
+)
+CODEX_DEFAULT_CONFIG = {
+    "authorization_url": OPENAI_CODEX_AUTHORIZATION_URL,
+    "token_url": OPENAI_CODEX_TOKEN_URL,
+    "client_id": OPENAI_CODEX_CLIENT_ID,
+    "scope": OPENAI_CODEX_SCOPE,
+    "base_url": OPENAI_CODEX_BASE_URL,
+}
+
+
+@dataclass
+class OAuthLoopbackFlow:
+    """Pending localhost callback flow."""
+
+    authorization_url: str
+    redirect_uri: str
+    state: str
+    code_verifier: str
+    server: HTTPServer
+    collector: dict[str, Any]
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return an OAuth PKCE verifier and S256 challenge."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def generate_state() -> str:
+    """Return a cryptographically random OAuth state value."""
+    return secrets.token_urlsafe(32)
+
+
+def token_expires_soon(
+    expires_at: float | int | str | None,
+    *,
+    now: float | None = None,
+    skew_seconds: int = REFRESH_SKEW_SECONDS,
+) -> bool:
+    """Return True when a token is missing or near expiry."""
+    if not expires_at:
+        return True
+    try:
+        expiry = float(expires_at)
+    except (TypeError, ValueError):
+        return True
+    current = time.time() if now is None else now
+    return expiry <= current + skew_seconds
+
+
+def decode_jwt_payload(token: str) -> dict[str, Any]:
+    """Decode an unsigned JWT payload for local claim extraction."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        data = base64.urlsafe_b64decode((payload + padding).encode("ascii"))
+        decoded = json.loads(data.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def extract_chatgpt_account_id(token_payload: dict[str, Any]) -> str:
+    """Extract the ChatGPT account id from OAuth token claims when present."""
+    for token_key in ("access_token", "id_token"):
+        claims = decode_jwt_payload(str(token_payload.get(token_key, "")))
+        direct = claims.get("https://api.openai.com/auth.chatgpt_account_id")
+        if isinstance(direct, str) and direct.strip():
+            return direct.strip()
+        auth_claim = claims.get("https://api.openai.com/auth")
+        if isinstance(auth_claim, dict):
+            nested = auth_claim.get("chatgpt_account_id")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+        for fallback_key in ("chatgpt_account_id", "account_id"):
+            fallback = claims.get(fallback_key)
+            if isinstance(fallback, str) and fallback.strip():
+                return fallback.strip()
+    return ""
+
+
+def build_authorization_url(
+    authorization_url: str,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    scope: str = "",
+    extra_params: dict[str, str] | None = None,
+) -> str:
+    """Build an OAuth authorization-code URL with PKCE parameters."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    if scope:
+        params["scope"] = scope
+    if extra_params:
+        params.update(extra_params)
+    separator = "&" if urllib.parse.urlparse(authorization_url).query else "?"
+    return authorization_url + separator + urllib.parse.urlencode(params)
+
+
+def extract_authorization_code(callback_url: str, expected_state: str) -> str:
+    """Validate a callback URL and return its authorization code."""
+    parsed = urllib.parse.urlparse(callback_url)
+    query = urllib.parse.parse_qs(parsed.query)
+    state = query.get("state", [""])[0]
+    if state != expected_state:
+        raise ValueError("OAuth callback state did not match the login request.")
+    error = query.get("error", [""])[0]
+    if error:
+        description = query.get("error_description", [""])[0]
+        raise ValueError(description or f"OAuth authorization failed: {error}")
+    code = query.get("code", [""])[0]
+    if not code:
+        raise ValueError("OAuth callback did not include an authorization code.")
+    return code
+
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Capture a single OAuth callback."""
+
+    def do_GET(self):  # noqa: N802
+        """Handle the OAuth redirect."""
+        collector = self.server.collector  # type: ignore[attr-defined]
+        collector["url"] = f"http://127.0.0.1:{self.server.server_port}{self.path}"
+        body = (
+            "<html><body><h3>OpenGeoAgent login complete</h3>"
+            "<p>You can close this browser tab and return to QGIS.</p>"
+            "</body></html>"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002
+        """Suppress callback server logging in QGIS."""
+        return
+
+
+def start_loopback_flow(
+    authorization_url: str,
+    *,
+    client_id: str,
+    scope: str = "",
+    bind_host: str = "127.0.0.1",
+    redirect_host: str = "127.0.0.1",
+    port: int = 0,
+    callback_path: str = "/callback",
+    extra_params: dict[str, str] | None = None,
+    fallback_port: bool = True,
+) -> OAuthLoopbackFlow:
+    """Start a localhost callback server and return the pending OAuth flow."""
+    verifier, challenge = generate_pkce_pair()
+    state = generate_state()
+    collector: dict[str, Any] = {}
+    try:
+        server = HTTPServer((bind_host, port), _OAuthCallbackHandler)
+    except OSError as exc:
+        if port == 0 or not fallback_port:
+            if port:
+                raise RuntimeError(
+                    f"OAuth callback port {port} is not available."
+                ) from exc
+            raise
+        server = HTTPServer((bind_host, 0), _OAuthCallbackHandler)
+    server.timeout = 1
+    server.collector = collector  # type: ignore[attr-defined]
+    if not callback_path.startswith("/"):
+        callback_path = "/" + callback_path
+    redirect_uri = f"http://{redirect_host}:{server.server_port}{callback_path}"
+    url = build_authorization_url(
+        authorization_url,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=challenge,
+        state=state,
+        scope=scope,
+        extra_params=extra_params,
+    )
+    return OAuthLoopbackFlow(url, redirect_uri, state, verifier, server, collector)
+
+
+def complete_loopback_flow(
+    flow: OAuthLoopbackFlow,
+    *,
+    token_url: str,
+    client_id: str,
+    timeout_seconds: int = 180,
+) -> dict[str, Any]:
+    """Wait for the browser callback and exchange the code for tokens."""
+    deadline = time.time() + timeout_seconds
+    try:
+        while time.time() < deadline and "url" not in flow.collector:
+            flow.server.handle_request()
+        if "url" not in flow.collector:
+            raise TimeoutError("Timed out waiting for the OAuth browser callback.")
+        code = extract_authorization_code(flow.collector["url"], flow.state)
+        return exchange_authorization_code(
+            token_url,
+            client_id=client_id,
+            code=code,
+            redirect_uri=flow.redirect_uri,
+            code_verifier=flow.code_verifier,
+        )
+    finally:
+        flow.server.server_close()
+
+
+def _post_form(url: str, data: dict[str, str]) -> dict[str, Any]:
+    """POST URL-encoded form data and return decoded JSON."""
+    encoded = urllib.parse.urlencode(data).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=encoded,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"OAuth token request failed: {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"OAuth token request failed: {exc}") from exc
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("OAuth token endpoint did not return JSON.") from exc
+
+
+def _normalize_token_response(response: dict[str, Any]) -> dict[str, Any]:
+    """Validate and add an absolute expiry timestamp to a token response."""
+    access_token = str(response.get("access_token", "")).strip()
+    if not access_token:
+        raise RuntimeError("OAuth token endpoint did not return an access token.")
+    normalized = dict(response)
+    try:
+        expires_in = int(normalized.get("expires_in", 3600))
+    except (TypeError, ValueError):
+        expires_in = 3600
+    normalized["expires_at"] = int(time.time()) + max(expires_in, 0)
+    normalized["token_type"] = str(normalized.get("token_type") or "Bearer")
+    account_id = extract_chatgpt_account_id(normalized)
+    if account_id:
+        normalized["account_id"] = account_id
+    return normalized
+
+
+def exchange_authorization_code(
+    token_url: str,
+    *,
+    client_id: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    """Exchange an authorization code for an OAuth token payload."""
+    response = _post_form(
+        token_url,
+        {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        },
+    )
+    return _normalize_token_response(response)
+
+
+def refresh_oauth_token(
+    token_url: str,
+    *,
+    client_id: str,
+    refresh_token: str,
+    scope: str = "",
+) -> dict[str, Any]:
+    """Refresh an OAuth access token."""
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "refresh_token": refresh_token,
+    }
+    if scope:
+        data["scope"] = scope
+    response = _post_form(token_url, data)
+    normalized = _normalize_token_response(response)
+    if "refresh_token" not in normalized:
+        normalized["refresh_token"] = refresh_token
+    return normalized
+
+
+def _qgis_auth_manager():
+    """Return the QGIS auth manager or raise a clear setup error."""
+    try:
+        from qgis.core import QgsApplication
+    except Exception as exc:
+        raise RuntimeError(
+            "QGIS Auth Manager is required for OAuth token storage."
+        ) from exc
+    manager = QgsApplication.authManager()
+    if manager is None:
+        raise RuntimeError("QGIS Auth Manager is not available.")
+    return manager
+
+
+def _store_secret_payload(payload: dict[str, Any], existing_authcfg: str = "") -> str:
+    """Store OAuth tokens in QGIS Auth Manager and return the auth config id."""
+    try:
+        from qgis.core import QgsAuthMethodConfig
+    except Exception as exc:
+        raise RuntimeError(
+            "QGIS Auth Manager is required for OAuth token storage."
+        ) from exc
+
+    manager = _qgis_auth_manager()
+    config = QgsAuthMethodConfig()
+    if existing_authcfg:
+        try:
+            manager.loadAuthenticationConfig(existing_authcfg, config, True)
+        except TypeError:
+            manager.loadAuthenticationConfig(existing_authcfg, config)
+    config.setName("OpenGeoAgent ChatGPT Login")
+    config.setMethod("Basic")
+    config.setConfig("username", "openai-codex")
+    config.setConfig("password", json.dumps(payload))
+    if existing_authcfg:
+        ok = manager.updateAuthenticationConfig(config)
+        authcfg = existing_authcfg
+    else:
+        ok = manager.storeAuthenticationConfig(config)
+        authcfg = config.id()
+    if not ok:
+        raise RuntimeError("Failed to store OAuth tokens in QGIS Auth Manager.")
+    return authcfg
+
+
+def _load_secret_payload(authcfg: str) -> dict[str, Any]:
+    """Load OAuth tokens from QGIS Auth Manager."""
+    try:
+        from qgis.core import QgsAuthMethodConfig
+    except Exception as exc:
+        raise RuntimeError(
+            "QGIS Auth Manager is required for OAuth token storage."
+        ) from exc
+
+    manager = _qgis_auth_manager()
+    config = QgsAuthMethodConfig()
+    try:
+        ok = manager.loadAuthenticationConfig(authcfg, config, True)
+    except TypeError:
+        ok = manager.loadAuthenticationConfig(authcfg, config)
+    if not ok:
+        raise RuntimeError("OpenAI OAuth tokens were not found in QGIS Auth Manager.")
+    raw = config.config("password")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Stored OpenAI OAuth token payload is invalid.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Stored OpenAI OAuth token payload is invalid.")
+    return payload
+
+
+def _remove_secret_payload(authcfg: str) -> None:
+    """Remove a QGIS Auth Manager token payload."""
+    if not authcfg:
+        return
+    manager = _qgis_auth_manager()
+    manager.removeAuthenticationConfig(authcfg)
+
+
+def store_token_payload(
+    settings,
+    token_payload: dict[str, Any],
+    *,
+    prefix: str = SETTINGS_PREFIX,
+) -> str:
+    """Store OAuth tokens and persist only the auth reference in QSettings."""
+    existing_authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    authcfg = _store_secret_payload(token_payload, str(existing_authcfg or ""))
+    settings.setValue(f"{prefix}{AUTHCFG_KEY}", authcfg)
+    settings.setValue(
+        f"{prefix}{EXPIRES_AT_KEY}", str(token_payload.get("expires_at", ""))
+    )
+    settings.setValue(
+        f"{prefix}{TOKEN_TYPE_KEY}", str(token_payload.get("token_type", "Bearer"))
+    )
+    return authcfg
+
+
+def load_token_payload(settings, *, prefix: str = SETTINGS_PREFIX) -> dict[str, Any]:
+    """Load the OAuth token payload referenced by QSettings."""
+    authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    if not str(authcfg).strip():
+        raise RuntimeError("OpenAI OAuth is not logged in.")
+    return _load_secret_payload(str(authcfg))
+
+
+def clear_token_payload(settings, *, prefix: str = SETTINGS_PREFIX) -> None:
+    """Remove OAuth tokens and their QSettings references."""
+    authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    if str(authcfg).strip():
+        _remove_secret_payload(str(authcfg))
+    for key in OAUTH_TOKEN_SETTING_KEYS:
+        settings.remove(f"{prefix}{key}")
+
+
+def ensure_openai_oauth_environment(
+    settings,
+    *,
+    prefix: str = SETTINGS_PREFIX,
+    codex: bool = True,
+) -> None:
+    """Refresh tokens if needed and export env vars for GeoAgent model creation."""
+    base_url = settings.value(f"{prefix}openai_oauth_base_url", "", type=str).strip()
+    if not base_url:
+        base_url = os.environ.get("OPENAI_CODEX_BASE_URL", "").strip()
+    if not base_url:
+        base_url = OPENAI_CODEX_BASE_URL
+    if not base_url:
+        raise RuntimeError("OpenAI Codex base URL is not configured.")
+
+    authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    if not str(authcfg).strip():
+        access_token = os.environ.get("OPENAI_CODEX_ACCESS_TOKEN", "").strip()
+        if access_token:
+            os.environ["OPENAI_CODEX_ACCESS_TOKEN"] = access_token
+            os.environ["OPENAI_CODEX_BASE_URL"] = base_url
+            account_id = os.environ.get("OPENAI_CODEX_ACCOUNT_ID", "").strip()
+            if not account_id:
+                account_id = extract_chatgpt_account_id({"access_token": access_token})
+            if account_id:
+                os.environ["OPENAI_CODEX_ACCOUNT_ID"] = account_id
+            return
+
+    payload = load_token_payload(settings, prefix=prefix)
+    if token_expires_soon(payload.get("expires_at")):
+        refresh_token = str(payload.get("refresh_token", "")).strip()
+        if not refresh_token:
+            raise RuntimeError(
+                "OpenAI OAuth token expired and no refresh token is stored."
+            )
+        token_url = settings.value(
+            f"{prefix}openai_oauth_token_url", "", type=str
+        ).strip()
+        client_id = settings.value(
+            f"{prefix}openai_oauth_client_id", "", type=str
+        ).strip()
+        scope = settings.value(f"{prefix}openai_oauth_scope", "", type=str).strip()
+        token_url = token_url or OPENAI_CODEX_TOKEN_URL
+        client_id = client_id or OPENAI_CODEX_CLIENT_ID
+        scope = scope or OPENAI_CODEX_SCOPE
+        if not token_url or not client_id:
+            raise RuntimeError("OpenAI OAuth token URL and client ID are required.")
+        payload = refresh_oauth_token(
+            token_url,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            scope=scope,
+        )
+        store_token_payload(settings, payload, prefix=prefix)
+
+    access_token = str(payload.get("access_token", "")).strip()
+    if not access_token:
+        raise RuntimeError("Stored OpenAI OAuth token payload has no access token.")
+    os.environ["OPENAI_CODEX_ACCESS_TOKEN"] = access_token
+    os.environ["OPENAI_CODEX_BASE_URL"] = base_url
+    account_id = str(payload.get("account_id", "")).strip()
+    if account_id:
+        os.environ["OPENAI_CODEX_ACCOUNT_ID"] = account_id

--- a/qgis_geoagent/open_geoagent/open_geoagent.py
+++ b/qgis_geoagent/open_geoagent/open_geoagent.py
@@ -275,7 +275,7 @@ LLM providers.</p>
 <h3>Features</h3>
 <ul>
 <li>Dockable chatbot panel for QGIS projects</li>
-<li>Provider and model selection for Bedrock, OpenAI, Anthropic, Google Gemini, Ollama, and LiteLLM</li>
+<li>Provider and model selection for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, and LiteLLM</li>
 <li>Sample prompts, prompt history, and Ctrl+Enter prompt sending</li>
 <li>One-click dependency installer in an isolated virtual environment</li>
 <li>GitHub update checker and packaging scripts</li>

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -1,0 +1,75 @@
+"""Tests for QGIS chat transcript tool-input formatting."""
+
+from open_geoagent.dialogs.chat_dock import _format_tool_calls
+
+
+def test_format_tool_calls_labels_routed_whitebox_tools() -> None:
+    """Verify brokered Whitebox calls show the actual routed tool name."""
+    text = _format_tool_calls(
+        [
+            {
+                "name": "run_whitebox_tool",
+                "args": {
+                    "tool_name": "d8_pointer",
+                    "parameters": {
+                        "dem": "/tmp/filled_dem.tif",
+                        "output": "/tmp/d8_pointer.tif",
+                    },
+                    "output_layer_name": "D8 pointer",
+                    "working_dir": "/tmp",
+                },
+            },
+            {
+                "name": "get_whitebox_tool_info",
+                "args": {"tool_name": "raster_streams_to_vector"},
+            },
+            {
+                "name": "list_project_layers",
+                "args": {},
+            },
+        ]
+    )
+
+    assert "- **`run_whitebox_tool -> d8_pointer`**:" in text
+    assert "`tool_name=d8_pointer`" not in text
+    assert "`dem=/tmp/filled_dem.tif`" in text
+    assert "`output=/tmp/d8_pointer.tif`" in text
+    assert "- **`get_whitebox_tool_info -> raster_streams_to_vector`**" in text
+    assert "- **`list_project_layers`**" in text
+
+
+def test_format_tool_calls_collapses_repeated_noop_defaults() -> None:
+    """Verify repeated model retries are grouped after dropping no-op defaults."""
+    text = _format_tool_calls(
+        [
+            {
+                "name": "run_whitebox_fill_sinks",
+                "args": {
+                    "add_outputs_to_qgis": True,
+                    "fill_pits": False,
+                    "fix_flats": False,
+                    "flat_increment": 0,
+                    "layer_name": "",
+                    "max_depth": 0,
+                    "max_length": 0,
+                    "method": "fill_depressions_wang_and_liu",
+                    "output_layer_name": "DEM filled",
+                    "output_path": "",
+                    "verbose": False,
+                },
+            },
+            {
+                "name": "run_whitebox_fill_sinks",
+                "args": {
+                    "method": "fill_depressions_wang_and_liu",
+                    "output_layer_name": "DEM filled",
+                },
+            },
+        ]
+    )
+
+    assert "repeated 2 times" in text
+    assert text.count("run_whitebox_fill_sinks") == 1
+    assert "`method=fill_depressions_wang_and_liu`" in text
+    assert "max_depth" not in text
+    assert "fill_pits" not in text

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -1,6 +1,28 @@
 """Tests for QGIS chat transcript tool-input formatting."""
 
-from open_geoagent.dialogs.chat_dock import _format_tool_calls
+from open_geoagent.dialogs.chat_dock import _conversation_markdown, _format_tool_calls
+
+
+def test_conversation_markdown_includes_full_history() -> None:
+    """Verify copying Markdown includes every chat turn."""
+    text = _conversation_markdown(
+        [
+            {"sender": "You", "body": "hello", "markdown": False},
+            {"sender": "OpenGeoAgent", "body": "**Hi**", "markdown": True},
+            {"sender": "You", "body": "run flow accumulation", "markdown": False},
+            {
+                "sender": "OpenGeoAgent",
+                "body": "Done\n\nTool inputs:\n- **`run_whitebox_tool`**",
+                "markdown": True,
+            },
+        ]
+    )
+
+    assert text.startswith("## You\n\nhello")
+    assert "## OpenGeoAgent\n\n**Hi**" in text
+    assert "## You\n\nrun flow accumulation" in text
+    assert "Tool inputs:" in text
+    assert text.count("## OpenGeoAgent") == 2
 
 
 def test_format_tool_calls_labels_routed_whitebox_tools() -> None:

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -31,6 +31,7 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
         answer_text = "ok"
         error_message = ""
         executed_tools: list = []
+        tool_calls: list = []
         cancelled_tools: list = []
         execution_time = 0.0
 

--- a/tests/test_confirmation_hook.py
+++ b/tests/test_confirmation_hook.py
@@ -88,3 +88,36 @@ def test_unconfirmed_tool_skips_callback() -> None:
     assert event.cancel_tool is False
     assert cancelled == []
     assert calls == []
+
+
+def test_hook_records_tool_call_inputs_before_confirmation_check() -> None:
+    """Verify hook records all tool inputs, including non-confirmed tools."""
+    meta = GeoToolMeta(name="run_whitebox_flow_accumulation")
+    registry = GeoToolRegistry()
+    registry.register(meta)
+    cancelled: list[str] = []
+    calls: list[dict] = []
+    hook = ConfirmationHookProvider(
+        registry,
+        lambda req: True,
+        cancelled,
+        calls,
+    )
+    event = _event(
+        "run_whitebox_flow_accumulation",
+        {"input_layer": "dem_filled", "output_layer_name": "flow_acc"},
+    )
+
+    hook._before_tool(event)  # noqa: SLF001
+
+    assert event.cancel_tool is False
+    assert cancelled == []
+    assert calls == [
+        {
+            "name": "run_whitebox_flow_accumulation",
+            "args": {
+                "input_layer": "dem_filled",
+                "output_layer_name": "flow_acc",
+            },
+        }
+    ]

--- a/tests/test_geoagent_surface.py
+++ b/tests/test_geoagent_surface.py
@@ -6,9 +6,15 @@ from geoagent import for_leafmap
 from geoagent.testing import MockLeafmap
 
 
+class _MockModel:
+    """Provide a test double for MockModel."""
+
+    stateful = False
+
+
 def test_geoagent_exposes_tool_names_and_registry() -> None:
     """Verify that geoagent exposes tool names and registry."""
-    agent = for_leafmap(MockLeafmap())
+    agent = for_leafmap(MockLeafmap(), model=_MockModel())
     names = agent.tool_names
     assert "get_map_state" in names
     configs = agent.tool_registry.get_all_tools_config()

--- a/tests/test_model_providers.py
+++ b/tests/test_model_providers.py
@@ -5,8 +5,31 @@ from __future__ import annotations
 import sys
 import types
 
+import pytest
+
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.model import resolve_model
+
+
+def _install_fake_openai_responses_model(monkeypatch):
+    """Install a fake Strands OpenAI Responses module."""
+
+    class FakeOpenAIResponsesModel:
+        """Capture OpenAI Responses constructor arguments."""
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module = types.ModuleType("strands.models.openai_responses")
+    module.OpenAIResponsesModel = FakeOpenAIResponsesModel
+    monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models",
+        types.ModuleType("strands.models"),
+    )
+    monkeypatch.setitem(sys.modules, "strands.models.openai_responses", module)
+    return FakeOpenAIResponsesModel
 
 
 def test_litellm_config_is_valid() -> None:
@@ -17,10 +40,57 @@ def test_litellm_config_is_valid() -> None:
     assert cfg.model == "openai/gpt-5.5"
 
 
+def test_openai_codex_config_is_valid() -> None:
+    """Verify that OpenAI Codex OAuth is accepted as a provider."""
+    cfg = GeoAgentConfig(provider="openai-codex", model="gpt-5.5")
+
+    assert cfg.provider == "openai-codex"
+    assert cfg.model == "gpt-5.5"
+
+
+def test_openai_codex_is_default_provider_without_env(monkeypatch) -> None:
+    """Verify OpenAI Codex is the default provider."""
+    for key in [
+        "OPENAI_API_KEY",
+        "OPENAI_CODEX_ACCESS_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OLLAMA_HOST",
+        "USE_OLLAMA",
+        "LITELLM_API_KEY",
+        "LITELLM_MODEL",
+        "LITELLM_BASE_URL",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    assert GeoAgentConfig().provider == "openai-codex"
+
+
+def test_openai_codex_can_be_selected_from_environment(monkeypatch) -> None:
+    """Verify that Codex OAuth token selects OpenAI Codex by default."""
+    for key in [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OLLAMA_HOST",
+        "USE_OLLAMA",
+        "LITELLM_API_KEY",
+        "LITELLM_MODEL",
+        "LITELLM_BASE_URL",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_CODEX_ACCESS_TOKEN", "codex-token")
+
+    assert GeoAgentConfig().provider == "openai-codex"
+
+
 def test_litellm_can_be_selected_from_environment(monkeypatch) -> None:
     """Verify that LiteLLM environment variables select LiteLLM by default."""
     for key in [
         "OPENAI_API_KEY",
+        "OPENAI_CODEX_ACCESS_TOKEN",
         "ANTHROPIC_API_KEY",
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
@@ -31,6 +101,45 @@ def test_litellm_can_be_selected_from_environment(monkeypatch) -> None:
     monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm.example.test")
 
     assert GeoAgentConfig().provider == "litellm"
+
+
+def test_resolve_openai_codex_model(monkeypatch) -> None:
+    """Verify OpenAI Codex resolves to the Responses model."""
+    fake_model = _install_fake_openai_responses_model(monkeypatch)
+    monkeypatch.setenv("OPENAI_CODEX_ACCESS_TOKEN", "codex-token")
+    monkeypatch.setenv("OPENAI_CODEX_ACCOUNT_ID", "account-123")
+
+    model = resolve_model(
+        GeoAgentConfig(
+            provider="openai-codex",
+            model="gpt-5.5",
+            temperature=0.1,
+            max_tokens=2048,
+        )
+    )
+
+    assert isinstance(model, fake_model)
+    assert model.kwargs == {
+        "client_args": {
+            "api_key": "codex-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "default_headers": {
+                "User-Agent": "codex-cli",
+                "ChatGPT-Account-Id": "account-123",
+            },
+        },
+        "model_id": "gpt-5.5",
+        "params": {},
+    }
+
+
+def test_openai_codex_requires_token(monkeypatch) -> None:
+    """Verify missing Codex OAuth token gives a clear error."""
+    _install_fake_openai_responses_model(monkeypatch)
+    monkeypatch.delenv("OPENAI_CODEX_ACCESS_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="ChatGPT OAuth access token"):
+        resolve_model(GeoAgentConfig(provider="openai-codex"))
 
 
 def test_resolve_litellm_model(monkeypatch) -> None:

--- a/tests/test_openai_oauth_helpers.py
+++ b/tests/test_openai_oauth_helpers.py
@@ -1,0 +1,176 @@
+"""Tests for OpenGeoAgent OpenAI OAuth helper behavior."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import pathlib
+import sys
+import urllib.parse
+
+import pytest
+
+OAUTH_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "qgis_geoagent"
+    / "open_geoagent"
+    / "oauth.py"
+)
+SPEC = importlib.util.spec_from_file_location("open_geoagent_oauth", OAUTH_PATH)
+oauth = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = oauth
+SPEC.loader.exec_module(oauth)
+
+
+class FakeSettings:
+    """Small QSettings stand-in for OAuth helper tests."""
+
+    def __init__(self):
+        self.values = {}
+
+    def value(self, key, default="", type=str):  # noqa: A002
+        """Return a stored value."""
+        value = self.values.get(key, default)
+        if type is str and value is not None:
+            return str(value)
+        return value
+
+    def setValue(self, key, value):  # noqa: N802
+        """Store a value."""
+        self.values[key] = value
+
+    def remove(self, key):
+        """Remove a value."""
+        self.values.pop(key, None)
+
+
+def test_generate_pkce_pair_uses_s256_challenge() -> None:
+    """Verify PKCE challenge generation."""
+    verifier, challenge = oauth.generate_pkce_pair()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+    assert len(verifier) >= 43
+    assert challenge == expected
+
+
+def test_extract_authorization_code_validates_state() -> None:
+    """Verify callback state validation."""
+    code = oauth.extract_authorization_code(
+        "http://127.0.0.1:49152/callback?code=abc&state=expected",
+        "expected",
+    )
+
+    assert code == "abc"
+    with pytest.raises(ValueError, match="state"):
+        oauth.extract_authorization_code(
+            "http://127.0.0.1:49152/callback?code=abc&state=other",
+            "expected",
+        )
+
+
+def test_codex_authorization_url_matches_registered_flow_shape() -> None:
+    """Verify Codex login uses the expected redirect and auth parameters."""
+    url = oauth.build_authorization_url(
+        oauth.OPENAI_CODEX_AUTHORIZATION_URL,
+        client_id=oauth.OPENAI_CODEX_CLIENT_ID,
+        redirect_uri="http://localhost:1455/auth/callback",
+        code_challenge="challenge",
+        state="state",
+        scope=oauth.OPENAI_CODEX_SCOPE,
+        extra_params=oauth.OPENAI_CODEX_AUTH_EXTRA_PARAMS,
+    )
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "auth.openai.com"
+    assert params["redirect_uri"] == ["http://localhost:1455/auth/callback"]
+    assert params["client_id"] == [oauth.OPENAI_CODEX_CLIENT_ID]
+    assert params["scope"] == ["openid profile email offline_access"]
+    assert params["id_token_add_organizations"] == ["true"]
+    assert params["codex_cli_simplified_flow"] == ["true"]
+    assert params["originator"] == ["pi"]
+
+
+def test_token_expires_soon_with_skew() -> None:
+    """Verify expiry refresh decisions."""
+    assert oauth.token_expires_soon(None, now=1000)
+    assert oauth.token_expires_soon(1200, now=1000, skew_seconds=300)
+    assert not oauth.token_expires_soon(1400, now=1000, skew_seconds=300)
+
+
+def test_extract_chatgpt_account_id_from_access_token() -> None:
+    """Verify account id extraction from a JWT payload."""
+    payload = {
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "account-123",
+        }
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    token = "header." + encoded.rstrip("=") + ".signature"
+
+    assert oauth.extract_chatgpt_account_id({"access_token": token}) == "account-123"
+
+
+def test_store_load_and_clear_token_payload(monkeypatch) -> None:
+    """Verify token storage uses only an auth reference in settings."""
+    settings = FakeSettings()
+    stored = {}
+    removed = []
+
+    def fake_store(payload, existing_authcfg=""):
+        stored["payload"] = payload
+        stored["existing_authcfg"] = existing_authcfg
+        return "authcfg-1"
+
+    def fake_load(authcfg):
+        stored["loaded_authcfg"] = authcfg
+        return stored["payload"]
+
+    def fake_remove(authcfg):
+        removed.append(authcfg)
+
+    monkeypatch.setattr(oauth, "_store_secret_payload", fake_store)
+    monkeypatch.setattr(oauth, "_load_secret_payload", fake_load)
+    monkeypatch.setattr(oauth, "_remove_secret_payload", fake_remove)
+
+    token = {
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "expires_at": 2000,
+        "token_type": "Bearer",
+    }
+    authcfg = oauth.store_token_payload(settings, token)
+
+    assert authcfg == "authcfg-1"
+    assert settings.value("OpenGeoAgent/openai_oauth_authcfg") == "authcfg-1"
+    assert "access_token" not in settings.values
+    assert oauth.load_token_payload(settings) == token
+
+    oauth.clear_token_payload(settings)
+
+    assert removed == ["authcfg-1"]
+    assert "OpenGeoAgent/openai_oauth_authcfg" not in settings.values
+    assert "OpenGeoAgent/openai_oauth_expires_at" not in settings.values
+
+
+def test_ensure_environment_allows_codex_env_token(monkeypatch) -> None:
+    """Verify Codex auth can use built-in base URL with an env token."""
+    settings = FakeSettings()
+    monkeypatch.setenv("OPENAI_CODEX_ACCESS_TOKEN", "codex-token")
+    monkeypatch.delenv("OPENAI_CODEX_BASE_URL", raising=False)
+
+    oauth.ensure_openai_oauth_environment(settings, codex=True)
+
+    assert oauth.os.environ["OPENAI_CODEX_ACCESS_TOKEN"] == "codex-token"
+    assert (
+        oauth.os.environ["OPENAI_CODEX_BASE_URL"]
+        == "https://chatgpt.com/backend-api/codex"
+    )

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -54,6 +54,7 @@ def test_factory_returns_tools_for_iface() -> None:
         "remove_layer",
         "set_layer_visibility",
         "set_layer_opacity",
+        "set_layer_symbology",
         "inspect_layer_fields",
         "get_selected_features",
         "select_features_by_expression",
@@ -501,6 +502,88 @@ def test_save_project_records_path(tmp_path) -> None:
     out = tools["save_project"](path=str(tmp_path / "project.qgz"))
     assert out.endswith("project.qgz")
     assert project.saved_path == out
+
+
+def test_set_layer_symbology_updates_mock_layer() -> None:
+    """Verify simple layer styling is exposed as a QGIS tool."""
+    project = MockQGISProject()
+    layer = MockQGISLayer("Stream network", "/tmp/streams.shp", "vector")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project=project)
+    tools = {t.tool_name: t for t in qgis_tools(iface, project)}
+
+    result = tools["set_layer_symbology"](
+        layer_name="Stream network",
+        color="blue",
+        line_width=2,
+        opacity=0.75,
+    )
+
+    assert result["message"] == "Updated symbology for layer 'Stream network'."
+    assert result["color"] == "blue"
+    assert result["line_width"] == 2.0
+    assert result["opacity"] == 0.75
+    assert layer.symbology == {"color": "blue", "line_width": 2.0}
+    assert layer.opacity() == 0.75
+    assert layer.repaint_count == 1
+    assert iface.mapCanvas().refresh_count == 1
+
+
+def test_set_layer_symbology_does_not_reassign_renderer_owned_symbol() -> None:
+    """Verify styling mutates the existing renderer symbol without re-owning it."""
+
+    class MockSymbolLayer:
+        """Minimal symbol layer with width controls."""
+
+        def __init__(self) -> None:
+            self.width = 0.0
+
+        def setWidth(self, width: float) -> None:
+            self.width = width
+
+    class MockSymbol:
+        """Minimal renderer-owned symbol."""
+
+        def __init__(self) -> None:
+            self.color = None
+            self.layer = MockSymbolLayer()
+
+        def setColor(self, color) -> None:
+            self.color = color
+
+        def symbolLayer(self, index: int):
+            return self.layer if index == 0 else None
+
+    class MockRenderer:
+        """Renderer that must keep ownership of its existing symbol."""
+
+        def __init__(self) -> None:
+            self.existing_symbol = MockSymbol()
+
+        def symbol(self):
+            return self.existing_symbol
+
+        def setSymbol(self, symbol) -> None:
+            raise AssertionError("setSymbol must not be called with an owned symbol")
+
+    project = MockQGISProject()
+    layer = MockQGISLayer("Stream network", "/tmp/streams.shp", "vector")
+    renderer = MockRenderer()
+    layer.renderer = lambda: renderer
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project=project)
+    tools = {t.tool_name: t for t in qgis_tools(iface, project)}
+
+    result = tools["set_layer_symbology"](
+        layer_name="Stream network",
+        color="blue",
+        line_width=2,
+    )
+
+    assert result["message"] == "Updated symbology for layer 'Stream network'."
+    assert renderer.existing_symbol.color == "blue"
+    assert renderer.existing_symbol.layer.width == 2.0
+    assert layer.repaint_count == 1
 
 
 def test_qgis_tools_route_calls_through_gui_marshal(monkeypatch) -> None:

--- a/tests/test_whitebox_tools.py
+++ b/tests/test_whitebox_tools.py
@@ -317,7 +317,7 @@ def test_run_whitebox_flow_accumulation_uses_active_layer(
 
 
 def test_run_whitebox_fill_sinks_uses_active_layer(monkeypatch, tmp_path) -> None:
-    """Verify the sink-filling convenience tool uses the active DEM."""
+    """Verify sink-filling defaults to fill_depressions on the active DEM."""
     input_path = tmp_path / "dem.tif"
     output_path = tmp_path / "dem_filled.tif"
     input_path.write_text("dem", encoding="utf-8")
@@ -331,7 +331,7 @@ def test_run_whitebox_fill_sinks_uses_active_layer(monkeypatch, tmp_path) -> Non
             self.verbose = True
 
         def tool_parameters(self, tool_name):
-            assert tool_name == "breach_depressions"
+            assert tool_name == "fill_depressions"
             return json.dumps(
                 {
                     "parameters": [
@@ -348,14 +348,14 @@ def test_run_whitebox_fill_sinks_uses_active_layer(monkeypatch, tmp_path) -> Non
                             "optional": False,
                         },
                         {
-                            "name": "Maximum Breach Depth (z units)",
+                            "name": "Maximum Depression Depth (z units)",
                             "flags": ["--max_depth"],
                             "parameter_type": "Float",
                             "optional": True,
                         },
                         {
-                            "name": "Fill single-cell pits?",
-                            "flags": ["--fill_pits"],
+                            "name": "Fix flats?",
+                            "flags": ["--fix_flats"],
                             "parameter_type": "Boolean",
                             "optional": True,
                         },
@@ -384,15 +384,15 @@ def test_run_whitebox_fill_sinks_uses_active_layer(monkeypatch, tmp_path) -> Non
         output_path=str(output_path),
         output_layer_name="DEM Filled",
         max_depth=10,
-        fill_pits=True,
+        fix_flats=True,
     )
 
-    assert captured["tool_name"] == "breach_depressions"
+    assert captured["tool_name"] == "fill_depressions"
     assert captured["args"] == [
         f"--dem={input_path}",
         f"--output={output_path}",
         "--max_depth=10.0",
-        "--fill_pits",
+        "--fix_flats",
     ]
     assert result["success"] is True
     assert result["layers_added"] == [
@@ -403,6 +403,169 @@ def test_run_whitebox_fill_sinks_uses_active_layer(monkeypatch, tmp_path) -> Non
         }
     ]
     assert "DEM Filled" in project.mapLayers()
+
+
+def test_run_whitebox_fill_sinks_can_explicitly_breach(monkeypatch, tmp_path) -> None:
+    """Verify breaching remains available only when explicitly requested."""
+    input_path = tmp_path / "dem.tif"
+    output_path = tmp_path / "dem_breached.tif"
+    input_path.write_text("dem", encoding="utf-8")
+
+    captured = {}
+
+    class _FakeWBT:
+        verbose = True
+
+        def __init__(self):
+            self.verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "breach_depressions"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input DEM File",
+                            "flags": ["-i", "--dem"],
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Output File",
+                            "flags": ["-o", "--output"],
+                            "parameter_type": {"NewFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Maximum Breach Channel Length",
+                            "flags": ["--max_length"],
+                            "parameter_type": "Float",
+                            "optional": True,
+                        },
+                        {
+                            "name": "Fill single-cell pits?",
+                            "flags": ["--fill_pits"],
+                            "parameter_type": "Boolean",
+                            "optional": True,
+                        },
+                    ]
+                }
+            )
+
+        def run_tool(self, tool_name, args, callback=None):
+            captured["tool_name"] = tool_name
+            captured["args"] = args
+            output_path.write_text("breached", encoding="utf-8")
+            return 0
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    project = MockQGISProject()
+    layer = MockQGISLayer("DEM layer", str(input_path), "raster")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project)
+    iface.setActiveLayer(layer)
+    tools = {tool.tool_name: tool for tool in whitebox_tools(iface, project)}
+
+    result = tools["run_whitebox_fill_sinks"].__wrapped__(
+        method="breach_depressions",
+        output_path=str(output_path),
+        output_layer_name="DEM Breached",
+        max_length=50,
+        fill_pits=True,
+    )
+
+    assert captured["tool_name"] == "breach_depressions"
+    assert captured["args"] == [
+        f"--dem={input_path}",
+        f"--output={output_path}",
+        "--max_length=50.0",
+        "--fill_pits",
+    ]
+    assert result["success"] is True
+    assert "DEM Breached" in project.mapLayers()
+
+
+def test_run_whitebox_fill_sinks_ignores_model_supplied_noop_defaults(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify empty strings, false flags, and zero limits are not passed."""
+    input_path = tmp_path / "dem.tif"
+    output_path = tmp_path / "dem_filled.tif"
+    input_path.write_text("dem", encoding="utf-8")
+
+    captured = {}
+
+    class _FakeWBT:
+        verbose = True
+
+        def __init__(self):
+            self.verbose = True
+
+        def tool_parameters(self, tool_name):
+            assert tool_name == "fill_depressions_wang_and_liu"
+            return json.dumps(
+                {
+                    "parameters": [
+                        {
+                            "name": "Input DEM File",
+                            "flags": ["-i", "--dem"],
+                            "parameter_type": {"ExistingFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Output File",
+                            "flags": ["-o", "--output"],
+                            "parameter_type": {"NewFile": "Raster"},
+                            "optional": False,
+                        },
+                        {
+                            "name": "Fix flats?",
+                            "flags": ["--fix_flats"],
+                            "parameter_type": "Boolean",
+                            "optional": True,
+                        },
+                    ]
+                }
+            )
+
+        def run_tool(self, tool_name, args, callback=None):
+            captured["tool_name"] = tool_name
+            captured["args"] = args
+            output_path.write_text("filled", encoding="utf-8")
+            return 0
+
+    whitebox_module = ModuleType("whitebox")
+    whitebox_module.WhiteboxTools = _FakeWBT
+    monkeypatch.setitem(sys.modules, "whitebox", whitebox_module)
+
+    project = MockQGISProject()
+    layer = MockQGISLayer("DEM layer", str(input_path), "raster")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project)
+    iface.setActiveLayer(layer)
+    tools = {tool.tool_name: tool for tool in whitebox_tools(iface, project)}
+
+    result = tools["run_whitebox_fill_sinks"].__wrapped__(
+        layer_name="",
+        output_path=str(output_path),
+        output_layer_name="",
+        method="fill_depressions_wang_and_liu",
+        max_depth=0,
+        max_length=0,
+        flat_increment=0,
+        fill_pits=False,
+        fix_flats=False,
+    )
+
+    assert captured["tool_name"] == "fill_depressions_wang_and_liu"
+    assert captured["args"] == [
+        f"--dem={input_path}",
+        f"--output={output_path}",
+    ]
+    assert result["success"] is True
 
 
 def test_run_whitebox_color_shaded_relief_uses_active_layer(


### PR DESCRIPTION
## Summary
- Add an OpenAI ChatGPT/Codex OAuth provider to GeoAgent (`OPENAI_CODEX_ACCESS_TOKEN`, `OPENAI_CODEX_MODEL`) and document it across README/docs.
- Wire the OAuth login flow into the QGIS plugin (new `oauth.py`, settings/chat dock updates) so users can sign in with their ChatGPT account instead of managing API keys.
- Refine WhiteboxTools handling and ship tests for the new provider, OAuth helpers, and chat tool inputs.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/ -q`
- [ ] Manual: sign in to ChatGPT/Codex from the QGIS plugin and run a chat round-trip