### PR TITLE
feat: add GEE snippet runner, layer statistics, and chat cancel

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.0.0"
+__version__ = "1.1.1"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -82,6 +82,19 @@ Workflow guidance:
   MNDWI, NDMI, or NBR, use calculate_gee_normalized_difference. Do not display
   a single source band as a proxy. Common Sentinel-2/HLS S30 pairs: NDVI B8/B4,
   NDWI B3/B8, MNDWI B3/B11, NBR B8/B12.
+- When the user asks for an Earth Engine operation that has no dedicated
+  GeoAgent tool, write a short Earth Engine Python snippet and run it with
+  run_gee_python_snippet. Prefer official Earth Engine API functions such as
+  ee.Terrain.hillshade for DEM hillshade. Do not say a task is impossible only
+  because no named GeoAgent tool exists.
+- When the user asks for scalar raster statistics such as mean elevation,
+  min/max, count, or summary values from a loaded Earth Engine layer, use
+  calculate_gee_layer_statistics. Do not use run_gee_python_snippet with
+  reduceRegion/getInfo for those requests. For large regions, use the default
+  coarse best-effort scale and report that the result is approximate.
+- When the user refers to an existing Earth Engine layer, call
+  list_loaded_gee_layers and reuse it with get_ee_layer(name) inside
+  run_gee_python_snippet instead of reloading data when possible.
 - For ImageCollections, call the selected aggregation a composite method.
   ``mosaic`` is valid, but it is an ImageCollection method, not an ee.Reducer.
 - For OPERA DSWx water maps, use OPERA/DSWX/L3_V1/HLS by default. Use

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -7,7 +7,12 @@ Python environments.
 
 from __future__ import annotations
 
+import ast
+import contextlib
+import io
 import os
+import sys
+import types
 from typing import Any, Optional
 from urllib.parse import quote
 
