### PR TITLE
feat: add FeatureCollection filterBounds option for GEE datasets

### DIFF
--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -72,12 +72,25 @@ Workflow guidance:
   not reuse a previous conversation location for a new dataset request unless
   the current request says "same area", "there", or otherwise clearly refers
   to that prior location. If the user asks for a global layer, or gives no
-  location, omit bbox.
-- When the user asks to clip a raster/Image/ImageCollection to an administrative
-  boundary or other vector region, use load_gee_dataset with
-  clip_collection_asset_id and clip_filter_property/value. The tool applies
-  ee.Image.clipToCollection to the raster output. For Tennessee, use
-  TIGER/2018/States with NAME=Tennessee.
+  location, omit bbox. For ImageCollections, regional display should use
+  filterBounds. When a specific FeatureCollection exists for the requested
+  region, prefer load_gee_dataset bounds_collection_asset_id and
+  bounds_filter_property/value over bbox coordinates; for example, use
+  TIGER/2018/States with NAME=Tennessee for Tennessee. Use bbox only when no
+  appropriate FeatureCollection is known, the user provides exact bbox
+  coordinates, or the bbox is already known and should be used only to zoom
+  QGIS to the requested region after loading. If you have both a
+  FeatureCollection filter and an already-known bbox for the same region, pass
+  both; the tool will use the FeatureCollection for filterBounds and the bbox
+  for QGIS zoom. Do not compute a bbox from the FeatureCollection geometry.
+- Earth Engine clip operations are computationally intensive. Do not use
+  ee.Image.clip or ee.Image.clipToCollection just because the user asks to show
+  data for a region; use filterBounds through bounds_collection_asset_id or
+  bbox instead. Only when the user specifically asks to clip, crop, or mask the
+  raster/Image/ImageCollection to an administrative boundary or other vector
+  region, use load_gee_dataset with clip_collection_asset_id and
+  clip_filter_property/value. The tool applies ee.Image.clipToCollection to the
+  raster output.
 - When the user asks for normalized difference indexes such as NDVI, NDWI,
   MNDWI, NDMI, or NBR, use calculate_gee_normalized_difference. Do not display
   a single source band as a proxy. Common Sentinel-2/HLS S30 pairs: NDVI B8/B4,

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -769,6 +769,9 @@ def _build_load_gee_dataset_snippet(
     bbox: list[float] | None,
     cloud_cover: int | None,
     cloud_property: str | None,
+    bounds_collection_asset_id: str | None,
+    bounds_filter_property: str | None,
+    bounds_filter_value: str | None,
     method: str | None,
     bands: str | list[str] | None,
     min_value: float | None,
@@ -812,7 +815,20 @@ def _build_load_gee_dataset_snippet(
                 f"{_format_python_snippet_value(end_date)}"
                 ")"
             )
-        if bbox is not None:
+        if bounds_collection_asset_id:
+            lines.append(
+                "bounds_fc = ee.FeatureCollection("
+                f"{_format_python_snippet_value(bounds_collection_asset_id)})"
+            )
+            if bounds_filter_property and bounds_filter_value is not None:
+                lines.append(
+                    "bounds_fc = bounds_fc.filter(ee.Filter.eq("
+                    f"{_format_python_snippet_value(bounds_filter_property)}, "
+                    f"{_format_python_snippet_value(_coerce_filter_value(bounds_filter_value))}"
+                    "))"
+                )
+            lines.append("collection = collection.filterBounds(bounds_fc)")
+        elif bbox is not None:
             lines.append(f"bbox = {_format_python_snippet_value(bbox)}")
             lines.append(
                 "collection = collection.filterBounds(ee.Geometry.Rectangle(bbox))"
@@ -894,6 +910,9 @@ def _build_normalized_difference_snippet(
     bbox: list[float] | None,
     cloud_cover: int | None,
     cloud_property: str | None,
+    bounds_collection_asset_id: str | None,
+    bounds_filter_property: str | None,
+    bounds_filter_value: str | None,
     method: str | None,
     positive_band: str,
     negative_band: str,
@@ -934,7 +953,20 @@ def _build_normalized_difference_snippet(
                 f"{_format_python_snippet_value(end_date)}"
                 ")"
             )
-        if bbox is not None:
+        if bounds_collection_asset_id:
+            lines.append(
+                "bounds_fc = ee.FeatureCollection("
+                f"{_format_python_snippet_value(bounds_collection_asset_id)})"
+            )
+            if bounds_filter_property and bounds_filter_value is not None:
+                lines.append(
+                    "bounds_fc = bounds_fc.filter(ee.Filter.eq("
+                    f"{_format_python_snippet_value(bounds_filter_property)}, "
+                    f"{_format_python_snippet_value(_coerce_filter_value(bounds_filter_value))}"
+                    "))"
+                )
+            lines.append("collection = collection.filterBounds(bounds_fc)")
+        elif bbox is not None:
             lines.append(f"bbox = {_format_python_snippet_value(bbox)}")
             lines.append(
                 "collection = collection.filterBounds(ee.Geometry.Rectangle(bbox))"
@@ -1356,6 +1388,9 @@ def gee_data_catalogs_tools(
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         bbox: Optional[str] = None,
+        bounds_collection_asset_id: Optional[str] = None,
+        bounds_filter_property: Optional[str] = None,
+        bounds_filter_value: Optional[str] = None,
         cloud_cover: Optional[int] = None,
         cloud_property: Optional[str] = None,
         reducer: str = "mosaic",
@@ -1377,7 +1412,21 @@ def gee_data_catalogs_tools(
                 FeatureCollection. When omitted, the plugin detects the type.
             start_date: Optional ImageCollection start date in YYYY-MM-DD.
             end_date: Optional ImageCollection end date in YYYY-MM-DD.
-            bbox: Optional WGS84 west,south,east,north filter.
+            bbox: Optional WGS84 west,south,east,north region filter. For
+                ImageCollections, this uses ``filterBounds`` when no
+                ``bounds_collection_asset_id`` is provided. When a bounds
+                FeatureCollection is provided, bbox is still used to zoom QGIS
+                after loading if it is already known.
+            bounds_collection_asset_id: Optional FeatureCollection asset id
+                used with ImageCollection ``filterBounds`` for regional
+                display. Prefer this over bbox coordinates when a specific
+                FeatureCollection exists for the requested region.
+                Example: TIGER/2018/States.
+            bounds_filter_property: Optional property to filter the bounds
+                FeatureCollection before calling ``filterBounds``. Example:
+                NAME.
+            bounds_filter_value: Optional value for ``bounds_filter_property``.
+                Example: Tennessee.
             cloud_cover: Optional maximum cloud-cover value.
             cloud_property: Optional cloud-cover property name.
             reducer: ImageCollection compositing method: mosaic, median, mean,
@@ -1389,6 +1438,11 @@ def gee_data_catalogs_tools(
             palette: Optional comma-separated colors or palette entries.
             clip_collection_asset_id: Optional FeatureCollection asset id used
                 to clip raster outputs with ``ee.Image.clipToCollection``.
+                Clipping is computationally intensive; only use this when the
+                user specifically asks to clip, crop, or mask data to the
+                region. For ordinary regional display, use
+                ``bounds_collection_asset_id`` when a specific
+                FeatureCollection exists, otherwise use ``bbox``.
                 Example: TIGER/2018/States.
             clip_filter_property: Optional property to filter the clipping
                 FeatureCollection before clipping. Example: NAME.
@@ -1415,8 +1469,18 @@ def gee_data_catalogs_tools(
             resolved_type = asset_type or detect_asset_type(asset_id)
             name = layer_name or asset_id.split("/")[-1]
             parsed_bbox = _parse_bbox(bbox)
+            bounds_collection = None
             clip_collection = None
             diagnostics: dict[str, Any] = {}
+            if bounds_collection_asset_id:
+                bounds_collection = ee.FeatureCollection(bounds_collection_asset_id)
+                if bounds_filter_property and bounds_filter_value is not None:
+                    bounds_collection = bounds_collection.filter(
+                        ee.Filter.eq(
+                            bounds_filter_property,
+                            _coerce_filter_value(bounds_filter_value),
+                        )
+                    )
             if clip_collection_asset_id:
                 clip_collection = ee.FeatureCollection(clip_collection_asset_id)
                 if clip_filter_property and clip_filter_value is not None:
@@ -1432,6 +1496,13 @@ def gee_data_catalogs_tools(
                 is_dswx = _is_opera_dswx(asset_id)
                 if parsed_bbox is not None:
                     diagnostics["bbox"] = parsed_bbox
+                if bounds_collection_asset_id:
+                    diagnostics["bounds"] = {
+                        "collection_asset_id": bounds_collection_asset_id,
+                        "filter_property": bounds_filter_property,
+                        "filter_value": bounds_filter_value,
+                        "method": "ImageCollection.filterBounds",
+                    }
                 if is_dswx and cloud_cover is not None:
                     diagnostics["ignored_cloud_cover"] = cloud_cover
                     diagnostics["cloud_filter_reason"] = (
@@ -1443,19 +1514,28 @@ def gee_data_catalogs_tools(
                     diagnostics["filtering"] = "direct_dswx_filterDate_filterBounds"
                     if start_date or end_date:
                         collection = collection.filterDate(start_date, end_date)
-                    if parsed_bbox is not None:
+                    if bounds_collection is not None:
+                        collection = collection.filterBounds(bounds_collection)
+                    elif parsed_bbox is not None:
                         collection = collection.filterBounds(
                             ee.Geometry.Rectangle(parsed_bbox)
                         )
-                elif start_date or end_date or parsed_bbox or cloud_cover is not None:
+                elif (
+                    start_date
+                    or end_date
+                    or (parsed_bbox and bounds_collection is None)
+                    or cloud_cover is not None
+                ):
                     collection = filter_image_collection(
                         collection,
                         start_date=start_date,
                         end_date=end_date,
-                        bbox=parsed_bbox,
+                        bbox=None if bounds_collection is not None else parsed_bbox,
                         cloud_cover=cloud_cover,
                         cloud_property=cloud_property or "CLOUDY_PIXEL_PERCENTAGE",
                     )
+                if bounds_collection is not None and not is_dswx:
+                    collection = collection.filterBounds(bounds_collection)
                 if diagnose:
                     diagnostics["first_image_bands"] = _first_image_band_names(
                         collection
@@ -1506,6 +1586,16 @@ def gee_data_catalogs_tools(
                 if resolved_type == "ImageCollection" and parsed_bbox
                 else None
             )
+            bounds_filter = (
+                {
+                    "collection_asset_id": bounds_collection_asset_id,
+                    "filter_property": bounds_filter_property,
+                    "filter_value": bounds_filter_value,
+                    "method": "ImageCollection.filterBounds",
+                }
+                if bounds_collection_asset_id
+                else None
+            )
             if clip_collection is not None and resolved_type != "FeatureCollection":
                 ee_object = ee.Image(ee_object).clipToCollection(clip_collection)
 
@@ -1523,6 +1613,9 @@ def gee_data_catalogs_tools(
                 bbox=parsed_bbox,
                 cloud_cover=None if _is_opera_dswx(asset_id) else cloud_cover,
                 cloud_property=cloud_property,
+                bounds_collection_asset_id=bounds_collection_asset_id,
+                bounds_filter_property=bounds_filter_property,
+                bounds_filter_value=bounds_filter_value,
                 method=method if resolved_type == "ImageCollection" else None,
                 bands=bands,
                 min_value=min_value,
@@ -1560,7 +1653,7 @@ def gee_data_catalogs_tools(
                 zoom_result = _zoom_to_layer_area(
                     iface=iface,
                     layer=layer,
-                    bbox=parsed_bbox,
+                    bbox=bbox_filter,
                 )
             except Exception as exc:
                 try:
@@ -1580,6 +1673,7 @@ def gee_data_catalogs_tools(
                         "failure_stage": "qgis_layer_add",
                         "diagnostics": diagnostics,
                         "bbox": bbox_filter,
+                        "bounds": bounds_filter,
                         "earth_engine_python_snippet": earth_engine_python_snippet,
                         "composite_method": (
                             method if resolved_type == "ImageCollection" else None
@@ -1608,6 +1702,7 @@ def gee_data_catalogs_tools(
                 "rendered_band": rendered_band,
                 "diagnostics": diagnostics,
                 "bbox": bbox_filter,
+                "bounds": bounds_filter,
                 "zoom": zoom_result,
                 "earth_engine_python_snippet": earth_engine_python_snippet,
                 "vis_params": vis_params,
@@ -1642,6 +1737,9 @@ def gee_data_catalogs_tools(
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         bbox: Optional[str] = None,
+        bounds_collection_asset_id: Optional[str] = None,
+        bounds_filter_property: Optional[str] = None,
+        bounds_filter_value: Optional[str] = None,
         cloud_cover: Optional[int] = None,
         cloud_property: Optional[str] = None,
         reducer: str = "median",
@@ -1667,7 +1765,21 @@ def gee_data_catalogs_tools(
             asset_type: Optional explicit type: Image or ImageCollection.
             start_date: Optional ImageCollection start date in YYYY-MM-DD.
             end_date: Optional ImageCollection end date in YYYY-MM-DD.
-            bbox: Optional WGS84 west,south,east,north ImageCollection filter.
+            bbox: Optional WGS84 west,south,east,north ImageCollection
+                ``filterBounds`` region filter used when no
+                ``bounds_collection_asset_id`` is provided. When a bounds
+                FeatureCollection is provided, bbox is still used to zoom QGIS
+                after loading if it is already known.
+            bounds_collection_asset_id: Optional FeatureCollection asset id
+                used with ImageCollection ``filterBounds`` for regional index
+                display. Prefer this over bbox coordinates when a specific
+                FeatureCollection exists for the requested region.
+                Example: TIGER/2018/States.
+            bounds_filter_property: Optional property to filter the bounds
+                FeatureCollection before calling ``filterBounds``. Example:
+                NAME.
+            bounds_filter_value: Optional value for ``bounds_filter_property``.
+                Example: Tennessee.
             cloud_cover: Optional maximum cloud-cover value.
             cloud_property: Optional cloud-cover property name.
             reducer: ImageCollection compositing method: mosaic, median, mean,
@@ -1678,6 +1790,11 @@ def gee_data_catalogs_tools(
             palette: Optional comma-separated colors. Defaults by index type.
             clip_collection_asset_id: Optional FeatureCollection asset id used
                 to clip the index image with ``ee.Image.clipToCollection``.
+                Clipping is computationally intensive; only use this when the
+                user specifically asks to clip, crop, or mask data to the
+                region. For ordinary regional display, use
+                ``bounds_collection_asset_id`` when a specific
+                FeatureCollection exists, otherwise use ``bbox``.
             clip_filter_property: Optional property to filter the clipping
                 FeatureCollection before clipping. Example: NAME.
             clip_filter_value: Optional value for ``clip_filter_property``.
@@ -1711,7 +1828,17 @@ def gee_data_catalogs_tools(
                 )
 
             parsed_bbox = _parse_bbox(bbox)
+            bounds_collection = None
             clip_collection = None
+            if bounds_collection_asset_id:
+                bounds_collection = ee.FeatureCollection(bounds_collection_asset_id)
+                if bounds_filter_property and bounds_filter_value is not None:
+                    bounds_collection = bounds_collection.filter(
+                        ee.Filter.eq(
+                            bounds_filter_property,
+                            _coerce_filter_value(bounds_filter_value),
+                        )
+                    )
             if clip_collection_asset_id:
                 clip_collection = ee.FeatureCollection(clip_collection_asset_id)
                 if clip_filter_property and clip_filter_value is not None:
@@ -1724,15 +1851,22 @@ def gee_data_catalogs_tools(
 
             if resolved_type == "ImageCollection":
                 collection = ee.ImageCollection(asset_id)
-                if start_date or end_date or parsed_bbox or cloud_cover is not None:
+                if (
+                    start_date
+                    or end_date
+                    or (parsed_bbox and bounds_collection is None)
+                    or cloud_cover is not None
+                ):
                     collection = filter_image_collection(
                         collection,
                         start_date=start_date,
                         end_date=end_date,
-                        bbox=parsed_bbox,
+                        bbox=None if bounds_collection is not None else parsed_bbox,
                         cloud_cover=cloud_cover,
                         cloud_property=cloud_property or "CLOUDY_PIXEL_PERCENTAGE",
                     )
+                if bounds_collection is not None:
+                    collection = collection.filterBounds(bounds_collection)
                 method = _normalize_composite_method(reducer, default="median")
                 source_image = _composite_image_collection(collection, method)
                 resolved_type = "ImageCollection"
@@ -1763,6 +1897,9 @@ def gee_data_catalogs_tools(
                 bbox=parsed_bbox,
                 cloud_cover=cloud_cover,
                 cloud_property=cloud_property,
+                bounds_collection_asset_id=bounds_collection_asset_id,
+                bounds_filter_property=bounds_filter_property,
+                bounds_filter_value=bounds_filter_value,
                 method=method if resolved_type == "ImageCollection" else None,
                 positive_band=positive_band,
                 negative_band=negative_band,
@@ -1806,6 +1943,16 @@ def gee_data_catalogs_tools(
                 ),
                 "vis_params": vis_params,
                 "bbox": parsed_bbox,
+                "bounds": (
+                    {
+                        "collection_asset_id": bounds_collection_asset_id,
+                        "filter_property": bounds_filter_property,
+                        "filter_value": bounds_filter_value,
+                        "method": "ImageCollection.filterBounds",
+                    }
+                    if bounds_collection_asset_id
+                    else None
+                ),
                 "zoom": zoom_result,
                 "earth_engine_python_snippet": earth_engine_python_snippet,
                 "clip": (

--- a/geoagent/tools/gee_data_catalogs.py
+++ b/geoagent/tools/gee_data_catalogs.py
@@ -1500,7 +1500,11 @@ def gee_data_catalogs_tools(
                     diagnostics["bounds"] = {
                         "collection_asset_id": bounds_collection_asset_id,
                         "filter_property": bounds_filter_property,
-                        "filter_value": bounds_filter_value,
+                        "filter_value": (
+                            _coerce_filter_value(bounds_filter_value)
+                            if bounds_filter_value is not None
+                            else None
+                        ),
                         "method": "ImageCollection.filterBounds",
                     }
                 if is_dswx and cloud_cover is not None:
@@ -1590,10 +1594,14 @@ def gee_data_catalogs_tools(
                 {
                     "collection_asset_id": bounds_collection_asset_id,
                     "filter_property": bounds_filter_property,
-                    "filter_value": bounds_filter_value,
+                    "filter_value": (
+                        _coerce_filter_value(bounds_filter_value)
+                        if bounds_filter_value is not None
+                        else None
+                    ),
                     "method": "ImageCollection.filterBounds",
                 }
-                if bounds_collection_asset_id
+                if (resolved_type == "ImageCollection" and bounds_collection_asset_id)
                 else None
             )
             if clip_collection is not None and resolved_type != "FeatureCollection":
@@ -1947,10 +1955,17 @@ def gee_data_catalogs_tools(
                     {
                         "collection_asset_id": bounds_collection_asset_id,
                         "filter_property": bounds_filter_property,
-                        "filter_value": bounds_filter_value,
+                        "filter_value": (
+                            _coerce_filter_value(bounds_filter_value)
+                            if bounds_filter_value is not None
+                            else None
+                        ),
                         "method": "ImageCollection.filterBounds",
                     }
-                    if bounds_collection_asset_id
+                    if (
+                        resolved_type == "ImageCollection"
+                        and bounds_collection_asset_id
+                    )
                     else None
                 ),
                 "zoom": zoom_result,

--- a/tests/test_gee_data_catalogs_tools.py
+++ b/tests/test_gee_data_catalogs_tools.py
@@ -96,6 +96,10 @@ def test_gee_data_catalogs_prompt_mentions_generated_ee_snippets() -> None:
     assert "list_loaded_gee_layers" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
     assert "calculate_gee_layer_statistics" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
     assert "reduceRegion/getInfo" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "filterBounds" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "computationally intensive" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "specifically asks to clip" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
+    assert "bounds_collection_asset_id" in GEE_DATA_CATALOGS_SYSTEM_PROMPT
 
 
 def test_load_gee_dataset_clips_raster_to_feature_collection(monkeypatch) -> None:
@@ -410,6 +414,129 @@ def test_load_gee_dataset_filters_explicit_image_collection_bbox(
     assert "m.add_layer(image, vis_params" in result["earth_engine_python_snippet"]
     assert iface.canvas.extent == (-84.0, 35.0, -83.0, 36.0)
     assert result["diagnostics"]["bbox"] == [-84.0, 35.0, -83.0, 36.0]
+
+
+def test_load_gee_dataset_prefers_feature_collection_filter_bounds(
+    monkeypatch,
+) -> None:
+    """Verify regional display can filterBounds with a FeatureCollection."""
+
+    class _Canvas:
+        def __init__(self) -> None:
+            self.extent = None
+
+        def setExtent(self, extent) -> None:
+            self.extent = extent
+
+        def refresh(self) -> None:
+            pass
+
+    class _Iface:
+        def __init__(self) -> None:
+            self.canvas = _Canvas()
+
+        def mapCanvas(self) -> _Canvas:
+            return self.canvas
+
+    class _FakeFeatureCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.filters = []
+
+        def filter(self, filter_obj):
+            self.filters.append(filter_obj)
+            return self
+
+    class _FakeImage:
+        def __init__(self, collection) -> None:
+            self.collection = collection
+
+    class _FakeImageCollection:
+        def __init__(self, asset_id: str) -> None:
+            self.asset_id = asset_id
+            self.bounds_filter = None
+
+        def filterBounds(self, geometry):
+            self.bounds_filter = geometry
+            return self
+
+        def mosaic(self):
+            return _FakeImage(self)
+
+    class _FakeFilter:
+        @staticmethod
+        def eq(prop: str, value: object):
+            return ("eq", prop, value)
+
+    class _FakeLayer:
+        def isValid(self):
+            return True
+
+    ee_module = ModuleType("ee")
+    ee_module.Filter = _FakeFilter
+    ee_module.FeatureCollection = _FakeFeatureCollection
+    ee_module.ImageCollection = _FakeImageCollection
+
+    captured = {}
+
+    ee_utils = ModuleType("gee_data_catalogs.core.ee_utils")
+
+    def _add_ee_layer(obj, vis, name):
+        captured.update({"object": obj, "vis": vis, "name": name})
+        return _FakeLayer()
+
+    def _filter_image_collection(collection, **kwargs):
+        raise AssertionError("FeatureCollection filterBounds should not use bbox")
+
+    ee_utils.add_ee_layer = _add_ee_layer
+    ee_utils.detect_asset_type = lambda asset_id: "ImageCollection"
+    ee_utils.filter_image_collection = _filter_image_collection
+    ee_utils.initialize_ee = lambda project=None: None
+    ee_utils.is_ee_initialized = lambda: True
+
+    monkeypatch.setitem(sys.modules, "ee", ee_module)
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs", ModuleType("gee_data_catalogs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "gee_data_catalogs.core", ModuleType("gee_data_catalogs.core")
+    )
+    monkeypatch.setitem(sys.modules, "gee_data_catalogs.core.ee_utils", ee_utils)
+    monkeypatch.setitem(sys.modules, "qgis", None)
+
+    iface = _Iface()
+    tools = {t.tool_name: t for t in gee_data_catalogs_tools(iface)}
+    result = tools["load_gee_dataset"].__wrapped__(
+        "TEST/IMAGE_COLLECTION",
+        reducer="mosaic",
+        bbox="-84,35,-83,36",
+        bounds_collection_asset_id="TIGER/2018/States",
+        bounds_filter_property="NAME",
+        bounds_filter_value="Tennessee",
+    )
+
+    bounds_fc = captured["object"].collection.bounds_filter
+    snippet = result["earth_engine_python_snippet"]
+    assert result["success"] is True
+    assert result["bounds"] == {
+        "collection_asset_id": "TIGER/2018/States",
+        "filter_property": "NAME",
+        "filter_value": "Tennessee",
+        "method": "ImageCollection.filterBounds",
+    }
+    assert result["bbox"] == [-84.0, 35.0, -83.0, 36.0]
+    assert bounds_fc.asset_id == "TIGER/2018/States"
+    assert bounds_fc.filters == [("eq", "NAME", "Tennessee")]
+    assert "bounds_fc = ee.FeatureCollection('TIGER/2018/States')" in snippet
+    assert "collection = collection.filterBounds(bounds_fc)" in snippet
+    assert "ee.Geometry.Rectangle(bbox)" not in snippet
+    assert "clipToCollection" not in snippet
+    assert result["zoom"] == {
+        "success": True,
+        "target": "bbox",
+        "bbox": [-84.0, 35.0, -83.0, 36.0],
+    }
+    assert iface.canvas.extent == (-84.0, 35.0, -83.0, 36.0)
 
 
 def test_load_gee_dataset_renders_opera_dswx_hls_with_valid_band_and_mode(


### PR DESCRIPTION
## Summary
- Adds `bounds_collection_asset_id`, `bounds_filter_property`, and `bounds_filter_value` parameters to `load_gee_dataset` and `calculate_gee_normalized_difference` so ImageCollections can be filtered to a region via `ImageCollection.filterBounds` with a FeatureCollection (e.g. `TIGER/2018/States` with `NAME=Tennessee`).
- Updates the GEE catalogs system prompt to steer the agent toward `filterBounds` for ordinary regional display and to reserve `clipToCollection` for cases where the user explicitly asks to clip, crop, or mask data, since clipping is computationally expensive on Earth Engine.
- Generated reproducible Earth Engine snippets and tool result payloads now include the bounds FeatureCollection so the displayed code matches what the tool actually executed.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_gee_data_catalogs_tools.py::test_load_gee_dataset_prefers_feature_collection_filter_bounds`
- [ ] CI green on the rest of the suite