### PR TITLE
feat: add OPERA DSWx composites and reproducible GEE snippets

### DIFF
--- a/geoagent/core/confirmation_hook.py
+++ b/geoagent/core/confirmation_hook.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from strands.hooks import HookProvider, HookRegistry
-from strands.hooks.events import BeforeToolCallEvent
+from strands.hooks.events import AfterToolCallEvent, BeforeToolCallEvent
 
 from geoagent.core.registry import GeoToolMeta, GeoToolRegistry
 from geoagent.core.safety import ConfirmCallback, ConfirmRequest
@@ -31,6 +31,7 @@ class ConfirmationHookProvider(HookProvider):
     ) -> None:  # noqa: ARG002
         """Register confirmation callbacks with the Strands hook registry."""
         registry.add_callback(BeforeToolCallEvent, self._before_tool)
+        registry.add_callback(AfterToolCallEvent, self._after_tool)
 
     def _resolve_meta(self, tool_name: str, selected: Any | None) -> GeoToolMeta | None:
         """Resolve metadata from the selected tool or registry."""
@@ -47,7 +48,11 @@ class ConfirmationHookProvider(HookProvider):
         inp = use.get("input")
         args = inp if isinstance(inp, dict) else {}
         if self._tool_calls is not None:
-            self._tool_calls.append({"name": name, "args": dict(args)})
+            record: dict[str, Any] = {"name": name, "args": dict(args)}
+            tool_use_id = use.get("toolUseId") or use.get("tool_use_id")
+            if tool_use_id:
+                record["tool_use_id"] = tool_use_id
+            self._tool_calls.append(record)
 
         selected = event.selected_tool
         meta = self._resolve_meta(name, selected)
@@ -77,3 +82,53 @@ class ConfirmationHookProvider(HookProvider):
         if not self._confirm(req):
             event.cancel_tool = "User denied confirmation for this tool."
             self._cancelled.append(name)
+
+    def _after_tool(self, event: AfterToolCallEvent) -> None:
+        """Attach compact tool results to the recorded tool call."""
+        if self._tool_calls is None:
+            return
+
+        use = event.tool_use
+        name = str(use.get("name", ""))
+        tool_use_id = use.get("toolUseId") or use.get("tool_use_id")
+        payload = {
+            "result": _compact_tool_result(event.result),
+        }
+        if event.exception is not None:
+            payload["exception"] = str(event.exception)
+
+        for call in reversed(self._tool_calls):
+            same_name = call.get("name") == name
+            same_id = tool_use_id and call.get("tool_use_id") == tool_use_id
+            if same_id or (same_name and "result" not in call):
+                call.update(payload)
+                return
+
+        record: dict[str, Any] = {"name": name, **payload}
+        if tool_use_id:
+            record["tool_use_id"] = tool_use_id
+        self._tool_calls.append(record)
+
+
+def _compact_tool_result(value: Any) -> Any:
+    """Return a JSON-friendly, size-limited representation of a tool result."""
+    if isinstance(value, dict):
+        return {str(k): _compact_tool_result(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_compact_tool_result(item) for item in value[:20]]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        if isinstance(value, str) and len(value) > 20000:
+            return value[:20000] + "\n... [truncated]"
+        return value
+    get = getattr(value, "get", None)
+    if callable(get):
+        try:
+            keys = ("status", "content", "toolUseId")
+            return {
+                key: _compact_tool_result(get(key))
+                for key in keys
+                if get(key) is not None
+            }
+        except Exception:
+            pass
+    return str(value)

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -67,8 +67,12 @@ Earth Engine layers into the current QGIS project.
 Workflow guidance:
 - Search the catalog before loading when the user names a topic rather than an
   exact Earth Engine asset id.
-- Prefer the current QGIS map extent or a user-provided bbox for spatially
-  constrained ImageCollection requests.
+- Only pass bbox to load_gee_dataset when the current user request explicitly
+  asks for a region/place/current map extent or provides bbox coordinates. Do
+  not reuse a previous conversation location for a new dataset request unless
+  the current request says "same area", "there", or otherwise clearly refers
+  to that prior location. If the user asks for a global layer, or gives no
+  location, omit bbox.
 - When the user asks to clip a raster/Image/ImageCollection to an administrative
   boundary or other vector region, use load_gee_dataset with
   clip_collection_asset_id and clip_filter_property/value. The tool applies
@@ -78,9 +82,22 @@ Workflow guidance:
   MNDWI, NDMI, or NBR, use calculate_gee_normalized_difference. Do not display
   a single source band as a proxy. Common Sentinel-2/HLS S30 pairs: NDVI B8/B4,
   NDWI B3/B8, MNDWI B3/B11, NBR B8/B12.
+- For ImageCollections, call the selected aggregation a composite method.
+  ``mosaic`` is valid, but it is an ImageCollection method, not an ee.Reducer.
+- For OPERA DSWx water maps, use OPERA/DSWX/L3_V1/HLS by default. Use
+  OPERA/DSWX/L3_V1/S1 only when the user explicitly asks for Sentinel-1 or S1.
+  Use WTR_Water_classification or BWTR_Binary_water band names. The tool masks
+  invalid classes, defaults HLS composites to mode and S1 composites to max,
+  and remaps class values for QGIS rendering.
+- Do not report that Earth Engine returned an empty collection or no bands
+  unless load_gee_dataset returns success=false with diagnostics proving that
+  specific condition. If layer insertion or tile generation fails, report that
+  actual error instead.
 - Ask for or infer visualization bands only when needed; common RGB defaults
   are acceptable for Landsat and Sentinel imagery.
 - Keep responses concise and include asset ids, layer names, and filters used.
+- If load_gee_dataset returns a bbox field, include the bbox coordinates in the
+  response in west,south,east,north order.
 """
 
 WHITEBOX_SYSTEM_PROMPT = """\

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -205,8 +205,6 @@ def _opera_dswx_band_alias(bands: str | list[str] | None) -> str:
         "BWTR": "BWTR_Binary_water",
         "BINARY_WATER": "BWTR_Binary_water",
         "BWTR_Binary_water": "BWTR_Binary_water",
-        "CONF": "CONF_Confidence",
-        "CONF_Confidence": "CONF_Confidence",
     }
     return aliases.get(first, first)
 