@@ -246,6 +251,522 @@ def _opera_dswx_render_image(
 def _format_python_snippet_value(value: Any) -> str:
     """Return a compact Python literal for snippet generation."""
     return repr(value)
+
+
+_ALLOWED_GEE_SNIPPET_IMPORTS = {"ee", "geemap"}
+_FORBIDDEN_GEE_SNIPPET_NAMES = {
+    "__builtins__",
+    "__import__",
+    "breakpoint",
+    "compile",
+    "delattr",
+    "dir",
+    "eval",
+    "exec",
+    "getattr",
+    "globals",
+    "help",
+    "input",
+    "locals",
+    "open",
+    "setattr",
+    "vars",
+}
+_FORBIDDEN_GEE_SNIPPET_ROOTS = {
+    "builtins",
+    "http",
+    "importlib",
+    "marshal",
+    "os",
+    "pathlib",
+    "pickle",
+    "requests",
+    "shutil",
+    "socket",
+    "subprocess",
+    "sys",
+    "urllib",
+}
+_FORBIDDEN_GEE_SNIPPET_ATTRIBUTES = {
+    "computeValue",
+    "getInfo",
+    "reduceRegion",
+    "reduceRegions",
+}
+_FORBIDDEN_GEE_SNIPPET_NODES = (
+    ast.AsyncFor,
+    ast.AsyncFunctionDef,
+    ast.AsyncWith,
+    ast.Await,
+    ast.ClassDef,
+    ast.Delete,
+    ast.FunctionDef,
+    ast.Global,
+    ast.Nonlocal,
+    ast.Raise,
+    ast.Try,
+    ast.With,
+)
+
+
+def _attribute_root(node: ast.AST) -> str | None:
+    """Return the leftmost name in an attribute expression."""
+    current = node
+    while isinstance(current, ast.Attribute):
+        current = current.value
+    if isinstance(current, ast.Name):
+        return current.id
+    return None
+
+
+def _validate_gee_python_snippet(code: str) -> None:
+    """Reject generated snippets outside the constrained EE layer surface."""
+    try:
+        tree = ast.parse(code, mode="exec")
+    except SyntaxError as exc:
+        raise ValueError(f"Invalid Python snippet: {exc}") from exc
+
+    for node in ast.walk(tree):
+        if isinstance(node, _FORBIDDEN_GEE_SNIPPET_NODES):
+            raise ValueError(
+                f"Unsupported Python construct in generated snippet: "
+                f"{type(node).__name__}"
+            )
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root not in _ALLOWED_GEE_SNIPPET_IMPORTS:
+                    raise ValueError(
+                        f"Import is not allowed in generated Earth Engine "
+                        f"snippets: {alias.name}"
+                    )
+        if isinstance(node, ast.ImportFrom):
+            module = (node.module or "").split(".", 1)[0]
+            if module not in _ALLOWED_GEE_SNIPPET_IMPORTS:
+                raise ValueError(
+                    f"Import is not allowed in generated Earth Engine snippets: "
+                    f"from {node.module or ''}"
+                )
+        if isinstance(node, ast.Name):
+            if node.id.startswith("__") or node.id in _FORBIDDEN_GEE_SNIPPET_NAMES:
+                raise ValueError(
+                    f"Name is not allowed in generated Earth Engine snippets: "
+                    f"{node.id}"
+                )
+            if node.id in _FORBIDDEN_GEE_SNIPPET_ROOTS:
+                raise ValueError(
+                    f"Module is not allowed in generated Earth Engine snippets: "
+                    f"{node.id}"
+                )
+        if isinstance(node, ast.Attribute):
+            if node.attr.startswith("__"):
+                raise ValueError(
+                    "Dunder attributes are not allowed in generated Earth "
+                    "Engine snippets."
+                )
+            if node.attr in _FORBIDDEN_GEE_SNIPPET_ATTRIBUTES:
+                raise ValueError(
+                    f"{node.attr} is not allowed in generated Earth Engine "
+                    "layer snippets. Use a dedicated analysis/statistics tool "
+                    "for scalar Earth Engine results."
+                )
+            root = _attribute_root(node)
+            if root in _FORBIDDEN_GEE_SNIPPET_ROOTS:
+                raise ValueError(
+                    f"Module is not allowed in generated Earth Engine snippets: "
+                    f"{root}"
+                )
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in _FORBIDDEN_GEE_SNIPPET_NAMES:
+                raise ValueError(
+                    f"Call is not allowed in generated Earth Engine snippets: "
+                    f"{func.id}"
+                )
+            root = _attribute_root(func)
+            if root in _FORBIDDEN_GEE_SNIPPET_ROOTS:
+                raise ValueError(
+                    f"Call is not allowed in generated Earth Engine snippets: "
+                    f"{root}"
+                )
+
+
+def _safe_builtins_for_gee_snippet(
+    ee_module: Any, geemap_module: Any
+) -> dict[str, Any]:
+    """Return a minimal builtins dict for generated EE snippets."""
+
+    def _safe_import(
+        name: str,
+        globals: dict[str, Any] | None = None,  # noqa: A002
+        locals: dict[str, Any] | None = None,  # noqa: A002
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if level != 0:
+            raise ImportError("Relative imports are not allowed in EE snippets.")
+        root = name.split(".", 1)[0]
+        if root == "ee":
+            return ee_module
+        if root == "geemap":
+            return geemap_module
+        raise ImportError(f"Import is not allowed in EE snippets: {name}")
+
+    return {
+        "__import__": _safe_import,
+        "abs": abs,
+        "all": all,
+        "any": any,
+        "bool": bool,
+        "dict": dict,
+        "enumerate": enumerate,
+        "float": float,
+        "int": int,
+        "len": len,
+        "list": list,
+        "max": max,
+        "min": min,
+        "print": print,
+        "range": range,
+        "repr": repr,
+        "round": round,
+        "set": set,
+        "sorted": sorted,
+        "str": str,
+        "sum": sum,
+        "tuple": tuple,
+        "zip": zip,
+    }
+
+
+def _loaded_gee_layer_records() -> list[dict[str, Any]]:
+    """Return compact metadata for registered plugin Earth Engine layers."""
+    from gee_data_catalogs.core.ee_utils import get_ee_layers
+
+    records: list[dict[str, Any]] = []
+    for name, payload in get_ee_layers().items():
+        ee_object = payload[0] if isinstance(payload, tuple) and payload else payload
+        vis_params = (
+            payload[1] if isinstance(payload, tuple) and len(payload) > 1 else {}
+        )
+        type_name = type(ee_object).__name__
+        records.append(
+            {
+                "name": str(name),
+                "object_type": type_name,
+                "vis_params": vis_params or {},
+            }
+        )
+    return records
+
+
+def _get_loaded_gee_object(layer_name: str) -> Any:
+    """Return a registered Earth Engine object by exact or case-insensitive name."""
+    from gee_data_catalogs.core.ee_utils import get_ee_layers
+
+    layers = get_ee_layers()
+    if layer_name in layers:
+        payload = layers[layer_name]
+        return payload[0] if isinstance(payload, tuple) else payload
+
+    requested = layer_name.strip().lower()
+    matches = [
+        (name, payload)
+        for name, payload in layers.items()
+        if str(name).strip().lower() == requested
+    ]
+    if not matches:
+        matches = [
+            (name, payload)
+            for name, payload in layers.items()
+            if requested and requested in str(name).strip().lower()
+        ]
+    if not matches:
+        available = ", ".join(str(name) for name in layers) or "(none)"
+        raise KeyError(
+            f"Earth Engine layer not found: {layer_name}. Available layers: {available}"
+        )
+    if len(matches) > 1:
+        names = ", ".join(str(name) for name, _payload in matches)
+        raise KeyError(f"Earth Engine layer name is ambiguous: {layer_name}. {names}")
+    payload = matches[0][1]
+    return payload[0] if isinstance(payload, tuple) else payload
+
+
+@contextlib.contextmanager
+def _temporary_ee_deadline(timeout_seconds: int | float):
+    """Temporarily set the Earth Engine API deadline when supported."""
+    try:
+        import ee
+
+        data = getattr(ee, "data", None)
+        set_deadline = getattr(data, "setDeadline", None)
+        get_deadline = getattr(data, "getDeadline", None)
+        old_deadline = get_deadline() if callable(get_deadline) else None
+        has_old_deadline = callable(get_deadline)
+        if callable(set_deadline):
+            set_deadline(max(1, int(float(timeout_seconds) * 1000)))
+        try:
+            yield
+        finally:
+            if callable(set_deadline) and has_old_deadline:
+                set_deadline(old_deadline)
+    except ImportError:
+        yield
+
+
+def _build_ee_statistics_reducer(
+    statistics: str | list[str] | None,
+) -> tuple[Any, list[str]]:
+    """Build a combined Earth Engine reducer for requested statistics."""
+    import ee
+
+    requested = _parse_list(statistics) or ["mean"]
+    aliases = {
+        "average": "mean",
+        "avg": "mean",
+        "std": "stdDev",
+        "stdev": "stdDev",
+        "stddev": "stdDev",
+    }
+    supported = {
+        "mean",
+        "min",
+        "max",
+        "median",
+        "stdDev",
+        "sum",
+        "count",
+    }
+    normalized: list[str] = []
+    for item in requested:
+        key = aliases.get(str(item).strip().lower(), str(item).strip())
+        if key not in supported:
+            raise ValueError(
+                f"Unsupported statistic: {item}. Supported statistics: "
+                f"{', '.join(sorted(supported))}"
+            )
+        normalized.append(key)
+
+    reducer = None
+    for stat in normalized:
+        reducer_fn = getattr(ee.Reducer, stat)
+        next_reducer = reducer_fn()
+        if reducer is None:
+            reducer = next_reducer
+        else:
+            reducer = reducer.combine(reducer2=next_reducer, sharedInputs=True)
+    return reducer, normalized
+
+
+def _calculate_gee_layer_statistics_impl(
+    *,
+    layer_name: str,
+    band: str | None,
+    statistics: str | list[str] | None,
+    scale: int | float,
+    max_pixels: int | float,
+    best_effort: bool,
+    tile_scale: int | float,
+    timeout_seconds: int | float,
+    region_collection_asset_id: str | None,
+    region_filter_property: str | None,
+    region_filter_value: str | None,
+) -> dict[str, Any]:
+    """Calculate bounded Earth Engine statistics for a registered image layer."""
+    import ee
+
+    source = _get_loaded_gee_object(layer_name)
+    image = ee.Image(source)
+    if band:
+        image = image.select(str(band).strip())
+
+    region = None
+    region_info = None
+    if region_collection_asset_id:
+        fc = ee.FeatureCollection(region_collection_asset_id)
+        if region_filter_property and region_filter_value is not None:
+            fc = fc.filter(
+                ee.Filter.eq(
+                    region_filter_property,
+                    _coerce_filter_value(region_filter_value),
+                )
+            )
+        region = fc.geometry()
+        region_info = {
+            "collection_asset_id": region_collection_asset_id,
+            "filter_property": region_filter_property,
+            "filter_value": region_filter_value,
+        }
+    else:
+        region = image.geometry()
+
+    reducer, normalized_statistics = _build_ee_statistics_reducer(statistics)
+    scale_value = float(scale)
+    max_pixels_value = int(float(max_pixels))
+    tile_scale_value = float(tile_scale)
+
+    reduction = image.reduceRegion(
+        reducer=reducer,
+        geometry=region,
+        scale=scale_value,
+        maxPixels=max_pixels_value,
+        bestEffort=bool(best_effort),
+        tileScale=tile_scale_value,
+    )
+    with _temporary_ee_deadline(timeout_seconds):
+        values = reduction.getInfo()
+
+    if not isinstance(values, dict):
+        values = {"value": values}
+
+    numeric_values = [
+        value for value in values.values() if isinstance(value, (int, float))
+    ]
+    return {
+        "success": True,
+        "layer_name": layer_name,
+        "band": band,
+        "statistics": normalized_statistics,
+        "values": values,
+        "mean": (
+            numeric_values[0]
+            if normalized_statistics == ["mean"] and numeric_values
+            else None
+        ),
+        "scale": scale_value,
+        "max_pixels": max_pixels_value,
+        "best_effort": bool(best_effort),
+        "tile_scale": tile_scale_value,
+        "timeout_seconds": float(timeout_seconds),
+        "region": region_info,
+        "approximate": bool(best_effort),
+    }
+
+
+def _run_gee_python_snippet_impl(
+    *,
+    iface: Any,
+    code: str,
+) -> dict[str, Any]:
+    """Execute a constrained EE/geemap snippet and add requested layers."""
+    import ee
+
+    _validate_gee_python_snippet(code)
+
+    layers_added: list[dict[str, Any]] = []
+
+    def _add_layer(
+        ee_object: Any,
+        vis_params: dict[str, Any] | None = None,
+        name: str = "Earth Engine Layer",
+        shown: bool = True,  # noqa: ARG001 - retained for geemap compatibility
+        opacity: float = 1.0,  # noqa: ARG001 - retained for geemap compatibility
+    ) -> Any:
+        display_name = str(name or "Earth Engine Layer")[:50]
+        layer = _add_ee_layer_nonblocking(
+            iface=iface,
+            ee_object=ee_object,
+            vis_params=vis_params or {},
+            name=display_name,
+        )
+        _validate_added_layer(layer, display_name)
+        layers_added.append(
+            {
+                "name": display_name,
+                "vis_params": vis_params or {},
+                "object_type": type(ee_object).__name__,
+            }
+        )
+        return layer
+
+    class QGISMap:
+        """Small geemap.Map-compatible adapter for generated snippets."""
+
+        def add_layer(
+            self,
+            ee_object: Any,
+            vis_params: dict[str, Any] | None = None,
+            name: str = "Earth Engine Layer",
+            shown: bool = True,
+            opacity: float = 1.0,
+        ) -> Any:
+            return _add_layer(ee_object, vis_params, name, shown, opacity)
+
+        def addLayer(
+            self,
+            ee_object: Any,
+            vis_params: dict[str, Any] | None = None,
+            name: str = "Earth Engine Layer",
+            shown: bool = True,
+            opacity: float = 1.0,
+        ) -> Any:
+            return self.add_layer(ee_object, vis_params, name, shown, opacity)
+
+        def add_ee_layer(
+            self,
+            ee_object: Any,
+            vis_params: dict[str, Any] | None = None,
+            name: str = "Earth Engine Layer",
+            shown: bool = True,
+            opacity: float = 1.0,
+        ) -> Any:
+            return self.add_layer(ee_object, vis_params, name, shown, opacity)
+
+    geemap_module = types.ModuleType("geemap")
+    geemap_module.Map = QGISMap
+    original_geemap = sys.modules.get("geemap")
+    sys.modules["geemap"] = geemap_module
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    namespace: dict[str, Any] = {
+        "__builtins__": _safe_builtins_for_gee_snippet(ee, geemap_module),
+        "Map": QGISMap,
+        "add_layer": _add_layer,
+        "ee": ee,
+        "geemap": geemap_module,
+        "get_ee_layer": _get_loaded_gee_object,
+        "list_ee_layers": _loaded_gee_layer_records,
+        "m": QGISMap(),
+    }
+
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exec(
+                compile(code, "<generated_gee_snippet>", "exec"), namespace
+            )  # nosec B102
+    finally:
+        if original_geemap is not None:
+            sys.modules["geemap"] = original_geemap
+        else:
+            sys.modules.pop("geemap", None)
+
+    if not layers_added:
+        return {
+            "success": False,
+            "error": (
+                "The generated Earth Engine snippet ran but did not add a layer. "
+                "Call m.add_layer(...), m.addLayer(...), or add_layer(...)."
+            ),
+            "layers_added": [],
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+            "earth_engine_python_snippet": code,
+        }
+
+    try:
+        _on_gui(lambda: iface.mapCanvas().refresh())
+    except Exception:
+        pass
+
+    return {
+        "success": True,
+        "layers_added": layers_added,
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        "earth_engine_python_snippet": code,
+    }
 
 
 def _build_load_gee_dataset_snippet(
@@ -1312,6 +1833,134 @@ def gee_data_catalogs_tools(
 
     @geo_tool(
         category="gee_data_catalogs",
+        name="list_loaded_gee_layers",
+        available_in=("full", "fast"),
+        requires_packages=("gee_data_catalogs",),
+    )
+    def list_loaded_gee_layers() -> dict[str, Any]:
+        """List currently registered Earth Engine layers in the QGIS project."""
+        layers = _loaded_gee_layer_records()
+        return {"count": len(layers), "layers": layers}
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="run_gee_python_snippet",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("gee_data_catalogs", "ee"),
+    )
+    def run_gee_python_snippet(
+        code: str,
+        description: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Run a constrained Earth Engine Python snippet and add QGIS layers.
+
+        Use this when the user asks for an Earth Engine operation that is not
+        covered by a dedicated GeoAgent tool. The snippet may use ``ee`` and a
+        small geemap-compatible map surface: ``m.add_layer(...)``,
+        ``m.addLayer(...)``, ``add_layer(...)``, ``get_ee_layer(name)``, and
+        ``list_ee_layers()``. It must add at least one layer.
+
+        Args:
+            code: Short Earth Engine Python snippet to run.
+            description: Optional plain-language summary for confirmation.
+        """
+        if not code or not code.strip():
+            return {
+                "success": False,
+                "error": "No Earth Engine Python snippet was provided.",
+                "earth_engine_python_snippet": code or "",
+            }
+
+        try:
+            result = _run_gee_python_snippet_impl(iface=iface, code=code.strip())
+        except Exception as exc:
+            return {
+                "success": False,
+                "error": str(exc),
+                "description": description,
+                "earth_engine_python_snippet": code.strip(),
+            }
+        result["description"] = description
+        return result
+
+    @geo_tool(
+        category="gee_data_catalogs",
+        name="calculate_gee_layer_statistics",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("gee_data_catalogs", "ee"),
+    )
+    def calculate_gee_layer_statistics(
+        layer_name: str,
+        band: Optional[str] = None,
+        statistics: Optional[str] = "mean",
+        scale: float = 1000.0,
+        max_pixels: float = 100000000,
+        best_effort: bool = True,
+        tile_scale: float = 4.0,
+        timeout_seconds: float = 60.0,
+        region_collection_asset_id: Optional[str] = None,
+        region_filter_property: Optional[str] = None,
+        region_filter_value: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Calculate bounded server-side statistics for a loaded EE image layer.
+
+        Use this for scalar questions such as mean elevation, min/max slope, or
+        summary statistics of a registered Earth Engine raster. Defaults are
+        intentionally coarse and best-effort so large regions such as the
+        continental United States return instead of blocking QGIS indefinitely.
+
+        Args:
+            layer_name: Registered Earth Engine layer name to analyze.
+            band: Optional band to select before reducing.
+            statistics: Comma-separated statistics: mean, min, max, median,
+                stdDev, sum, count.
+            scale: Reduction scale in meters. Defaults to 1000 m for large
+                area responsiveness.
+            max_pixels: Earth Engine maxPixels value.
+            best_effort: Whether Earth Engine may coarsen scale to fit limits.
+            tile_scale: Earth Engine reduceRegion tileScale.
+            timeout_seconds: Request deadline for the blocking EE evaluation.
+            region_collection_asset_id: Optional FeatureCollection region. If
+                omitted, the loaded image geometry/mask is used.
+            region_filter_property: Optional filter property for the region FC.
+            region_filter_value: Optional filter value for the region FC.
+        """
+        try:
+            return _calculate_gee_layer_statistics_impl(
+                layer_name=layer_name,
+                band=band,
+                statistics=statistics,
+                scale=scale,
+                max_pixels=max_pixels,
+                best_effort=best_effort,
+                tile_scale=tile_scale,
+                timeout_seconds=timeout_seconds,
+                region_collection_asset_id=region_collection_asset_id,
+                region_filter_property=region_filter_property,
+                region_filter_value=region_filter_value,
+            )
+        except Exception as exc:
+            return {
+                "success": False,
+                "error": str(exc),
+                "layer_name": layer_name,
+                "band": band,
+                "statistics": statistics,
+                "scale": scale,
+                "max_pixels": max_pixels,
+                "best_effort": best_effort,
+                "tile_scale": tile_scale,
+                "timeout_seconds": timeout_seconds,
+                "hint": (
+                    "For large regions, retry with a coarser scale such as "
+                    "2000 or 5000 meters, or provide a smaller region."
+                ),
+            }
+
+    @geo_tool(
+        category="gee_data_catalogs",
         name="open_gee_catalog_panel",
         available_in=("full", "fast"),
     )
@@ -1374,6 +2023,9 @@ def gee_data_catalogs_tools(
         initialize_earth_engine,
         load_gee_dataset,
         calculate_gee_normalized_difference,
+        list_loaded_gee_layers,
+        run_gee_python_snippet,
+        calculate_gee_layer_statistics,
         open_gee_catalog_panel,
         configure_gee_dataset_load,
     ]

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -11,7 +11,6 @@ import ast
 import contextlib
 import io
 import os
-import sys
 import types
 from typing import Any, Optional
 from urllib.parse import quote
@@ -300,11 +299,13 @@ _FORBIDDEN_GEE_SNIPPET_NODES = (
     ast.Await,
     ast.ClassDef,
     ast.Delete,
+    ast.For,
     ast.FunctionDef,
     ast.Global,
     ast.Nonlocal,
     ast.Raise,
     ast.Try,
+    ast.While,
     ast.With,
 )
 
@@ -715,8 +716,6 @@ def _run_gee_python_snippet_impl(
 
     geemap_module = types.ModuleType("geemap")
     geemap_module.Map = QGISMap
-    original_geemap = sys.modules.get("geemap")
-    sys.modules["geemap"] = geemap_module
 
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -731,16 +730,8 @@ def _run_gee_python_snippet_impl(
         "m": QGISMap(),
     }
 
-    try:
-        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-            exec(
-                compile(code, "<generated_gee_snippet>", "exec"), namespace
-            )  # nosec B102
-    finally:
-        if original_geemap is not None:
-            sys.modules["geemap"] = original_geemap
-        else:
-            sys.modules.pop("geemap", None)
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        exec(compile(code, "<generated_gee_snippet>", "exec"), namespace)  # nosec B102
 
     if not layers_added:
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.0.0"
+version = "1.1.1"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -76,7 +76,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.0.0"
+current_version = "1.1.1"
 commit = true
 tag = true
 

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -399,6 +399,21 @@ class ChatWorker(QThread):
             )
             response = agent.chat(self.prompt)
 
+            if self.isInterruptionRequested():
+                self.finished.emit(
+                    {
+                        "success": False,
+                        "answer": "",
+                        "error": "",
+                        "tools": ", ".join(response.executed_tools or []),
+                        "tool_calls": response.tool_calls or [],
+                        "cancelled": ", ".join(response.cancelled_tools or []),
+                        "elapsed": f"{response.execution_time:.2f}s",
+                        "cancelled_by_user": True,
+                    }
+                )
+                return
+
             self.finished.emit(
                 {
                     "success": bool(response.success),
@@ -408,6 +423,7 @@ class ChatWorker(QThread):
                     "tool_calls": response.tool_calls or [],
                     "cancelled": ", ".join(response.cancelled_tools or []),
                     "elapsed": f"{response.execution_time:.2f}s",
+                    "cancelled_by_user": False,
                 }
             )
         except Exception as exc:
@@ -419,11 +435,14 @@ class ChatWorker(QThread):
                     "tools": "",
                     "cancelled": "",
                     "elapsed": "",
+                    "cancelled_by_user": self.isInterruptionRequested(),
                 }
             )
 
     def _confirm_tool(self, request):
         """Ask the QGIS user before running confirmation-required tools."""
+        if self.isInterruptionRequested():
+            return False
         if self.auto_approve_tools:
             return True
 
@@ -572,6 +591,11 @@ class ChatDockWidget(QDockWidget):
         self.send_btn.clicked.connect(self._send_prompt)
         primary_button_layout.addWidget(self.send_btn)
 
+        self.cancel_btn = QPushButton("Cancel")
+        self.cancel_btn.setEnabled(False)
+        self.cancel_btn.clicked.connect(self._cancel_running_task)
+        primary_button_layout.addWidget(self.cancel_btn)
+
         self.clear_btn = QPushButton("Clear")
         self.clear_btn.clicked.connect(self._clear_transcript)
         primary_button_layout.addWidget(self.clear_btn)
@@ -673,6 +697,7 @@ class ChatDockWidget(QDockWidget):
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
         self._start_running_status("Running GeoAgent")
         self.send_btn.setEnabled(False)
+        self.cancel_btn.setEnabled(True)
 
         self._worker = ChatWorker(
             self.iface,
@@ -755,7 +780,11 @@ class ChatDockWidget(QDockWidget):
     def _on_worker_finished(self, result):
         """Render the completed chat worker result."""
         self._stop_running_status()
-        if result.get("success"):
+        if result.get("cancelled_by_user"):
+            self._append_message("OpenGeoAgent", "Cancelled by user.", markdown=False)
+            self.status_label.setText("Cancelled")
+            self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+        elif result.get("success"):
             answer = result.get("answer") or "(No text response.)"
             details = []
             tool_inputs = _format_tool_calls(result.get("tool_calls") or [])
@@ -780,7 +809,21 @@ class ChatDockWidget(QDockWidget):
             self.status_label.setStyleSheet("color: red; font-size: 10px;")
 
         self.send_btn.setEnabled(True)
+        self.cancel_btn.setEnabled(False)
         self._worker = None
+
+    def _cancel_running_task(self):
+        """Request cancellation of the in-flight chat worker."""
+        worker = self._worker
+        if worker is None:
+            return
+        worker.requestInterruption()
+        self.cancel_btn.setEnabled(False)
+        self.status_label.setText(
+            "Cancellation requested. Waiting for current call to stop."
+        )
+        self.status_label.setStyleSheet("color: #EF6C00; font-size: 10px;")
+        self._start_running_status("Cancelling GeoAgent")
 
     def _start_running_status(self, base_text):
         """Start or update the animated status text."""

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -593,6 +593,11 @@ class ChatDockWidget(QDockWidget):
 
         self.cancel_btn = QPushButton("Cancel")
         self.cancel_btn.setEnabled(False)
+        self.cancel_btn.setToolTip(
+            "Stops GeoAgent at the next checkpoint. The in-flight model "
+            "request and any tool already running cannot be aborted "
+            "mid-call; cancellation takes effect between steps."
+        )
         self.cancel_btn.clicked.connect(self._cancel_running_task)
         primary_button_layout.addWidget(self.cancel_btn)
 
@@ -820,7 +825,8 @@ class ChatDockWidget(QDockWidget):
         worker.requestInterruption()
         self.cancel_btn.setEnabled(False)
         self.status_label.setText(
-            "Cancellation requested. Waiting for current call to stop."
+            "Cancellation requested. Waiting for the current model "
+            "call or tool to finish before stopping."
         )
         self.status_label.setStyleSheet("color: #EF6C00; font-size: 10px;")
         self._start_running_status("Cancelling GeoAgent")

--- a/tests/test_gee_data_catalogs_tools.py
+++ b/tests/test_gee_data_catalogs_tools.py
@@ -58,12 +58,19 @@ def test_gee_data_catalogs_tools_expose_catalog_surface() -> None:
     assert "initialize_earth_engine" in tools
     assert "load_gee_dataset" in tools
     assert "calculate_gee_normalized_difference" in tools
+    assert "list_loaded_gee_layers" in tools
+    assert "run_gee_python_snippet" in tools
+    assert "calculate_gee_layer_statistics" in tools
     assert "open_gee_catalog_panel" in tools
     assert "configure_gee_dataset_load" in tools
 
 
-def test_for_gee_data_catalogs_registers_catalog_and_qgis_tools() -> None:
+def test_for_gee_data_catalogs_registers_catalog_and_qgis_tools(monkeypatch) -> None:
     """Verify the GEE factory combines catalog and QGIS tool surfaces."""
+    import geoagent.core.factory as factory
+
+    monkeypatch.setattr(factory, "packages_available", lambda _packages: True)
+
     agent = for_gee_data_catalogs(
         MockQGISIface(),
         MockQGISProject(),
@@ -73,8 +80,22 @@ def test_for_gee_data_catalogs_registers_catalog_and_qgis_tools() -> None:
 
     assert "open_gee_catalog_panel" in names
     assert "configure_gee_dataset_load" in names
+    assert "list_loaded_gee_layers" in names
+    assert "run_gee_python_snippet" in names
+    assert "calculate_gee_layer_statistics" in names
     assert "list_project_layers" in names
     assert agent.context.metadata["integration"] == "gee_data_catalogs"
+
+
+def test_gee_data_catalogs_prompt_mentions_generated_ee_snippets() -> None:
+    """Verify the integration prompt tells the model to use EE snippets."""
+    from geoagent.core.factory import GEE_DATA_CATALOGS_SYSTEM_PROMPT
+
+    assert "run_gee_python_snippet" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "ee.Terrain.hillshade" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "list_loaded_gee_layers" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "calculate_gee_layer_statistics" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "reduceRegion/getInfo" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
 
 
 def test_load_gee_dataset_clips_raster_to_feature_collection(monkeypatch) -> None:
@@ -676,3 +697,275 @@ def test_calculate_gee_normalized_difference_loads_index(monkeypatch) -> None:
     assert captured["vis"]["min"] == -1.0
     assert captured["vis"]["max"] == 1.0
     assert iface.canvas.refreshed is True
+
+
+def test_list_loaded_gee_layers_reports_registry(monkeypatch) -> None:
+    """Verify the helper exposes registered EE layer metadata."""
+
+    class _FakeImage:
+        pass
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.get_ee_layers = lambda: {
+        "SRTM DEM": (_FakeImage(), {"min": 0, "max": 4000})
+    }
+
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(object())}
+    result = tools["list_loaded_gee_layers"].__wrapped__()
+
+    assert result["count"] == 1
+    assert result["layers"][0]["name"] == "SRTM DEM"
+    assert result["layers"][0]["object_type"] == "_FakeImage"
+    assert result["layers"][0]["vis_params"] == {"min": 0, "max": 4000}
+
+
+def test_calculate_gee_layer_statistics_reduces_registered_dem(monkeypatch) -> None:
+    """Verify scalar statistics use bounded reduceRegion settings."""
+
+    class _FakeDictionary:
+        def __init__(self, values):
+            self.values = values
+
+        def getInfo(self):
+            return self.values
+
+    class _FakeImage:
+        def __init__(self) -> None:
+            self.selected_band = None
+
+        def select(self, band: str):
+            self.selected_band = band
+            return self
+
+        def geometry(self):
+            return "image-geometry"
+
+        def reduceRegion(self, **kwargs):
+            captured["reduce_region"] = kwargs
+            return _FakeDictionary({"elevation": 853.25})
+
+    class _FakeReducer:
+        @staticmethod
+        def mean():
+            return "mean-reducer"
+
+    dem = _FakeImage()
+    captured = {}
+
+    ee_module = ModuleType("ee")
+    ee_module.Image = lambda value: value
+    ee_module.Reducer = _FakeReducer
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.get_ee_layers = lambda: {"NASADEM elevation clipped to US": (dem, {})}
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(object())}
+    result = tools["calculate_gee_layer_statistics"].__wrapped__(
+        "NASADEM elevation clipped to US",
+        band="elevation",
+    )
+
+    assert result["success"] is True
+    assert result["values"] == {"elevation": 853.25}
+    assert result["mean"] == 853.25
+    assert result["approximate"] is True
+    assert result["scale"] == 1000.0
+    assert result["best_effort"] is True
+    assert dem.selected_band == "elevation"
+    assert captured["reduce_region"] == {
+        "reducer": "mean-reducer",
+        "geometry": "image-geometry",
+        "scale": 1000.0,
+        "maxPixels": 100000000,
+        "bestEffort": True,
+        "tileScale": 4.0,
+    }
+
+
+def test_run_gee_python_snippet_hillshade_from_registered_layer(
+    monkeypatch,
+) -> None:
+    """Verify generated snippets can use ee.Terrain.hillshade and add layers."""
+
+    class _Canvas:
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        def refresh(self) -> None:
+            self.refreshed = True
+
+    class _Iface:
+        def __init__(self) -> None:
+            self.canvas = _Canvas()
+
+        def mapCanvas(self) -> _Canvas:
+            return self.canvas
+
+    class _FakeImage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _FakeTerrain:
+        @staticmethod
+        def hillshade(image):
+            return _FakeImage(f"hillshade:{image.name}")
+
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
+    dem = _FakeImage("srtm")
+    captured = {}
+
+    ee_module = ModuleType("ee")
+    ee_module.Terrain = _FakeTerrain
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.get_ee_layers = lambda: {"SRTM DEM clipped to United States": (dem, {})}
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    ee_utils.add_ee_layer = _add_ee_layer
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    code = """
+import ee
+import geemap
+
+dem = get_ee_layer('SRTM DEM clipped to United States')
+hillshade = ee.Terrain.hillshade(dem)
+m = geemap.Map()
+m.add_layer(hillshade, {'min': 0, 'max': 255}, 'SRTM Hillshade')
+"""
+    iface = _Iface()
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(iface)}
+    result = tools["run_gee_python_snippet"].__wrapped__(
+        code,
+        description="Create a true hillshade from the existing DEM.",
+    )
+
+    assert result["success"] is True
+    assert result["layers_added"] == [
+        {
+            "name": "SRTM Hillshade",
+            "vis_params": {"min": 0, "max": 255},
+            "object_type": "_FakeImage",
+        }
+    ]
+    assert captured["object"].name == "hillshade:srtm"
+    assert captured["vis"] == {"min": 0, "max": 255}
+    assert captured["name"] == "SRTM Hillshade"
+    assert "ee.Terrain.hillshade(dem)" in result["earth_engine_python_snippet"]
+    assert result["description"] == "Create a true hillshade from the existing DEM."
+    assert iface.canvas.refreshed is True
+
+
+def test_run_gee_python_snippet_supports_direct_add_layer(
+    monkeypatch,
+) -> None:
+    """Verify generated snippets can use the top-level add_layer helper."""
+
+    class _Canvas:
+        def refresh(self) -> None:
+            pass
+
+    class _Iface:
+        def mapCanvas(self) -> _Canvas:
+            return _Canvas()
+
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
+    ee_module = ModuleType("ee")
+    ee_module.Image = lambda asset_id: ("image", asset_id)
+
+    captured = {}
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.get_ee_layers = lambda: {}
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    ee_utils.add_ee_layer = _add_ee_layer
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    code = "image = ee.Image('USGS/SRTMGL1_003')\nadd_layer(image, {}, 'SRTM')"
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(_Iface())}
+    result = tools["run_gee_python_snippet"].__wrapped__(code)
+
+    assert result["success"] is True
+    assert captured["object"] == ("image", "USGS/SRTMGL1_003")
+    assert captured["name"] == "SRTM"
+    assert result["layers_added"][0]["name"] == "SRTM"
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "open('/tmp/out.txt', 'w')",
+        "import os\nos.remove('/tmp/out.txt')",
+        "import subprocess\nsubprocess.run(['echo', 'x'])",
+        "eval('1 + 1')",
+        "__import__('os')",
+        "image.reduceRegion(reducer=ee.Reducer.mean()).getInfo()",
+    ],
+)
+def test_run_gee_python_snippet_rejects_unsafe_code(monkeypatch, code: str) -> None:
+    """Verify unsafe generated snippets are rejected before execution."""
+
+    ee_module = ModuleType("ee")
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+    ee_utils.get_ee_layers = lambda: {}
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(object())}
+    result = tools["run_gee_python_snippet"].__wrapped__(code)
+
+    assert result["success"] is False
+    assert "not allowed" in result["error"]
+    assert result["earth_engine_python_snippet"] == code


### PR DESCRIPTION
## Summary
- Add three QGIS Earth Engine tools so the agent can serve EE requests that lack a dedicated wrapper: `list_loaded_gee_layers`, `run_gee_python_snippet` (sandboxed `ee`/`geemap` exec with an AST allowlist), and `calculate_gee_layer_statistics` for bounded scalar reductions.
- Add a Cancel button to the chat dock so users can interrupt a running prompt and stop pending confirmation-required tools.
- Bump version to 1.1.1.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] CI test suite passes
- [ ] In QGIS, load a DEM via the GEE catalog, then ask the agent to add a hillshade. Confirm `run_gee_python_snippet` is used and a hillshade layer appears.
- [ ] Ask the agent for the mean elevation of the loaded DEM. Confirm `calculate_gee_layer_statistics` returns a scalar value with `approximate: true`.
- [ ] Send a long prompt, click Cancel before completion, and confirm the dock reports cancellation and re-enables Send.