### PR TITLE
refactor: sort PROVIDERS list alphabetically in chat_dock.py

### DIFF
--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -40,13 +40,13 @@ DEFAULT_MODELS = {
     "litellm": "openai/gpt-5.5",
 }
 PROVIDERS = [
+    "anthropic",
     "bedrock",
+    "gemini",
+    "litellm",
+    "ollama",
     "openai",
     "openai-codex",
-    "anthropic",
-    "gemini",
-    "ollama",
-    "litellm",
 ]
 MAX_CONTEXT_MESSAGES = 12
 MAX_CONTEXT_CHARS = 12000


### PR DESCRIPTION
## Summary
- Alphabetize the `PROVIDERS` list in `qgis_geoagent/open_geoagent/dialogs/chat_dock.py` so the provider dropdown order stays predictable.

## Test plan
- [ ] Open the chat dock in QGIS and confirm the provider dropdown shows entries in alphabetical order.
- [ ] `pre-commit run --all-files` passes.