@@ -283,10 +281,22 @@ def _build_load_gee_dataset_snippet(
 
     if resolved_type == "ImageCollection":
         lines.append("collection = ee.ImageCollection(asset_id)")
-        if start_date or end_date:
+        if start_date and end_date:
             lines.append(
                 "collection = collection.filterDate("
                 f"{_format_python_snippet_value(start_date)}, "
+                f"{_format_python_snippet_value(end_date)}"
+                ")"
+            )
+        elif start_date:
+            lines.append(
+                "collection = collection.filterDate("
+                f"{_format_python_snippet_value(start_date)}"
+                ")"
+            )
+        elif end_date:
+            lines.append(
+                "collection = collection.filterDate("
                 f"{_format_python_snippet_value(end_date)}"
                 ")"
             )
@@ -299,6 +309,11 @@ def _build_load_gee_dataset_snippet(
         if _is_opera_dswx(asset_id):
             band = rendered_band or _opera_dswx_band_alias(bands)
             reducer_name = "mode" if method == "mode" else "max"
+            if band == "BWTR_Binary_water":
+                class_values = [0, 1, 252, 253, 254]
+            else:
+                class_values = [0, 1, 2, 252, 253, 254]
+            to_values = list(range(len(class_values)))
             lines.extend(
                 [
                     f"band = {_format_python_snippet_value(band)}",
@@ -308,8 +323,8 @@ def _build_load_gee_dataset_snippet(
                     "    )",
                     ")",
                     f"image = masked.reduce(ee.Reducer.{reducer_name}()).rename(band)",
-                    "class_values = [0, 1, 2, 252, 253, 254]",
-                    "to_values = [0, 1, 2, 3, 4, 5]",
+                    f"class_values = {_format_python_snippet_value(class_values)}",
+                    f"to_values = {_format_python_snippet_value(to_values)}",
                     "image = image.select(band).remap(class_values, to_values)",
                     "image = image.updateMask(image.neq(0))  # make non-water transparent",
                 ]
@@ -388,10 +403,22 @@ def _build_normalized_difference_snippet(
     ]
     if resolved_type == "ImageCollection":
         lines.append("collection = ee.ImageCollection(asset_id)")
-        if start_date or end_date:
+        if start_date and end_date:
             lines.append(
                 "collection = collection.filterDate("
                 f"{_format_python_snippet_value(start_date)}, "
+                f"{_format_python_snippet_value(end_date)}"
+                ")"
+            )
+        elif start_date:
+            lines.append(
+                "collection = collection.filterDate("
+                f"{_format_python_snippet_value(start_date)}"
+                ")"
+            )
+        elif end_date:
+            lines.append(
+                "collection = collection.filterDate("
                 f"{_format_python_snippet_value(end_date)}"
                 ")"
             )
@@ -1052,7 +1079,7 @@ def gee_data_catalogs_tools(
                         "vis_params": vis_params,
                     }
             try:
-                iface.mapCanvas().refresh()
+                _on_gui(lambda: iface.mapCanvas().refresh())
             except Exception:
                 pass
             return {
@@ -1247,7 +1274,7 @@ def gee_data_catalogs_tools(
                 bbox=parsed_bbox,
             )
             try:
-                iface.mapCanvas().refresh()
+                _on_gui(lambda: iface.mapCanvas().refresh())
             except Exception:
                 pass
             return {

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from typing import Any, Optional
+from urllib.parse import quote
 
 from geoagent.core.decorators import geo_tool
 from geoagent.tools._qt_marshal import run_on_qt_gui_thread
@@ -134,6 +135,560 @@ def _default_index_palette(index_name: str) -> list[str]:
     if key in {"NBR", "NBR2"}:
         return ["d7191c", "fdae61", "ffffbf", "a6d96a", "1a9641"]
     return ["d73027", "f7f7f7", "1a9850"]
+
+
+def _normalize_composite_method(
+    method: str | None,
+    default: str = "mosaic",
+    *,
+    allow_mode: bool = False,
+) -> str:
+    """Return a supported ImageCollection compositing method."""
+    method = str(method or "").lower().strip()
+    allowed = {"mosaic", "median", "mean", "min", "max", "first"}
+    if allow_mode:
+        allowed.add("mode")
+    if method in allowed:
+        return method
+    return default
+
+
+def _composite_image_collection(collection: Any, method: str) -> Any:
+    """Convert an ImageCollection to an Image using a supported method."""
+    if method == "mosaic":
+        return collection.mosaic()
+    if method == "median":
+        return collection.median()
+    if method == "mean":
+        return collection.mean()
+    if method == "min":
+        return collection.min()
+    if method == "max":
+        return collection.max()
+    if method == "first":
+        return collection.first()
+    if method == "mode":
+        try:
+            import ee
+
+            return collection.reduce(ee.Reducer.mode())
+        except Exception:
+            return collection.mosaic()
+    return collection.mosaic()
+
+
+def _is_opera_dswx(asset_id: str) -> bool:
+    """Return True for supported OPERA DSWx Earth Engine collections."""
+    return str(asset_id).strip() in {
+        "OPERA/DSWX/L3_V1/HLS",
+        "OPERA/DSWX/L3_V1/S1",
+    }
+
+
+def _opera_dswx_default_composite_method(asset_id: str) -> str:
+    """Return the catalog-recommended DSWx composite method."""
+    if str(asset_id).strip() == "OPERA/DSWX/L3_V1/S1":
+        return "max"
+    return "mode"
+
+
+def _opera_dswx_band_alias(bands: str | list[str] | None) -> str:
+    """Return a valid OPERA DSWx-HLS display band from common aliases."""
+    parsed = _parse_list(bands)
+    if not parsed:
+        return "WTR_Water_classification"
+    first = parsed[0].strip()
+    aliases = {
+        "WTR": "WTR_Water_classification",
+        "B01_WTR": "WTR_Water_classification",
+        "WTR_Water_classification": "WTR_Water_classification",
+        "BWTR": "BWTR_Binary_water",
+        "BINARY_WATER": "BWTR_Binary_water",
+        "BWTR_Binary_water": "BWTR_Binary_water",
+        "CONF": "CONF_Confidence",
+        "CONF_Confidence": "CONF_Confidence",
+    }
+    return aliases.get(first, first)
+
+
+def _opera_dswx_render_image(
+    collection: Any,
+    band_name: str,
+    method: str = "mode",
+) -> tuple[Any, dict[str, Any]]:
+    """Build a renderable OPERA DSWx classification composite."""
+    import ee
+
+    if band_name == "BWTR_Binary_water":
+        class_values = [0, 1, 252, 253, 254]
+        palette = ["ffffff", "0000ff", "f2f2f2", "dfdfdf", "da00ff"]
+    else:
+        band_name = "WTR_Water_classification"
+        class_values = [0, 1, 2, 252, 253, 254]
+        palette = ["ffffff", "0000ff", "0088ff", "f2f2f2", "dfdfdf", "da00ff"]
+
+    masked_collection = collection.map(
+        lambda image: image.select(band_name).updateMask(
+            image.select(band_name).lt(252)
+        )
+    )
+    reducer = ee.Reducer.mode() if method == "mode" else ee.Reducer.max()
+    composite = masked_collection.reduce(reducer).rename(band_name)
+    remapped = composite.select(band_name).remap(
+        class_values, list(range(len(class_values)))
+    )
+    remapped = remapped.updateMask(remapped.neq(0))
+    return remapped, {
+        "min": 0.0,
+        "max": float(len(class_values) - 1),
+        "palette": palette,
+    }
+
+
+def _format_python_snippet_value(value: Any) -> str:
+    """Return a compact Python literal for snippet generation."""
+    return repr(value)
+
+
+def _build_load_gee_dataset_snippet(
+    *,
+    asset_id: str,
+    resolved_type: str,
+    start_date: str | None,
+    end_date: str | None,
+    bbox: list[float] | None,
+    cloud_cover: int | None,
+    cloud_property: str | None,
+    method: str | None,
+    bands: str | list[str] | None,
+    min_value: float | None,
+    max_value: float | None,
+    palette: str | list[str] | None,
+    vis_params: dict[str, Any],
+    layer_name: str,
+    rendered_band: str | None,
+    clip_collection_asset_id: str | None,
+    clip_filter_property: str | None,
+    clip_filter_value: str | None,
+) -> str:
+    """Build a reproducible Earth Engine Python snippet for a loaded layer."""
+    lines = [
+        "import ee",
+        "import geemap",
+        "",
+        "m = geemap.Map()",
+        "",
+        f"asset_id = {_format_python_snippet_value(asset_id)}",
+    ]
+
+    if resolved_type == "ImageCollection":
+        lines.append("collection = ee.ImageCollection(asset_id)")
+        if start_date or end_date:
+            lines.append(
+                "collection = collection.filterDate("
+                f"{_format_python_snippet_value(start_date)}, "
+                f"{_format_python_snippet_value(end_date)}"
+                ")"
+            )
+        if bbox is not None:
+            lines.append(f"bbox = {_format_python_snippet_value(bbox)}")
+            lines.append(
+                "collection = collection.filterBounds(ee.Geometry.Rectangle(bbox))"
+            )
+
+        if _is_opera_dswx(asset_id):
+            band = rendered_band or _opera_dswx_band_alias(bands)
+            reducer_name = "mode" if method == "mode" else "max"
+            lines.extend(
+                [
+                    f"band = {_format_python_snippet_value(band)}",
+                    "masked = collection.map(",
+                    "    lambda image: image.select(band).updateMask(",
+                    "        image.select(band).lt(252)",
+                    "    )",
+                    ")",
+                    f"image = masked.reduce(ee.Reducer.{reducer_name}()).rename(band)",
+                    "class_values = [0, 1, 2, 252, 253, 254]",
+                    "to_values = [0, 1, 2, 3, 4, 5]",
+                    "image = image.select(band).remap(class_values, to_values)",
+                    "image = image.updateMask(image.neq(0))  # make non-water transparent",
+                ]
+            )
+        else:
+            if cloud_cover is not None:
+                prop = cloud_property or "CLOUDY_PIXEL_PERCENTAGE"
+                lines.append(
+                    "collection = collection.filter("
+                    f"ee.Filter.lt({_format_python_snippet_value(prop)}, "
+                    f"{_format_python_snippet_value(cloud_cover)}))"
+                )
+            composite = method or "mosaic"
+            if composite == "mosaic":
+                lines.append("image = collection.mosaic()")
+            elif composite == "mode":
+                lines.append("image = collection.reduce(ee.Reducer.mode())")
+            else:
+                lines.append(f"image = collection.{composite}()")
+    elif resolved_type == "FeatureCollection":
+        lines.append("image = ee.FeatureCollection(asset_id)")
+    else:
+        lines.append("image = ee.Image(asset_id)")
+
+    if clip_collection_asset_id and resolved_type != "FeatureCollection":
+        lines.append(
+            "clip_fc = ee.FeatureCollection("
+            f"{_format_python_snippet_value(clip_collection_asset_id)})"
+        )
+        if clip_filter_property and clip_filter_value is not None:
+            lines.append(
+                "clip_fc = clip_fc.filter(ee.Filter.eq("
+                f"{_format_python_snippet_value(clip_filter_property)}, "
+                f"{_format_python_snippet_value(_coerce_filter_value(clip_filter_value))}"
+                "))"
+            )
+        lines.append("image = image.clipToCollection(clip_fc)")
+
+    lines.append(f"vis_params = {_format_python_snippet_value(vis_params)}")
+    lines.append("")
+    lines.append(
+        "m.add_layer("
+        f"image, vis_params, {_format_python_snippet_value(layer_name)}"
+        ")"
+    )
+    return "\n".join(lines)
+
+
+def _build_normalized_difference_snippet(
+    *,
+    asset_id: str,
+    resolved_type: str,
+    start_date: str | None,
+    end_date: str | None,
+    bbox: list[float] | None,
+    cloud_cover: int | None,
+    cloud_property: str | None,
+    method: str | None,
+    positive_band: str,
+    negative_band: str,
+    output_name: str,
+    vis_params: dict[str, Any],
+    layer_name: str,
+    clip_collection_asset_id: str | None,
+    clip_filter_property: str | None,
+    clip_filter_value: str | None,
+) -> str:
+    """Build a reproducible Earth Engine Python snippet for an index layer."""
+    lines = [
+        "import ee",
+        "import geemap",
+        "",
+        "m = geemap.Map()",
+        "",
+        f"asset_id = {_format_python_snippet_value(asset_id)}",
+    ]
+    if resolved_type == "ImageCollection":
+        lines.append("collection = ee.ImageCollection(asset_id)")
+        if start_date or end_date:
+            lines.append(
+                "collection = collection.filterDate("
+                f"{_format_python_snippet_value(start_date)}, "
+                f"{_format_python_snippet_value(end_date)}"
+                ")"
+            )
+        if bbox is not None:
+            lines.append(f"bbox = {_format_python_snippet_value(bbox)}")
+            lines.append(
+                "collection = collection.filterBounds(ee.Geometry.Rectangle(bbox))"
+            )
+        if cloud_cover is not None:
+            prop = cloud_property or "CLOUDY_PIXEL_PERCENTAGE"
+            lines.append(
+                "collection = collection.filter("
+                f"ee.Filter.lt({_format_python_snippet_value(prop)}, "
+                f"{_format_python_snippet_value(cloud_cover)}))"
+            )
+        composite = method or "median"
+        if composite == "mosaic":
+            lines.append("source = collection.mosaic()")
+        elif composite == "mode":
+            lines.append("source = collection.reduce(ee.Reducer.mode())")
+        else:
+            lines.append(f"source = collection.{composite}()")
+    else:
+        lines.append("source = ee.Image(asset_id)")
+
+    lines.append(
+        "image = source.normalizedDifference("
+        f"[{_format_python_snippet_value(positive_band)}, "
+        f"{_format_python_snippet_value(negative_band)}]"
+        f").rename({_format_python_snippet_value(output_name)})"
+    )
+    if clip_collection_asset_id:
+        lines.append(
+            "clip_fc = ee.FeatureCollection("
+            f"{_format_python_snippet_value(clip_collection_asset_id)})"
+        )
+        if clip_filter_property and clip_filter_value is not None:
+            lines.append(
+                "clip_fc = clip_fc.filter(ee.Filter.eq("
+                f"{_format_python_snippet_value(clip_filter_property)}, "
+                f"{_format_python_snippet_value(_coerce_filter_value(clip_filter_value))}"
+                "))"
+            )
+        lines.append("image = image.clipToCollection(clip_fc)")
+
+    lines.append(f"vis_params = {_format_python_snippet_value(vis_params)}")
+    lines.append("")
+    lines.append(
+        "m.add_layer("
+        f"image, vis_params, {_format_python_snippet_value(layer_name)}"
+        ")"
+    )
+    return "\n".join(lines)
+
+
+def _safe_get_info(value: Any) -> Any:
+    """Best-effort ``getInfo`` for Earth Engine diagnostics."""
+    try:
+        get_info = getattr(value, "getInfo", None)
+        if callable(get_info):
+            return get_info()
+    except Exception as exc:
+        return {"error": str(exc)}
+    return None
+
+
+def _image_band_names(image: Any) -> list[str] | dict[str, str]:
+    """Return output image band names or an error diagnostic."""
+    try:
+        import ee
+
+        info = _safe_get_info(ee.Image(image).bandNames())
+        if isinstance(info, list):
+            return [str(item) for item in info]
+        if isinstance(info, dict) and "error" in info:
+            return {"error": info["error"]}
+        return []
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def _first_image_band_names(collection: Any) -> list[str] | dict[str, str]:
+    """Return band names from the first image without counting the collection."""
+    try:
+        import ee
+
+        return _image_band_names(ee.Image(collection.first()))
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def _raise_layer_error(
+    exc: Exception,
+    *,
+    asset_id: str,
+    layer_name: str,
+    diagnostics: dict[str, Any],
+) -> None:
+    """Raise a layer-loading error with Earth Engine diagnostics attached."""
+    raise RuntimeError(
+        "Failed to add Earth Engine layer to QGIS.\n"
+        f"Asset: {asset_id}\n"
+        f"Layer: {layer_name}\n"
+        f"Diagnostics: {diagnostics}\n"
+        f"Error: {exc}"
+    ) from exc
+
+
+def _xyz_uri_from_tile_url(tile_url: str) -> str:
+    """Return a QGIS XYZ datasource URI with the nested tile URL encoded."""
+    encoded_url = quote(tile_url, safe=":/{}")
+    return f"type=xyz&url={encoded_url}&zmax=24&zmin=0"
+
+
+def _ee_tile_url(ee_object: Any, vis_params: dict[str, Any]) -> str:
+    """Generate an Earth Engine XYZ tile URL off the QGIS GUI thread."""
+    try:
+        import ee
+
+        if isinstance(ee_object, ee.FeatureCollection):
+            style_keys = {
+                "color",
+                "pointSize",
+                "pointShape",
+                "width",
+                "fillColor",
+                "styleProperty",
+                "neighborhood",
+                "lineType",
+            }
+            style_params = {k: v for k, v in vis_params.items() if k in style_keys}
+            if style_params:
+                ee_object = ee_object.style(**style_params)
+            vis_params = {}
+        elif isinstance(ee_object, ee.ImageCollection):
+            ee_object = ee_object.mosaic()
+
+        map_id = ee_object.getMapId(vis_params)
+        return map_id.get("tile_fetcher").url_format
+    except Exception as exc:
+        raise RuntimeError(f"Failed to create Earth Engine tile URL: {exc}") from exc
+
+
+def _add_xyz_layer_on_gui(
+    *,
+    iface: Any,
+    ee_object: Any,
+    vis_params: dict[str, Any],
+    name: str,
+    tile_url: str,
+    shown: bool = True,
+    opacity: float = 1.0,
+) -> Any:
+    """Add a precomputed Earth Engine XYZ URL to QGIS on the GUI thread."""
+
+    def _run() -> Any:
+        from qgis.core import QgsProject, QgsRasterLayer
+
+        from gee_data_catalogs.core.ee_utils import (
+            _store_ee_layer_metadata,
+            add_ee_layer_to_registry,
+            remove_ee_layer_from_registry,
+        )
+
+        project = QgsProject.instance()
+        for existing_layer in project.mapLayersByName(name):
+            project.removeMapLayer(existing_layer.id())
+        remove_ee_layer_from_registry(name)
+
+        current_extent = None
+        try:
+            canvas = iface.mapCanvas()
+            current_extent = canvas.extent() if canvas is not None else None
+        except Exception:  # nosec B110
+            pass
+
+        uri = _xyz_uri_from_tile_url(tile_url)
+        layer = QgsRasterLayer(uri, name, "wms")
+        if not layer.isValid():
+            raise ValueError(f"Failed to create valid Earth Engine XYZ layer: {name}")
+
+        if hasattr(layer, "renderer") and layer.renderer():
+            layer.renderer().setOpacity(opacity)
+
+        project.addMapLayer(layer, False)
+        root = project.layerTreeRoot()
+        root.insertLayer(0, layer)
+        layer_tree = root.findLayer(layer.id())
+        if layer_tree:
+            layer_tree.setItemVisibilityChecked(shown)
+
+        if current_extent is not None:
+            try:
+                canvas = iface.mapCanvas()
+                canvas.setExtent(current_extent)
+                canvas.refresh()
+            except Exception:  # nosec B110
+                pass
+
+        add_ee_layer_to_registry(name, ee_object, vis_params)
+        _store_ee_layer_metadata(layer, ee_object, vis_params)
+        return layer
+
+    return _on_gui(_run)
+
+
+def _add_ee_layer_nonblocking(
+    *,
+    iface: Any,
+    ee_object: Any,
+    vis_params: dict[str, Any],
+    name: str,
+) -> Any:
+    """Add an EE layer while keeping slow EE calls off the QGIS GUI thread."""
+    try:
+        import qgis  # noqa: F401
+    except Exception:
+        from gee_data_catalogs.core.ee_utils import add_ee_layer
+
+        return add_ee_layer(ee_object, vis_params, name)
+
+    tile_url = _ee_tile_url(ee_object, vis_params)
+    return _add_xyz_layer_on_gui(
+        iface=iface,
+        ee_object=ee_object,
+        vis_params=vis_params,
+        name=name,
+        tile_url=tile_url,
+    )
+
+
+def _validate_added_layer(layer: Any, name: str) -> None:
+    """Raise when the plugin returns an invalid QGIS layer."""
+    if layer is None:
+        raise ValueError(f"Failed to add Earth Engine layer to QGIS: {name}")
+    is_valid = getattr(layer, "isValid", None)
+    if callable(is_valid) and not is_valid():
+        raise ValueError(f"Earth Engine layer was added but is invalid: {name}")
+
+
+def _zoom_to_layer_area(
+    *,
+    iface: Any,
+    layer: Any,
+    bbox: list[float] | None = None,
+) -> dict[str, Any]:
+    """Best-effort zoom to an explicit bbox or the added layer extent."""
+
+    def _run() -> dict[str, Any]:
+        try:
+            canvas = iface.mapCanvas()
+        except Exception as exc:
+            return {"success": False, "error": f"Map canvas unavailable: {exc}"}
+
+        if canvas is None:
+            return {"success": False, "error": "Map canvas unavailable."}
+
+        try:
+            if bbox is not None:
+                west, south, east, north = bbox
+                try:
+                    from qgis.core import (  # type: ignore[import-not-found]
+                        QgsCoordinateReferenceSystem,
+                        QgsCoordinateTransform,
+                        QgsProject,
+                        QgsRectangle,
+                    )
+
+                    extent = QgsRectangle(west, south, east, north)
+                    destination_crs = canvas.mapSettings().destinationCrs()
+                    if destination_crs and destination_crs.authid() != "EPSG:4326":
+                        transform = QgsCoordinateTransform(
+                            QgsCoordinateReferenceSystem("EPSG:4326"),
+                            destination_crs,
+                            QgsProject.instance(),
+                        )
+                        extent = transform.transformBoundingBox(extent)
+                except Exception:
+                    extent = (west, south, east, north)
+                canvas.setExtent(extent)
+                canvas.refresh()
+                return {"success": True, "target": "bbox", "bbox": bbox}
+
+            extent_fn = getattr(layer, "extent", None)
+            if callable(extent_fn):
+                extent = extent_fn()
+                is_empty = getattr(extent, "isEmpty", None)
+                if not callable(is_empty) or not is_empty():
+                    canvas.setExtent(extent)
+                    canvas.refresh()
+                    return {"success": True, "target": "layer_extent"}
+
+            return {"success": False, "error": "No zoomable bbox or layer extent."}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    return _on_gui(_run)
 
 
 def gee_data_catalogs_tools(
@@ -272,6 +827,7 @@ def gee_data_catalogs_tools(
         clip_collection_asset_id: Optional[str] = None,
         clip_filter_property: Optional[str] = None,
         clip_filter_value: Optional[str] = None,
+        diagnose: bool = False,
     ) -> dict[str, Any]:
         """Load a GEE Image, ImageCollection, or FeatureCollection into QGIS.
 
@@ -285,7 +841,9 @@ def gee_data_catalogs_tools(
             bbox: Optional WGS84 west,south,east,north filter.
             cloud_cover: Optional maximum cloud-cover value.
             cloud_property: Optional cloud-cover property name.
-            reducer: ImageCollection reducer: mosaic, median, mean, min, max, first.
+            reducer: ImageCollection compositing method: mosaic, median, mean,
+                min, max, first, mode. ``mosaic`` is not an ee.Reducer; it is
+                applied with ``ee.ImageCollection.mosaic()``.
             bands: Optional comma-separated visualization bands.
             min_value: Optional visualization minimum.
             max_value: Optional visualization maximum.
@@ -297,13 +855,15 @@ def gee_data_catalogs_tools(
                 FeatureCollection before clipping. Example: NAME.
             clip_filter_value: Optional value for ``clip_filter_property``.
                 Example: Tennessee.
+            diagnose: When true, evaluate lightweight Earth Engine diagnostics
+                such as first-image and output band names. Leave false for
+                normal layer loading to avoid blocking QGIS on ``getInfo``.
         """
 
         def _run() -> dict[str, Any]:
             import ee
 
             from gee_data_catalogs.core.ee_utils import (
-                add_ee_layer,
                 detect_asset_type,
                 filter_image_collection,
                 initialize_ee,
@@ -317,6 +877,7 @@ def gee_data_catalogs_tools(
             name = layer_name or asset_id.split("/")[-1]
             parsed_bbox = _parse_bbox(bbox)
             clip_collection = None
+            diagnostics: dict[str, Any] = {}
             if clip_collection_asset_id:
                 clip_collection = ee.FeatureCollection(clip_collection_asset_id)
                 if clip_filter_property and clip_filter_value is not None:
@@ -329,7 +890,25 @@ def gee_data_catalogs_tools(
 
             if resolved_type == "ImageCollection":
                 collection = ee.ImageCollection(asset_id)
-                if start_date or end_date or parsed_bbox or cloud_cover is not None:
+                is_dswx = _is_opera_dswx(asset_id)
+                if parsed_bbox is not None:
+                    diagnostics["bbox"] = parsed_bbox
+                if is_dswx and cloud_cover is not None:
+                    diagnostics["ignored_cloud_cover"] = cloud_cover
+                    diagnostics["cloud_filter_reason"] = (
+                        "OPERA DSWx examples mask WTR values >= 252 instead "
+                        "of filtering by a generic cloud-cover property."
+                    )
+
+                if is_dswx:
+                    diagnostics["filtering"] = "direct_dswx_filterDate_filterBounds"
+                    if start_date or end_date:
+                        collection = collection.filterDate(start_date, end_date)
+                    if parsed_bbox is not None:
+                        collection = collection.filterBounds(
+                            ee.Geometry.Rectangle(parsed_bbox)
+                        )
+                elif start_date or end_date or parsed_bbox or cloud_cover is not None:
                     collection = filter_image_collection(
                         collection,
                         start_date=start_date,
@@ -338,16 +917,35 @@ def gee_data_catalogs_tools(
                         cloud_cover=cloud_cover,
                         cloud_property=cloud_property or "CLOUDY_PIXEL_PERCENTAGE",
                     )
-                method = reducer.lower().strip()
-                if method not in {"mosaic", "median", "mean", "min", "max", "first"}:
-                    method = "mosaic"
-                ee_object = getattr(collection, method)()
-                vis_params = _build_vis_params(
-                    bands=bands,
-                    min_value=min_value,
-                    max_value=max_value,
-                    palette=palette,
-                )
+                if diagnose:
+                    diagnostics["first_image_bands"] = _first_image_band_names(
+                        collection
+                    )
+                if is_dswx:
+                    default_method = _opera_dswx_default_composite_method(asset_id)
+                    requested_method = _normalize_composite_method(
+                        reducer, default=default_method, allow_mode=True
+                    )
+                    method = (
+                        requested_method
+                        if requested_method in {"max", "mode"}
+                        else default_method
+                    )
+                    band_name = _opera_dswx_band_alias(bands)
+                    ee_object, vis_params = _opera_dswx_render_image(
+                        collection, band_name, method
+                    )
+                else:
+                    method = _normalize_composite_method(
+                        reducer, default="mosaic", allow_mode=True
+                    )
+                    ee_object = _composite_image_collection(collection, method)
+                    vis_params = _build_vis_params(
+                        bands=bands,
+                        min_value=min_value,
+                        max_value=max_value,
+                        palette=palette,
+                    )
             elif resolved_type == "FeatureCollection":
                 ee_object = ee.FeatureCollection(asset_id)
                 vis_params = _build_vis_params(
@@ -364,10 +962,95 @@ def gee_data_catalogs_tools(
                     palette=palette,
                 )
 
+            bbox_filter = (
+                parsed_bbox
+                if resolved_type == "ImageCollection" and parsed_bbox
+                else None
+            )
             if clip_collection is not None and resolved_type != "FeatureCollection":
                 ee_object = ee.Image(ee_object).clipToCollection(clip_collection)
 
-            add_ee_layer(ee_object, vis_params, name[:50])
+            display_name = name[:50]
+            rendered_band = (
+                band_name
+                if resolved_type == "ImageCollection" and _is_opera_dswx(asset_id)
+                else None
+            )
+            earth_engine_python_snippet = _build_load_gee_dataset_snippet(
+                asset_id=asset_id,
+                resolved_type=resolved_type,
+                start_date=start_date,
+                end_date=end_date,
+                bbox=parsed_bbox,
+                cloud_cover=None if _is_opera_dswx(asset_id) else cloud_cover,
+                cloud_property=cloud_property,
+                method=method if resolved_type == "ImageCollection" else None,
+                bands=bands,
+                min_value=min_value,
+                max_value=max_value,
+                palette=palette,
+                vis_params=vis_params,
+                layer_name=display_name,
+                rendered_band=rendered_band,
+                clip_collection_asset_id=clip_collection_asset_id,
+                clip_filter_property=clip_filter_property,
+                clip_filter_value=clip_filter_value,
+            )
+            if diagnose and resolved_type != "FeatureCollection":
+                diagnostics["output_bands"] = _image_band_names(ee_object)
+                if diagnostics["output_bands"] == []:
+                    return {
+                        "success": False,
+                        "asset_id": asset_id,
+                        "asset_type": resolved_type,
+                        "layer_name": display_name,
+                        "error": (
+                            "Earth Engine output image has no bands after "
+                            "filtering and compositing."
+                        ),
+                        "diagnostics": diagnostics,
+                    }
+            try:
+                layer = _add_ee_layer_nonblocking(
+                    iface=iface,
+                    ee_object=ee_object,
+                    vis_params=vis_params,
+                    name=display_name,
+                )
+                _validate_added_layer(layer, display_name)
+                zoom_result = _zoom_to_layer_area(
+                    iface=iface,
+                    layer=layer,
+                    bbox=parsed_bbox,
+                )
+            except Exception as exc:
+                try:
+                    _raise_layer_error(
+                        exc,
+                        asset_id=asset_id,
+                        layer_name=display_name,
+                        diagnostics=diagnostics,
+                    )
+                except RuntimeError as layer_error:
+                    return {
+                        "success": False,
+                        "asset_id": asset_id,
+                        "asset_type": resolved_type,
+                        "layer_name": display_name,
+                        "error": str(layer_error),
+                        "failure_stage": "qgis_layer_add",
+                        "diagnostics": diagnostics,
+                        "bbox": bbox_filter,
+                        "earth_engine_python_snippet": earth_engine_python_snippet,
+                        "composite_method": (
+                            method if resolved_type == "ImageCollection" else None
+                        ),
+                        "requested_reducer": (
+                            reducer if resolved_type == "ImageCollection" else None
+                        ),
+                        "rendered_band": rendered_band,
+                        "vis_params": vis_params,
+                    }
             try:
                 iface.mapCanvas().refresh()
             except Exception:
@@ -376,7 +1059,18 @@ def gee_data_catalogs_tools(
                 "success": True,
                 "asset_id": asset_id,
                 "asset_type": resolved_type,
-                "layer_name": name[:50],
+                "layer_name": display_name,
+                "composite_method": (
+                    method if resolved_type == "ImageCollection" else None
+                ),
+                "requested_reducer": (
+                    reducer if resolved_type == "ImageCollection" else None
+                ),
+                "rendered_band": rendered_band,
+                "diagnostics": diagnostics,
+                "bbox": bbox_filter,
+                "zoom": zoom_result,
+                "earth_engine_python_snippet": earth_engine_python_snippet,
                 "vis_params": vis_params,
                 "clip": (
                     {
@@ -390,7 +1084,7 @@ def gee_data_catalogs_tools(
                 ),
             }
 
-        return _on_gui(_run)
+        return _run()
 
     @geo_tool(
         category="gee_data_catalogs",
@@ -437,7 +1131,9 @@ def gee_data_catalogs_tools(
             bbox: Optional WGS84 west,south,east,north ImageCollection filter.
             cloud_cover: Optional maximum cloud-cover value.
             cloud_property: Optional cloud-cover property name.
-            reducer: ImageCollection reducer: mosaic, median, mean, min, max, first.
+            reducer: ImageCollection compositing method: mosaic, median, mean,
+                min, max, first, mode. ``mosaic`` is not an ee.Reducer; it is
+                applied with ``ee.ImageCollection.mosaic()``.
             min_value: Visualization minimum. Defaults to -1.
             max_value: Visualization maximum. Defaults to 1.
             palette: Optional comma-separated colors. Defaults by index type.
@@ -460,7 +1156,6 @@ def gee_data_catalogs_tools(
             import ee
 
             from gee_data_catalogs.core.ee_utils import (
-                add_ee_layer,
                 detect_asset_type,
                 filter_image_collection,
                 initialize_ee,
@@ -499,10 +1194,8 @@ def gee_data_catalogs_tools(
                         cloud_cover=cloud_cover,
                         cloud_property=cloud_property or "CLOUDY_PIXEL_PERCENTAGE",
                     )
-                method = reducer.lower().strip()
-                if method not in {"mosaic", "median", "mean", "min", "max", "first"}:
-                    method = "median"
-                source_image = getattr(collection, method)()
+                method = _normalize_composite_method(reducer, default="median")
+                source_image = _composite_image_collection(collection, method)
                 resolved_type = "ImageCollection"
             else:
                 source_image = ee.Image(asset_id)
@@ -522,7 +1215,37 @@ def gee_data_catalogs_tools(
                 palette=palette or _default_index_palette(output_name),
             )
             name = layer_name or f"{asset_id.split('/')[-1]} {output_name}"
-            add_ee_layer(index_image, vis_params, name[:50])
+            display_name = name[:50]
+            earth_engine_python_snippet = _build_normalized_difference_snippet(
+                asset_id=asset_id,
+                resolved_type=resolved_type,
+                start_date=start_date,
+                end_date=end_date,
+                bbox=parsed_bbox,
+                cloud_cover=cloud_cover,
+                cloud_property=cloud_property,
+                method=method if resolved_type == "ImageCollection" else None,
+                positive_band=positive_band,
+                negative_band=negative_band,
+                output_name=output_name,
+                vis_params=vis_params,
+                layer_name=display_name,
+                clip_collection_asset_id=clip_collection_asset_id,
+                clip_filter_property=clip_filter_property,
+                clip_filter_value=clip_filter_value,
+            )
+            layer = _add_ee_layer_nonblocking(
+                iface=iface,
+                ee_object=index_image,
+                vis_params=vis_params,
+                name=display_name,
+            )
+            _validate_added_layer(layer, display_name)
+            zoom_result = _zoom_to_layer_area(
+                iface=iface,
+                layer=layer,
+                bbox=parsed_bbox,
+            )
             try:
                 iface.mapCanvas().refresh()
             except Exception:
@@ -531,13 +1254,21 @@ def gee_data_catalogs_tools(
                 "success": True,
                 "asset_id": asset_id,
                 "asset_type": resolved_type,
-                "layer_name": name[:50],
+                "layer_name": display_name,
                 "index_name": output_name,
                 "formula": f"({positive_band} - {negative_band}) / "
                 f"({positive_band} + {negative_band})",
                 "bands": [positive_band, negative_band],
-                "reducer": reducer if resolved_type == "ImageCollection" else None,
+                "composite_method": (
+                    method if resolved_type == "ImageCollection" else None
+                ),
+                "requested_reducer": (
+                    reducer if resolved_type == "ImageCollection" else None
+                ),
                 "vis_params": vis_params,
+                "bbox": parsed_bbox,
+                "zoom": zoom_result,
+                "earth_engine_python_snippet": earth_engine_python_snippet,
                 "clip": (
                     {
                         "collection_asset_id": clip_collection_asset_id,
@@ -550,7 +1281,7 @@ def gee_data_catalogs_tools(
                 ),
             }
 
-        return _on_gui(_run)
+        return _run()
 
     @geo_tool(
         category="gee_data_catalogs",

--- a/tests/test_gee_data_catalogs_tools.py
+++ b/tests/test_gee_data_catalogs_tools.py
@@ -9,7 +9,10 @@ import pytest
 
 from geoagent import for_gee_data_catalogs
 from geoagent.testing import MockQGISIface, MockQGISProject
-from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
+from geoagent.tools.gee_data_catalogs import (
+    _xyz_uri_from_tile_url,
+    gee_data_catalogs_tools,
+)
 
 
 class _MockModel:
@@ -30,6 +33,19 @@ def test_gee_data_catalogs_module_imports_without_qgis() -> None:
 def test_gee_data_catalogs_tools_returns_empty_for_none_iface() -> None:
     """Verify the GEE Data Catalogs factory returns no tools without iface."""
     assert gee_data_catalogs_tools(None) == []
+
+
+def test_ee_xyz_uri_encodes_nested_query_parameters() -> None:
+    """Verify QGIS parses EE token query params as part of the tile URL."""
+    uri = _xyz_uri_from_tile_url(
+        "https://example.com/{z}/{x}/{y}?token=abc&expires=123"
+    )
+
+    expected = (
+        "type=xyz&url=https://example.com/{z}/{x}/{y}"
+        "%3Ftoken%3Dabc%26expires%3D123&zmax=24&zmin=0"
+    )
+    assert uri == expected
 
 
 def test_gee_data_catalogs_tools_expose_catalog_surface() -> None:
@@ -96,6 +112,10 @@ def test_load_gee_dataset_clips_raster_to_feature_collection(monkeypatch) -> Non
             self.clipped_to = feature_collection
             return self
 
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
     class _FakeFilter:
         @staticmethod
         def eq(prop: str, value: object):
@@ -111,9 +131,12 @@ def test_load_gee_dataset_clips_raster_to_feature_collection(monkeypatch) -> Non
     captured = {}
 
     ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
-    ee_utils.add_ee_layer = lambda obj, vis, name: captured.update(
-        {"object": obj, "vis": vis, "name": name}
-    )
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    ee_utils.add_ee_layer = _add_ee_layer
     ee_utils.detect_asset_type = lambda asset_id: "Image"
     ee_utils.filter_image_collection = lambda collection, **kwargs: collection
     ee_utils.initialize_ee = lambda project=None: None
@@ -143,12 +166,399 @@ def test_load_gee_dataset_clips_raster_to_feature_collection(monkeypatch) -> Non
 
     loaded = captured["object"]
     assert result["success"] is True
+    assert result["composite_method"] is None
     assert result["clip"]["method"] == "ee.Image.clipToCollection"
     assert result["clip"]["collection_asset_id"] == "TIGER/2018/States"
     assert loaded.clipped_to.asset_id == "TIGER/2018/States"
     assert loaded.clipped_to.filters == [("eq", "NAME", "Tennessee")]
     assert captured["vis"]["bands"] == ["occurrence"]
     assert iface.canvas.refreshed is True
+
+
+def test_load_gee_dataset_uses_mosaic_as_composite_method(monkeypatch) -> None:
+    """Verify mosaic is handled as an ImageCollection method, not an ee.Reducer."""
+
+    class _Canvas:
+        def __init__(self) -> None:
+            self.extent = None
+
+        def setExtent(self, extent) -> None:
+            self.extent = extent
+
+        def refresh(self) -> None:
+            pass
+
+    class _Iface:
+        def __init__(self) -> None:
+            self.canvas = _Canvas()
+
+        def mapCanvas(self) -> _Canvas:
+            return self.canvas
+
+    class _FakeImage:
+        def __init__(self, method: str) -> None:
+            self.method = method
+
+    class _FakeImageCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+
+        def mosaic(self):
+            return _FakeImage("mosaic")
+
+        def median(self):
+            return _FakeImage("median")
+
+        def mean(self):
+            return _FakeImage("mean")
+
+        def min(self):
+            return _FakeImage("min")
+
+        def max(self):
+            return _FakeImage("max")
+
+        def first(self):
+            return _FakeImage("first")
+
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
+    ee_module = ModuleType("ee")
+    ee_module.ImageCollection = _FakeImageCollection
+
+    captured = {}
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    ee_utils.add_ee_layer = _add_ee_layer
+    ee_utils.detect_asset_type = lambda asset_id: "ImageCollection"
+
+    def _filter_image_collection(collection, **kwargs):
+        captured["filter_kwargs"] = kwargs
+        return collection
+
+    ee_utils.filter_image_collection = _filter_image_collection
+    ee_utils.initialize_ee = lambda project=None: None
+    ee_utils.is_ee_initialized = lambda: True
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    iface = _Iface()
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(iface)}
+    result = tools["load_gee_dataset"].__wrapped__(
+        "TEST/IMAGE_COLLECTION",
+        reducer="mosaic",
+        bands="WTR",
+        min_value=0,
+        max_value=2,
+        palette="white,blue",
+    )
+
+    assert result["success"] is True
+    assert result["composite_method"] == "mosaic"
+    assert result["requested_reducer"] == "mosaic"
+    assert captured["object"].method == "mosaic"
+    assert captured["vis"]["bands"] == ["WTR"]
+
+    false_color = tools["load_gee_dataset"].__wrapped__(
+        "COPERNICUS/S2_SR_HARMONIZED",
+        layer_name="Sentinel-2 false color composite - San Francisco",
+        reducer="first",
+        bands="B8,B4,B3",
+        min_value=0,
+        max_value=3000,
+        bbox="-122.55,37.65,-122.3,37.85",
+        start_date="2025-06-01",
+        end_date="2025-08-31",
+        cloud_cover=10,
+    )
+
+    snippet = false_color["earth_engine_python_snippet"]
+    assert false_color["success"] is True
+    assert false_color["composite_method"] == "first"
+    assert "ee.Initialize()" not in snippet
+    assert "import geemap" in snippet
+    assert "m = geemap.Map()" in snippet
+    assert "image = collection.first()" in snippet
+    assert (
+        "vis_params = {'bands': ['B8', 'B4', 'B3'], 'min': 0.0, 'max': 3000.0}"
+        in snippet
+    )
+    assert (
+        "m.add_layer(image, vis_params, "
+        "'Sentinel-2 false color composite - San Francisco')" in snippet
+    )
+
+
+def test_load_gee_dataset_filters_explicit_image_collection_bbox(
+    monkeypatch,
+) -> None:
+    """Verify explicit ImageCollection bbox filters are passed through."""
+
+    class _Canvas:
+        def __init__(self) -> None:
+            self.extent = None
+
+        def setExtent(self, extent) -> None:
+            self.extent = extent
+
+        def refresh(self) -> None:
+            pass
+
+    class _Iface:
+        def __init__(self) -> None:
+            self.canvas = _Canvas()
+
+        def mapCanvas(self) -> _Canvas:
+            return self.canvas
+
+    class _FakeImage:
+        def __init__(self, method: str) -> None:
+            self.method = method
+
+    class _FakeImageCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+
+        def mosaic(self):
+            return _FakeImage("mosaic")
+
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
+    ee_module = ModuleType("ee")
+    ee_module.ImageCollection = _FakeImageCollection
+
+    captured = {}
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.add_ee_layer = lambda obj, vis, name: _FakeLayer()
+    ee_utils.detect_asset_type = lambda asset_id: "ImageCollection"
+
+    def _filter_image_collection(collection, **kwargs):
+        captured["filter_kwargs"] = kwargs
+        return collection
+
+    ee_utils.filter_image_collection = _filter_image_collection
+    ee_utils.initialize_ee = lambda project=None: None
+    ee_utils.is_ee_initialized = lambda: True
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    iface = _Iface()
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(iface)}
+    result = tools["load_gee_dataset"].__wrapped__(
+        "TEST/IMAGE_COLLECTION",
+        reducer="mosaic",
+        bbox="-84,35,-83,36",
+    )
+
+    assert result["success"] is True
+    assert captured["filter_kwargs"]["bbox"] == [-84.0, 35.0, -83.0, 36.0]
+    assert result["bbox"] == [-84.0, 35.0, -83.0, 36.0]
+    assert result["zoom"] == {
+        "success": True,
+        "target": "bbox",
+        "bbox": [-84.0, 35.0, -83.0, 36.0],
+    }
+    assert "import geemap" in result["earth_engine_python_snippet"]
+    assert "ee.Initialize()" not in result["earth_engine_python_snippet"]
+    assert "collection.filterBounds" in result["earth_engine_python_snippet"]
+    assert "image = collection.mosaic()" in result["earth_engine_python_snippet"]
+    assert "m.add_layer(image, vis_params" in result["earth_engine_python_snippet"]
+    assert iface.canvas.extent == (-84.0, 35.0, -83.0, 36.0)
+    assert result["diagnostics"]["bbox"] == [-84.0, 35.0, -83.0, 36.0]
+
+
+def test_load_gee_dataset_renders_opera_dswx_hls_with_valid_band_and_mode(
+    monkeypatch,
+) -> None:
+    """Verify OPERA DSWx-HLS uses documented bands and remapped mode rendering."""
+
+    class _Canvas:
+        def refresh(self) -> None:
+            pass
+
+    class _Iface:
+        def mapCanvas(self) -> _Canvas:
+            return _Canvas()
+
+    class _FakeImage:
+        def __init__(self, band: str | None = None) -> None:
+            self.band = band
+            self.mask = None
+
+        def select(self, band: str):
+            return _FakeImage(band)
+
+        def lt(self, value: int):
+            return ("lt", self.band, value)
+
+        def updateMask(self, mask):
+            self.mask = mask
+            return self
+
+    class _FakeModeImage:
+        def __init__(self) -> None:
+            self.name = None
+            self.selected = None
+            self.mask = None
+
+        def rename(self, name: str):
+            self.name = name
+            return self
+
+        def select(self, band: str):
+            self.selected = band
+            return self
+
+        def remap(self, source_values, target_values):
+            self.source_values = source_values
+            self.target_values = target_values
+            return self
+
+        def neq(self, value):
+            return ("neq", value)
+
+        def updateMask(self, mask):
+            self.mask = mask
+            return {
+                "source_band": self.selected,
+                "source_values": self.source_values,
+                "target_values": self.target_values,
+                "mask": mask,
+            }
+
+    class _FakeImageCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.mapped_image = None
+            self.reducer = None
+            self.date_filter = None
+            self.bounds_filter = None
+
+        def filterDate(self, start, end):
+            self.date_filter = (start, end)
+            return self
+
+        def filterBounds(self, geometry):
+            self.bounds_filter = geometry
+            return self
+
+        def map(self, fn):
+            self.mapped_image = fn(_FakeImage())
+            return self
+
+        def reduce(self, reducer):
+            self.reducer = reducer
+            return _FakeModeImage()
+
+    class _FakeReducer:
+        @staticmethod
+        def mode():
+            return "mode"
+
+        @staticmethod
+        def max():
+            return "max"
+
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
+    ee_module = ModuleType("ee")
+    ee_module.ImageCollection = _FakeImageCollection
+    ee_module.Reducer = _FakeReducer
+    ee_module.Geometry = type(
+        "Geometry",
+        (),
+        {"Rectangle": staticmethod(lambda bbox: ("rectangle", bbox))},
+    )
+
+    captured = {}
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    ee_utils.add_ee_layer = _add_ee_layer
+    ee_utils.detect_asset_type = lambda asset_id: "ImageCollection"
+
+    def _filter_image_collection(collection, **kwargs):
+        raise AssertionError("DSWx should not use generic collection filtering")
+
+    ee_utils.filter_image_collection = _filter_image_collection
+    ee_utils.initialize_ee = lambda project=None: None
+    ee_utils.is_ee_initialized = lambda: True
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(_Iface())}
+    result = tools["load_gee_dataset"].__wrapped__(
+        "OPERA/DSWX/L3_V1/HLS",
+        reducer="mosaic",
+        bands="B01_WTR",
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+        bbox="-84.05,35.85,-83.75,36.10",
+        cloud_cover=20,
+    )
+
+    assert result["success"] is True
+    assert result["composite_method"] == "mode"
+    assert result["requested_reducer"] == "mosaic"
+    assert result["rendered_band"] == "WTR_Water_classification"
+    assert result["diagnostics"]["filtering"] == "direct_dswx_filterDate_filterBounds"
+    assert result["diagnostics"]["ignored_cloud_cover"] == 20
+    assert result["bbox"] == [-84.05, 35.85, -83.75, 36.1]
+    assert result["diagnostics"]["bbox"] == [-84.05, 35.85, -83.75, 36.1]
+    assert "ee.Reducer.mode()" in result["earth_engine_python_snippet"]
+    assert "image.updateMask(image.neq(0))" in result["earth_engine_python_snippet"]
+    assert "m = geemap.Map()" in result["earth_engine_python_snippet"]
+    assert captured["object"]["source_band"] == "WTR_Water_classification"
+    assert captured["object"]["source_values"] == [0, 1, 2, 252, 253, 254]
+    assert captured["object"]["target_values"] == [0, 1, 2, 3, 4, 5]
+    assert captured["object"]["mask"] == ("neq", 0)
+    assert captured["vis"]["min"] == 0.0
+    assert captured["vis"]["max"] == 5.0
+    assert captured["vis"]["palette"] == [
+        "ffffff",
+        "0000ff",
+        "0088ff",
+        "f2f2f2",
+        "dfdfdf",
+        "da00ff",
+    ]
 
 
 def test_calculate_gee_normalized_difference_loads_index(monkeypatch) -> None:
@@ -196,6 +606,10 @@ def test_calculate_gee_normalized_difference_loads_index(monkeypatch) -> None:
             self.clipped_to = feature_collection
             return self
 
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
     class _FakeFilter:
         @staticmethod
         def eq(prop: str, value: object):
@@ -211,9 +625,12 @@ def test_calculate_gee_normalized_difference_loads_index(monkeypatch) -> None:
     captured = {}
 
     ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
-    ee_utils.add_ee_layer = lambda obj, vis, name: captured.update(
-        {"object": obj, "vis": vis, "name": name}
-    )
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    ee_utils.add_ee_layer = _add_ee_layer
     ee_utils.detect_asset_type = lambda asset_id: "Image"
     ee_utils.filter_image_collection = lambda collection, **kwargs: collection
     ee_utils.initialize_ee = lambda project=None: None
@@ -249,6 +666,12 @@ def test_calculate_gee_normalized_difference_loads_index(monkeypatch) -> None:
     assert loaded.name == "NDVI"
     assert loaded.clipped_to.asset_id == "TIGER/2018/States"
     assert captured["name"] == "HLS S2 NDVI"
+    assert "normalizedDifference(['B8', 'B4'])" in result["earth_engine_python_snippet"]
+    assert "ee.Initialize()" not in result["earth_engine_python_snippet"]
+    assert (
+        "m.add_layer(image, vis_params, 'HLS S2 NDVI')"
+        in result["earth_engine_python_snippet"]
+    )
     assert captured["vis"]["bands"] == ["NDVI"]
     assert captured["vis"]["min"] == -1.0
     assert captured["vis"]["max"] == 1.0


### PR DESCRIPTION
## Summary
- Render OPERA DSWx-HLS and DSWx-S1 ImageCollections with documented classification bands, mask sentinel values >= 252, and remap classes for QGIS rendering.
- Emit reusable Earth Engine Python snippets for `load_gee_dataset` and `calculate_gee_normalized_difference` outputs, surface composite/requested-reducer fields, and treat `mosaic` as an ImageCollection method rather than an `ee.Reducer`.
- Capture tool results via a new `AfterToolCallEvent` hook, tighten the GEE system prompt around bbox reuse and error reporting, and harden QGIS layer insertion off the GUI thread.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_gee_data_catalogs_tools.py -q`
- [ ] Load `OPERA/DSWX/L3_V1/HLS` in QGIS and confirm a remapped water classification layer renders with the expected palette
- [ ] Load a Sentinel-2 composite with an explicit bbox and verify the returned `earth_engine_python_snippet` reproduces the layer in a notebook