### PR TITLE
feat: add ChatGPT/Codex OAuth login for Python sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ CLAUDE.md
 .firecrawl/
 .codex
 *.zip
+docs/examples/codex_example_map.png

--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ specified:
 ChatGPT/Codex OAuth uses the Codex browser login flow and the Codex Responses
 backend.
 
+For notebooks and Python scripts, log in once with the CLI:
+
+```bash
+geoagent codex login
+```
+
+or from Python/Jupyter:
+
+```python
+from geoagent import login_openai_codex
+
+login_openai_codex()
+```
+
+GeoAgent stores the refresh token in your user config directory and exports
+`OPENAI_CODEX_ACCESS_TOKEN` for the current Python process. Later sessions can
+reuse the stored login automatically, or explicitly call:
+
+```python
+from geoagent import ensure_openai_codex_environment
+
+ensure_openai_codex_environment()
+```
+
 You can also configure providers explicitly:
 
 ```python
@@ -350,6 +374,7 @@ so small prompts may not show a large timing difference on every provider.
 Runnable notebooks live under `docs/examples/`:
 
 - `docs/examples/intro.ipynb` — basic GeoAgent usage.
+- `docs/examples/openai_codex.ipynb` — ChatGPT/Codex OAuth in Python/Jupyter.
 - `docs/examples/live_mapping.ipynb` — live map workflow.
 - `docs/examples/qgis_agent.ipynb` — QGIS-oriented workflow using mocks.
 - `examples/nasa_opera_qgis.py` — NASA OPERA workflow for QGIS.

--- a/docs/examples/openai_codex.ipynb
+++ b/docs/examples/openai_codex.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# GeoAgent + ChatGPT/Codex OAuth\n",
+    "\n",
+    "This notebook uses the same ChatGPT/Codex OAuth flow as the QGIS plugin, but stores the login in GeoAgent's user config directory for regular Python and Jupyter sessions.\n",
+    "\n",
+    "- Install: `pip install \"GeoAgent[openai]\"`.\n",
+    "- Run the login cell once. Later notebooks can reuse the stored login automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"GeoAgent[openai]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import ensure_openai_codex_environment\n",
+    "from geoagent import login_openai_codex\n",
+    "\n",
+    "try:\n",
+    "    ensure_openai_codex_environment()\n",
+    "    print(\"Using stored ChatGPT/Codex login.\")\n",
+    "except RuntimeError:\n",
+    "    login_openai_codex()\n",
+    "    print(\"Logged in with ChatGPT/Codex OAuth.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "MODEL = os.environ.get(\"OPENAI_CODEX_MODEL\", \"gpt-5.5\")\n",
+    "print(\"Using model:\", MODEL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import GeoAgent, GeoAgentConfig\n",
+    "\n",
+    "agent = GeoAgent(\n",
+    "    config=GeoAgentConfig(\n",
+    "        provider=\"openai-codex\",\n",
+    "        model=MODEL,\n",
+    "        temperature=0.0,\n",
+    "        max_tokens=2048,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "resp = agent.chat(\"In one sentence, what is GeoAgent useful for?\")\n",
+    "print(\"success:\", resp.success)\n",
+    "print(resp.answer_text)\n",
+    "print(\"executed_tools:\", resp.executed_tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Leafmap Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"GeoAgent[leafmap]\" leafmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap.maplibregl as leafmap\n",
+    "from geoagent import for_leafmap\n",
+    "\n",
+    "m = leafmap.Map(center=[-83.92, 35.96], zoom=9, height=\"520px\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "map_agent = for_leafmap(\n",
+    "    m,\n",
+    "    provider=\"openai-codex\",\n",
+    "    model_id=MODEL,\n",
+    "    fast=True,\n",
+    ")\n",
+    "\n",
+    "resp = map_agent.chat(\"Using the current map state, describe the map center and zoom.\")\n",
+    "print(resp.answer_text)\n",
+    "print(\"tools:\", resp.executed_tools)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qgis",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/openai_codex.ipynb
+++ b/docs/examples/openai_codex.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q \"GeoAgent[openai]\""
+    "# %pip install -q \"GeoAgent[openai]\""
    ]
   },
   {
@@ -83,7 +83,7 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "## Leafmap Example"
+    "## Image Example"
    ]
   },
   {
@@ -93,13 +93,88 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q \"GeoAgent[leafmap]\" leafmap"
+    "# %pip install -q pillow"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from IPython.display import Image, display\n",
+    "from PIL import Image as PILImage\n",
+    "from PIL import ImageDraw\n",
+    "\n",
+    "image_path = Path(\"codex_example_map.png\")\n",
+    "img = PILImage.new(\"RGB\", (640, 360), \"#dce9f2\")\n",
+    "draw = ImageDraw.Draw(img)\n",
+    "draw.rectangle((0, 235, 640, 360), fill=\"#6fbf73\")\n",
+    "draw.polygon([(0, 90), (190, 70), (310, 160), (0, 230)], fill=\"#8ccf6a\")\n",
+    "draw.polygon([(430, 45), (640, 25), (640, 230), (520, 205)], fill=\"#7db56f\")\n",
+    "draw.line(\n",
+    "    [(70, 0), (120, 80), (170, 140), (230, 210), (330, 360)],\n",
+    "    fill=\"#3d7fbf\",\n",
+    "    width=18,\n",
+    ")\n",
+    "draw.ellipse((100, 95, 140, 135), fill=\"#e84d4d\")\n",
+    "draw.ellipse((455, 155, 495, 195), fill=\"#f2c94c\")\n",
+    "draw.text((32, 28), \"Synthetic map image\", fill=\"#1f2937\")\n",
+    "draw.text((145, 105), \"site A\", fill=\"#1f2937\")\n",
+    "draw.text((500, 165), \"site B\", fill=\"#1f2937\")\n",
+    "img.save(image_path)\n",
+    "display(Image(filename=str(image_path)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_bytes = image_path.read_bytes()\n",
+    "resp = agent.chat(\n",
+    "    [\n",
+    "        {\n",
+    "            \"text\": \"Describe this map-like image. Identify the labeled sites, water, and land cover.\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"image\": {\n",
+    "                \"format\": \"png\",\n",
+    "                \"source\": {\"bytes\": image_bytes},\n",
+    "            }\n",
+    "        },\n",
+    "    ]\n",
+    ")\n",
+    "print(resp.answer_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Leafmap Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -q \"GeoAgent[leafmap]\" leafmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +207,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "qgis",
+   "display_name": "geo",
    "language": "python",
    "name": "python3"
   },
@@ -146,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,25 @@
 # Usage
 
+## ChatGPT/Codex Login
+
+For notebooks and Python scripts, run the browser login once:
+
+```bash
+geoagent codex login
+```
+
+or start the same flow from Jupyter:
+
+```python
+from geoagent import login_openai_codex
+
+login_openai_codex()
+```
+
+GeoAgent saves the refresh token in your user config directory, exports
+`OPENAI_CODEX_ACCESS_TOKEN` for the current process, and refreshes the stored
+login automatically when `provider="openai-codex"` is used later.
+
 ```python
 from geoagent import GeoAgent, for_leafmap, GeoAgentConfig
 

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -13,6 +13,13 @@ from geoagent.core.decorators import (
     stamp_geo_meta,
 )
 from geoagent.core.model import get_default_model, get_llm, resolve_model
+from geoagent.core.openai_codex import (
+    clear_token_payload as clear_openai_codex_token,
+    ensure_openai_codex_environment,
+    is_openai_codex_logged_in,
+    load_token_payload as load_openai_codex_token,
+    login_openai_codex,
+)
 from geoagent.core.result import GeoAgentResponse
 from geoagent.core.safety import (
     ConfirmCallback,
@@ -62,4 +69,9 @@ __all__ = [
     "resolve_model",
     "get_llm",
     "get_default_model",
+    "login_openai_codex",
+    "ensure_openai_codex_environment",
+    "load_openai_codex_token",
+    "clear_openai_codex_token",
+    "is_openai_codex_logged_in",
 ]

--- a/geoagent/cli.py
+++ b/geoagent/cli.py
@@ -65,11 +65,15 @@ def _run_codex_status(args: argparse.Namespace) -> int:
     expires_at = payload.get("expires_at")
     status = "expires soon" if token_expires_soon(expires_at) else "valid"
     if expires_at:
-        expiry = time.strftime(
-            "%Y-%m-%d %H:%M:%S %Z",
-            time.localtime(float(expires_at)),
-        )
-        print(f"Logged in ({status}); token expires at {expiry}")
+        try:
+            expiry = time.strftime(
+                "%Y-%m-%d %H:%M:%S %Z",
+                time.localtime(float(expires_at)),
+            )
+        except (TypeError, ValueError, OverflowError):
+            print(f"Logged in ({status}); token expiry is unknown")
+        else:
+            print(f"Logged in ({status}); token expires at {expiry}")
     else:
         print(f"Logged in ({status}); token expiry is unknown")
     return 0

--- a/geoagent/cli.py
+++ b/geoagent/cli.py
@@ -1,15 +1,17 @@
 """GeoAgent CLI.
 
 Commands:
-  geoagent ui        Launch the Solara UI
-  geoagent --help    Show help
+  geoagent ui              Launch the Solara UI
+  geoagent codex login     Login with ChatGPT/Codex OAuth
+  geoagent --help          Show help
 """
 
 from __future__ import annotations
 
 import argparse
-import sys
 import subprocess
+import sys
+import time
 
 
 def _run_solara_app() -> int:
@@ -28,6 +30,60 @@ def _run_solara_app() -> int:
         return 1
 
 
+def _run_codex_login(args: argparse.Namespace) -> int:
+    """Run the ChatGPT/Codex OAuth login flow."""
+    try:
+        from geoagent.core.openai_codex import default_token_file, login_openai_codex
+
+        login_openai_codex(
+            open_browser=not args.no_browser,
+            timeout_seconds=args.timeout,
+            token_file=args.token_file,
+        )
+        print(f"Saved Codex login to {args.token_file or default_token_file()}")
+        return 0
+    except Exception as exc:
+        print(f"Codex login failed: {exc}")
+        return 1
+
+
+def _run_codex_status(args: argparse.Namespace) -> int:
+    """Print local ChatGPT/Codex OAuth status."""
+    try:
+        from geoagent.core.openai_codex import (
+            default_token_file,
+            load_token_payload,
+            token_expires_soon,
+        )
+
+        path = args.token_file or default_token_file()
+        payload = load_token_payload(token_file=path)
+    except Exception as exc:
+        print(f"Not logged in: {exc}")
+        return 1
+
+    expires_at = payload.get("expires_at")
+    status = "expires soon" if token_expires_soon(expires_at) else "valid"
+    if expires_at:
+        expiry = time.strftime(
+            "%Y-%m-%d %H:%M:%S %Z",
+            time.localtime(float(expires_at)),
+        )
+        print(f"Logged in ({status}); token expires at {expiry}")
+    else:
+        print(f"Logged in ({status}); token expiry is unknown")
+    return 0
+
+
+def _run_codex_logout(args: argparse.Namespace) -> int:
+    """Remove the local ChatGPT/Codex OAuth token file."""
+    from geoagent.core.openai_codex import clear_token_payload
+
+    clear_token_payload(token_file=args.token_file)
+    print("Removed local Codex login.")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the script entry point."""
     parser = argparse.ArgumentParser(
@@ -37,11 +93,65 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", metavar="command")
 
     subparsers.add_parser("ui", help="Launch the Solara UI")
+    codex_parser = subparsers.add_parser(
+        "codex",
+        help="Manage ChatGPT/Codex OAuth login",
+    )
+    codex_subparsers = codex_parser.add_subparsers(
+        dest="codex_command",
+        metavar="command",
+    )
+
+    codex_login = codex_subparsers.add_parser(
+        "login",
+        help="Login with ChatGPT/Codex OAuth",
+    )
+    codex_login.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Print the login URL instead of opening a browser",
+    )
+    codex_login.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Seconds to wait for the browser callback",
+    )
+    codex_login.add_argument(
+        "--token-file",
+        help="Override the local token file path",
+    )
+    codex_login.set_defaults(func=_run_codex_login)
+
+    codex_status = codex_subparsers.add_parser(
+        "status",
+        help="Show local ChatGPT/Codex OAuth status",
+    )
+    codex_status.add_argument(
+        "--token-file",
+        help="Override the local token file path",
+    )
+    codex_status.set_defaults(func=_run_codex_status)
+
+    codex_logout = codex_subparsers.add_parser(
+        "logout",
+        help="Remove the local ChatGPT/Codex OAuth token",
+    )
+    codex_logout.add_argument(
+        "--token-file",
+        help="Override the local token file path",
+    )
+    codex_logout.set_defaults(func=_run_codex_logout)
 
     args = parser.parse_args(argv)
 
     if args.command == "ui":
         return _run_solara_app()
+    if args.command == "codex":
+        if hasattr(args, "func"):
+            return args.func(args)
+        codex_parser.print_help()
+        return 0
 
     # No command: show help
     parser.print_help()

--- a/geoagent/core/__init__.py
+++ b/geoagent/core/__init__.py
@@ -3,6 +3,17 @@
 from geoagent.core.agent import GeoAgent
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext
+from geoagent.core.openai_codex import (
+    ensure_openai_codex_environment,
+    login_openai_codex,
+)
 from geoagent.core.result import GeoAgentResponse
 
-__all__ = ["GeoAgent", "GeoAgentConfig", "GeoAgentContext", "GeoAgentResponse"]
+__all__ = [
+    "GeoAgent",
+    "GeoAgentConfig",
+    "GeoAgentContext",
+    "GeoAgentResponse",
+    "ensure_openai_codex_environment",
+    "login_openai_codex",
+]

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -175,7 +175,7 @@ class GeoAgent:
 
     def chat(
         self,
-        query: str,
+        query: Any,
         target_map: Any = None,
     ) -> GeoAgentResponse:
         """Run a single user turn and return a :class:`GeoAgentResponse`."""
@@ -224,7 +224,7 @@ class GeoAgent:
 
         return self._chat_impl(query)
 
-    def _chat_impl(self, query: str) -> GeoAgentResponse:
+    def _chat_impl(self, query: Any) -> GeoAgentResponse:
         """Run a single user turn on the current thread."""
         self._cancelled.clear()
         self._tool_calls.clear()
@@ -259,7 +259,7 @@ class GeoAgent:
                 map=self._context.map_obj,
             )
 
-    def _chat_on_qgis_gui_thread(self, query: str) -> GeoAgentResponse:
+    def _chat_on_qgis_gui_thread(self, query: Any) -> GeoAgentResponse:
         """Run sync QGIS chat without starving the Qt event loop.
 
         QGIS users often call ``resp = agent.chat(...)`` from the Python
@@ -298,7 +298,7 @@ class GeoAgent:
 
     def chat_in_background(
         self,
-        query: str,
+        query: Any,
         *,
         target_map: Any = None,
         on_result: Any | None = None,

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -49,6 +49,14 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         api_key = client_args.get("api_key") or os.environ.get(
             "OPENAI_CODEX_ACCESS_TOKEN"
         )
+        if not api_key:
+            try:
+                from geoagent.core.openai_codex import ensure_openai_codex_environment
+
+                ensure_openai_codex_environment()
+                api_key = os.environ.get("OPENAI_CODEX_ACCESS_TOKEN")
+            except RuntimeError:
+                api_key = ""
         base_url = (
             client_args.get("base_url")
             or cfg.openai_codex_base_url
@@ -59,7 +67,8 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         if not api_key:
             raise ValueError(
                 "OpenAI Codex provider requires a ChatGPT OAuth access token. "
-                "Login from OpenGeoAgent settings or set OPENAI_CODEX_ACCESS_TOKEN."
+                "Run `geoagent codex login`, call `geoagent.login_openai_codex()`, "
+                "or set OPENAI_CODEX_ACCESS_TOKEN."
             )
         client_args["api_key"] = api_key
         client_args["base_url"] = base_url

--- a/geoagent/core/openai_codex.py
+++ b/geoagent/core/openai_codex.py
@@ -1,0 +1,496 @@
+"""ChatGPT/Codex OAuth helpers for Python scripts and notebooks."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import stat
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+OPENAI_CODEX_AUTHORIZATION_URL = "https://auth.openai.com/oauth/authorize"
+# Public OAuth endpoint URL, not a credential.
+OPENAI_CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"  # nosec B105
+OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_SCOPE = "openid profile email offline_access"
+OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+OPENAI_CODEX_CALLBACK_PORT = 1455
+OPENAI_CODEX_CALLBACK_PATH = "/auth/callback"
+OPENAI_CODEX_AUTH_EXTRA_PARAMS = {  # nosec B105
+    "id_token_add_organizations": "true",
+    "codex_cli_simplified_flow": "true",
+    "originator": "pi",
+}
+REFRESH_SKEW_SECONDS = 300
+TOKEN_FILE_ENV = "GEOAGENT_CODEX_TOKEN_FILE"
+
+
+@dataclass
+class OAuthLoopbackFlow:
+    """Pending localhost callback flow."""
+
+    authorization_url: str
+    redirect_uri: str
+    state: str
+    code_verifier: str
+    server: HTTPServer
+    collector: dict[str, Any]
+
+
+def default_token_file() -> Path:
+    """Return the default file used for non-QGIS Codex OAuth token storage."""
+    override = os.environ.get(TOKEN_FILE_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    if os.name == "nt":
+        root = Path(os.environ.get("APPDATA") or Path.home() / "AppData" / "Roaming")
+    else:
+        root = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+    return root / "geoagent" / "openai_codex_oauth.json"
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return an OAuth PKCE verifier and S256 challenge."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def generate_state() -> str:
+    """Return a cryptographically random OAuth state value."""
+    return secrets.token_urlsafe(32)
+
+
+def token_expires_soon(
+    expires_at: float | int | str | None,
+    *,
+    now: float | None = None,
+    skew_seconds: int = REFRESH_SKEW_SECONDS,
+) -> bool:
+    """Return True when a token is missing or near expiry."""
+    if not expires_at:
+        return True
+    try:
+        expiry = float(expires_at)
+    except (TypeError, ValueError):
+        return True
+    current = time.time() if now is None else now
+    return expiry <= current + skew_seconds
+
+
+def decode_jwt_payload(token: str) -> dict[str, Any]:
+    """Decode an unsigned JWT payload for local claim extraction."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        data = base64.urlsafe_b64decode((payload + padding).encode("ascii"))
+        decoded = json.loads(data.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def extract_chatgpt_account_id(token_payload: dict[str, Any]) -> str:
+    """Extract the ChatGPT account id from OAuth token claims when present."""
+    for token_key in ("access_token", "id_token"):
+        claims = decode_jwt_payload(str(token_payload.get(token_key, "")))
+        direct = claims.get("https://api.openai.com/auth.chatgpt_account_id")
+        if isinstance(direct, str) and direct.strip():
+            return direct.strip()
+        auth_claim = claims.get("https://api.openai.com/auth")
+        if isinstance(auth_claim, dict):
+            nested = auth_claim.get("chatgpt_account_id")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+        for fallback_key in ("chatgpt_account_id", "account_id"):
+            fallback = claims.get(fallback_key)
+            if isinstance(fallback, str) and fallback.strip():
+                return fallback.strip()
+    return ""
+
+
+def build_authorization_url(
+    authorization_url: str,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    scope: str = "",
+    extra_params: dict[str, str] | None = None,
+) -> str:
+    """Build an OAuth authorization-code URL with PKCE parameters."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    if scope:
+        params["scope"] = scope
+    if extra_params:
+        params.update(extra_params)
+    separator = "&" if urllib.parse.urlparse(authorization_url).query else "?"
+    return authorization_url + separator + urllib.parse.urlencode(params)
+
+
+def extract_authorization_code(callback_url: str, expected_state: str) -> str:
+    """Validate a callback URL and return its authorization code."""
+    parsed = urllib.parse.urlparse(callback_url)
+    query = urllib.parse.parse_qs(parsed.query)
+    state = query.get("state", [""])[0]
+    if state != expected_state:
+        raise ValueError("OAuth callback state did not match the login request.")
+    error = query.get("error", [""])[0]
+    if error:
+        description = query.get("error_description", [""])[0]
+        raise ValueError(description or f"OAuth authorization failed: {error}")
+    code = query.get("code", [""])[0]
+    if not code:
+        raise ValueError("OAuth callback did not include an authorization code.")
+    return code
+
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Capture a single OAuth callback."""
+
+    def do_GET(self):  # noqa: N802
+        """Handle the OAuth redirect."""
+        collector = self.server.collector  # type: ignore[attr-defined]
+        collector["url"] = f"http://127.0.0.1:{self.server.server_port}{self.path}"
+        body = (
+            "<html><body><h3>GeoAgent login complete</h3>"
+            "<p>You can close this browser tab and return to Python.</p>"
+            "</body></html>"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002
+        """Suppress callback server logging."""
+        return
+
+
+def start_loopback_flow(
+    authorization_url: str = OPENAI_CODEX_AUTHORIZATION_URL,
+    *,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    scope: str = OPENAI_CODEX_SCOPE,
+    bind_host: str = "127.0.0.1",
+    redirect_host: str = "localhost",
+    port: int = OPENAI_CODEX_CALLBACK_PORT,
+    callback_path: str = OPENAI_CODEX_CALLBACK_PATH,
+    extra_params: dict[str, str] | None = None,
+    fallback_port: bool = False,
+) -> OAuthLoopbackFlow:
+    """Start a localhost callback server and return the pending OAuth flow."""
+    verifier, challenge = generate_pkce_pair()
+    state = generate_state()
+    collector: dict[str, Any] = {}
+    try:
+        server = HTTPServer((bind_host, port), _OAuthCallbackHandler)
+    except OSError as exc:
+        if port == 0 or not fallback_port:
+            if port:
+                raise RuntimeError(
+                    f"OAuth callback port {port} is not available."
+                ) from exc
+            raise
+        server = HTTPServer((bind_host, 0), _OAuthCallbackHandler)
+    server.timeout = 1
+    server.collector = collector  # type: ignore[attr-defined]
+    if not callback_path.startswith("/"):
+        callback_path = "/" + callback_path
+    redirect_uri = f"http://{redirect_host}:{server.server_port}{callback_path}"
+    url = build_authorization_url(
+        authorization_url,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=challenge,
+        state=state,
+        scope=scope,
+        extra_params=extra_params or OPENAI_CODEX_AUTH_EXTRA_PARAMS,
+    )
+    return OAuthLoopbackFlow(url, redirect_uri, state, verifier, server, collector)
+
+
+def complete_loopback_flow(
+    flow: OAuthLoopbackFlow,
+    *,
+    token_url: str = OPENAI_CODEX_TOKEN_URL,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    timeout_seconds: int = 180,
+) -> dict[str, Any]:
+    """Wait for the browser callback and exchange the code for tokens."""
+    deadline = time.time() + timeout_seconds
+    try:
+        while time.time() < deadline and "url" not in flow.collector:
+            flow.server.handle_request()
+        if "url" not in flow.collector:
+            raise TimeoutError("Timed out waiting for the OAuth browser callback.")
+        code = extract_authorization_code(flow.collector["url"], flow.state)
+        return exchange_authorization_code(
+            token_url,
+            client_id=client_id,
+            code=code,
+            redirect_uri=flow.redirect_uri,
+            code_verifier=flow.code_verifier,
+        )
+    finally:
+        flow.server.server_close()
+
+
+def _post_form(url: str, data: dict[str, str]) -> dict[str, Any]:
+    """POST URL-encoded form data and return decoded JSON."""
+    encoded = urllib.parse.urlencode(data).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=encoded,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"OAuth token request failed: {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"OAuth token request failed: {exc}") from exc
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("OAuth token endpoint did not return JSON.") from exc
+
+
+def _normalize_token_response(response: dict[str, Any]) -> dict[str, Any]:
+    """Validate and add an absolute expiry timestamp to a token response."""
+    access_token = str(response.get("access_token", "")).strip()
+    if not access_token:
+        raise RuntimeError("OAuth token endpoint did not return an access token.")
+    normalized = dict(response)
+    try:
+        expires_in = int(normalized.get("expires_in", 3600))
+    except (TypeError, ValueError):
+        expires_in = 3600
+    normalized["expires_at"] = int(time.time()) + max(expires_in, 0)
+    normalized["token_type"] = str(normalized.get("token_type") or "Bearer")
+    account_id = extract_chatgpt_account_id(normalized)
+    if account_id:
+        normalized["account_id"] = account_id
+    return normalized
+
+
+def exchange_authorization_code(
+    token_url: str,
+    *,
+    client_id: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    """Exchange an authorization code for an OAuth token payload."""
+    response = _post_form(
+        token_url,
+        {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        },
+    )
+    return _normalize_token_response(response)
+
+
+def refresh_oauth_token(
+    token_url: str = OPENAI_CODEX_TOKEN_URL,
+    *,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    refresh_token: str,
+    scope: str = OPENAI_CODEX_SCOPE,
+) -> dict[str, Any]:
+    """Refresh an OAuth access token."""
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "refresh_token": refresh_token,
+    }
+    if scope:
+        data["scope"] = scope
+    response = _post_form(token_url, data)
+    normalized = _normalize_token_response(response)
+    if "refresh_token" not in normalized:
+        normalized["refresh_token"] = refresh_token
+    return normalized
+
+
+def save_token_payload(
+    token_payload: dict[str, Any],
+    *,
+    token_file: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Store Codex OAuth tokens in a local user-only JSON file."""
+    path = (
+        Path(token_file).expanduser()
+        if token_file is not None
+        else default_token_file()
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(token_payload, indent=2, sort_keys=True)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as file:
+        file.write(payload)
+        file.write("\n")
+    try:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+    return path
+
+
+def load_token_payload(
+    *,
+    token_file: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Load the locally stored Codex OAuth token payload."""
+    path = (
+        Path(token_file).expanduser()
+        if token_file is not None
+        else default_token_file()
+    )
+    if not path.exists():
+        raise RuntimeError(
+            "OpenAI Codex is not logged in. Run `geoagent codex login` or call "
+            "`geoagent.login_openai_codex()` first."
+        )
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Stored Codex token file is invalid: {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Stored Codex token file is invalid: {path}")
+    return payload
+
+
+def clear_token_payload(
+    *,
+    token_file: str | os.PathLike[str] | None = None,
+) -> None:
+    """Remove the locally stored Codex OAuth token payload."""
+    path = (
+        Path(token_file).expanduser()
+        if token_file is not None
+        else default_token_file()
+    )
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def export_openai_codex_environment(
+    token_payload: dict[str, Any],
+    *,
+    base_url: str | None = None,
+) -> None:
+    """Export token payload values to environment variables for model creation."""
+    access_token = str(token_payload.get("access_token", "")).strip()
+    if not access_token:
+        raise RuntimeError("Stored OpenAI Codex token payload has no access token.")
+    os.environ["OPENAI_CODEX_ACCESS_TOKEN"] = access_token
+    os.environ["OPENAI_CODEX_BASE_URL"] = (
+        base_url or os.environ.get("OPENAI_CODEX_BASE_URL") or OPENAI_CODEX_BASE_URL
+    )
+    account_id = str(token_payload.get("account_id", "")).strip()
+    if not account_id:
+        account_id = extract_chatgpt_account_id(token_payload)
+    if account_id:
+        os.environ["OPENAI_CODEX_ACCOUNT_ID"] = account_id
+
+
+def ensure_openai_codex_environment(
+    *,
+    token_file: str | os.PathLike[str] | None = None,
+    refresh: bool = True,
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    """Load or refresh Codex OAuth tokens and export env vars for GeoAgent."""
+    env_token = os.environ.get("OPENAI_CODEX_ACCESS_TOKEN", "").strip()
+    if env_token:
+        payload = {"access_token": env_token}
+        account_id = os.environ.get("OPENAI_CODEX_ACCOUNT_ID", "").strip()
+        if account_id:
+            payload["account_id"] = account_id
+        export_openai_codex_environment(payload, base_url=base_url)
+        return payload
+
+    payload = load_token_payload(token_file=token_file)
+    if refresh and token_expires_soon(payload.get("expires_at")):
+        refresh_token = str(payload.get("refresh_token", "")).strip()
+        if not refresh_token:
+            raise RuntimeError(
+                "OpenAI Codex token expired and no refresh token is stored. "
+                "Run `geoagent codex login` again."
+            )
+        payload = refresh_oauth_token(refresh_token=refresh_token)
+        save_token_payload(payload, token_file=token_file)
+    export_openai_codex_environment(payload, base_url=base_url)
+    return payload
+
+
+def login_openai_codex(
+    *,
+    open_browser: bool = True,
+    timeout_seconds: int = 180,
+    token_file: str | os.PathLike[str] | None = None,
+    save: bool = True,
+    set_environment: bool = True,
+) -> dict[str, Any]:
+    """Run the ChatGPT/Codex browser login flow for scripts or notebooks."""
+    flow = start_loopback_flow()
+    if open_browser:
+        opened = webbrowser.open(flow.authorization_url)
+        if not opened:
+            print("Open this URL to finish ChatGPT login:")
+            print(flow.authorization_url)
+    else:
+        print("Open this URL to finish ChatGPT login:")
+        print(flow.authorization_url)
+    payload = complete_loopback_flow(flow, timeout_seconds=timeout_seconds)
+    if save:
+        save_token_payload(payload, token_file=token_file)
+    if set_environment:
+        export_openai_codex_environment(payload)
+    return payload
+
+
+def is_openai_codex_logged_in(
+    *,
+    token_file: str | os.PathLike[str] | None = None,
+) -> bool:
+    """Return True when a local Codex OAuth token payload exists."""
+    try:
+        payload = load_token_payload(token_file=token_file)
+    except RuntimeError:
+        return False
+    return bool(str(payload.get("access_token", "")).strip())

--- a/geoagent/core/openai_codex.py
+++ b/geoagent/core/openai_codex.py
@@ -99,7 +99,7 @@ def decode_jwt_payload(token: str) -> dict[str, Any]:
     try:
         data = base64.urlsafe_b64decode((payload + padding).encode("ascii"))
         decoded = json.loads(data.decode("utf-8"))
-    except (ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         return {}
     return decoded if isinstance(decoded, dict) else {}
 
@@ -355,16 +355,30 @@ def save_token_payload(
         if token_file is not None
         else default_token_file()
     )
+    if path.is_symlink():
+        raise RuntimeError(f"Refusing to write Codex tokens through a symlink: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(token_payload, indent=2, sort_keys=True)
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as file:
-        file.write(payload)
-        file.write("\n")
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(tmp_path, flags, 0o600)
     try:
-        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-    except OSError:
-        pass
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(payload)
+            file.write("\n")
+        try:
+            tmp_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
     return path
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
     - Contributing: contributing.md
     - Examples:
         - examples/intro.ipynb
+        - examples/openai_codex.ipynb
         - examples/live_mapping.ipynb
         - examples/qgis_agent.ipynb
     - API Reference:
@@ -96,4 +97,3 @@ nav:
         - System Prompts: prompts.md
         - Tools: tools.md
         - Web UI: ui.md
-

--- a/scripts/write_example_notebooks.py
+++ b/scripts/write_example_notebooks.py
@@ -10,27 +10,45 @@ try:
     import nbformat
     from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
 except ModuleNotFoundError:
+    _cell_id_counter = 0
+
+    def _next_cell_id() -> str:
+        """Return a stable synthetic notebook cell id."""
+        global _cell_id_counter
+        cell_id = str(_cell_id_counter)
+        _cell_id_counter += 1
+        return cell_id
+
+    def _source_lines(source: str) -> list[str]:
+        """Return nbformat-style source lines."""
+        return source.splitlines(keepends=True) or [""]
 
     def new_code_cell(source: str) -> dict:
         """Return a minimal Jupyter code cell."""
         return {
             "cell_type": "code",
             "execution_count": None,
+            "id": _next_cell_id(),
             "metadata": {},
             "outputs": [],
-            "source": source,
+            "source": _source_lines(source),
         }
 
     def new_markdown_cell(source: str) -> dict:
         """Return a minimal Jupyter markdown cell."""
         return {
             "cell_type": "markdown",
+            "id": _next_cell_id(),
             "metadata": {},
-            "source": source,
+            "source": _source_lines(source),
         }
 
     def new_notebook(*, metadata: dict, cells: list[dict]) -> dict:
         """Return a minimal Jupyter notebook document."""
+        global _cell_id_counter
+        for index, cell in enumerate(cells):
+            cell["id"] = str(index)
+        _cell_id_counter = 0
         return {
             "cells": cells,
             "metadata": metadata,
@@ -298,6 +316,56 @@ def main() -> None:
                 "print(resp.answer_text)\n"
                 'print("executed_tools:", resp.executed_tools)'
             ),
+            new_markdown_cell("## Image Example"),
+            new_code_cell("%pip install -q pillow"),
+            new_code_cell(
+                "from pathlib import Path\n"
+                "\n"
+                "from IPython.display import Image, display\n"
+                "from PIL import Image as PILImage\n"
+                "from PIL import ImageDraw\n"
+                "\n"
+                'image_path = Path("codex_example_map.png")\n'
+                'img = PILImage.new("RGB", (640, 360), "#dce9f2")\n'
+                "draw = ImageDraw.Draw(img)\n"
+                'draw.rectangle((0, 235, 640, 360), fill="#6fbf73")\n'
+                "draw.polygon(\n"
+                '    [(0, 90), (190, 70), (310, 160), (0, 230)], fill="#8ccf6a"\n'
+                ")\n"
+                "draw.polygon(\n"
+                '    [(430, 45), (640, 25), (640, 230), (520, 205)], fill="#7db56f"\n'
+                ")\n"
+                "draw.line(\n"
+                "    [(70, 0), (120, 80), (170, 140), (230, 210), (330, 360)],\n"
+                '    fill="#3d7fbf",\n'
+                "    width=18,\n"
+                ")\n"
+                'draw.ellipse((100, 95, 140, 135), fill="#e84d4d")\n'
+                'draw.ellipse((455, 155, 495, 195), fill="#f2c94c")\n'
+                'draw.text((32, 28), "Synthetic map image", fill="#1f2937")\n'
+                'draw.text((145, 105), "site A", fill="#1f2937")\n'
+                'draw.text((500, 165), "site B", fill="#1f2937")\n'
+                "img.save(image_path)\n"
+                "display(Image(filename=str(image_path)))"
+            ),
+            new_code_cell(
+                "image_bytes = image_path.read_bytes()\n"
+                "resp = agent.chat(\n"
+                "    [\n"
+                "        {\n"
+                '            "text": "Describe this map-like image. '
+                'Identify the labeled sites, water, and land cover."\n'
+                "        },\n"
+                "        {\n"
+                '            "image": {\n'
+                '                "format": "png",\n'
+                '                "source": {"bytes": image_bytes},\n'
+                "            }\n"
+                "        },\n"
+                "    ]\n"
+                ")\n"
+                "print(resp.answer_text)"
+            ),
             new_markdown_cell("## Leafmap Example"),
             new_code_cell('%pip install -q "GeoAgent[leafmap]" leafmap'),
             new_code_cell(
@@ -315,9 +383,8 @@ def main() -> None:
                 "    fast=True,\n"
                 ")\n"
                 "\n"
-                "resp = map_agent.chat(\n"
-                '    "Using the current map state, describe the map center and zoom."\n'
-                ")\n"
+                'resp = map_agent.chat("Using the current map state, describe the '
+                'map center and zoom.")\n'
                 "print(resp.answer_text)\n"
                 'print("tools:", resp.executed_tools)'
             ),

--- a/scripts/write_example_notebooks.py
+++ b/scripts/write_example_notebooks.py
@@ -1,12 +1,57 @@
 #!/usr/bin/env python3
-"""Generate docs/examples notebooks (GeoAgent 1.0 + Anthropic)."""
+"""Generate docs/examples notebooks."""
 
 from __future__ import annotations
 
-import nbformat
-from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+import json
+from pathlib import Path
+
+try:
+    import nbformat
+    from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+except ModuleNotFoundError:
+
+    def new_code_cell(source: str) -> dict:
+        """Return a minimal Jupyter code cell."""
+        return {
+            "cell_type": "code",
+            "execution_count": None,
+            "metadata": {},
+            "outputs": [],
+            "source": source,
+        }
+
+    def new_markdown_cell(source: str) -> dict:
+        """Return a minimal Jupyter markdown cell."""
+        return {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": source,
+        }
+
+    def new_notebook(*, metadata: dict, cells: list[dict]) -> dict:
+        """Return a minimal Jupyter notebook document."""
+        return {
+            "cells": cells,
+            "metadata": metadata,
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+
+    class _NbFormatFallback:
+        """Small writer compatible with ``nbformat.write`` for this script."""
+
+        @staticmethod
+        def write(notebook: dict, path: str) -> None:
+            Path(path).write_text(
+                json.dumps(notebook, indent=1, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+
+    nbformat = _NbFormatFallback()
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
+CODEX_MODEL = "gpt-5.5"
 
 
 def main() -> None:
@@ -35,7 +80,8 @@ def main() -> None:
                 "import os\n"
                 "\n"
                 'if not os.environ.get("ANTHROPIC_API_KEY"):\n'
-                '    raise RuntimeError("Set ANTHROPIC_API_KEY before running this cell.")\n'
+                '    raise RuntimeError("Set ANTHROPIC_API_KEY before running this '
+                'cell.")\n'
                 "\n"
                 f'MODEL = os.environ.get("ANTHROPIC_MODEL", "{DEFAULT_MODEL}")\n'
                 'print("Using model:", MODEL)'
@@ -53,7 +99,8 @@ def main() -> None:
                 "    ),\n"
                 ")\n"
                 "\n"
-                'resp = agent.chat("In one sentence, what is STAC in Earth observation?")\n'
+                'resp = agent.chat("In one sentence, what is STAC in Earth '
+                'observation?")\n'
                 'print("success:", resp.success)\n'
                 "print(resp.answer_text)\n"
                 'print("executed_tools:", resp.executed_tools)'
@@ -89,12 +136,17 @@ def main() -> None:
                 "from geoagent.tools.leafmap import leafmap_tools\n"
                 "\n"
                 'm = leafmap.Map(center=[-83.92, 35.96], zoom=9, height="520px")\n'
+                "m"
+            ),
+            new_markdown_cell("## Map widget"),
+            new_code_cell(
                 "\n"
                 'vs = getattr(m, "view_state", None)\n'
                 "if isinstance(vs, dict):\n"
                 '    print("view_state keys:", list(vs.keys()))\n'
                 "else:\n"
-                '    print("view_state:", type(vs).__name__ if vs is not None else None)\n'
+                '    print("view_state:", type(vs).__name__ if vs is not None '
+                "else None)\n"
                 "\n"
                 "cfg = GeoAgentConfig(\n"
                 '    provider="anthropic",\n'
@@ -104,9 +156,11 @@ def main() -> None:
                 ")\n"
                 "agent = for_leafmap(m, config=cfg, fast=True)\n"
                 "\n"
-                'get_state = next(t for t in leafmap_tools(m) if t.tool_name == "get_map_state")\n'
+                "get_state = next(t for t in leafmap_tools(m) if t.tool_name == "
+                '"get_map_state")\n'
                 "st = get_state()\n"
-                'print("get_map_state zoom / center:", st.get("zoom"), st.get("center"))\n'
+                'print("get_map_state zoom / center:", '
+                'st.get("zoom"), st.get("center"))\n'
                 "\n"
                 "resp = agent.chat(\n"
                 '    "Using the map state, what is the zoom level? One sentence."\n'
@@ -114,8 +168,11 @@ def main() -> None:
                 "print(resp.answer_text)\n"
                 'print("tools:", resp.executed_tools)'
             ),
-            new_markdown_cell("## Map widget"),
-            new_code_cell("m"),
+            new_code_cell(
+                'resp = agent.chat("Fly to San Francisco")\n'
+                "print(resp.answer_text)\n"
+                'print("tools:", resp.executed_tools)'
+            ),
         ],
     )
 
@@ -132,10 +189,12 @@ def main() -> None:
                 "from geoagent import for_qgis\n"
                 "from geoagent.core.config import GeoAgentConfig\n"
                 "\n"
-                'agent = for_qgis(iface, config=GeoAgentConfig(provider="anthropic", model=MODEL))\n'
+                'agent = for_qgis(iface, config=GeoAgentConfig(provider="anthropic", '
+                "model=MODEL))\n"
                 'agent.chat("List project layers.")\n'
                 "```\n\n"
-                'Requires `pip install "GeoAgent[anthropic]"` and `ANTHROPIC_API_KEY`.'
+                'Requires `pip install "GeoAgent[anthropic]"` and '
+                "`ANTHROPIC_API_KEY`."
             ),
             new_code_cell('%pip install -q "GeoAgent[anthropic]"'),
             new_code_cell(
@@ -148,7 +207,8 @@ def main() -> None:
             ),
             new_code_cell(
                 "from geoagent import for_qgis\n"
-                "from geoagent.testing import MockQGISIface, MockQGISLayer, MockQGISProject\n"
+                "from geoagent.testing import MockQGISIface, MockQGISLayer, "
+                "MockQGISProject\n"
                 "\n"
                 "project = MockQGISProject()\n"
                 'project.addMapLayer(MockQGISLayer("StudyArea", "/tmp/a.shp"))\n'
@@ -162,7 +222,102 @@ def main() -> None:
                 "    fast=True,\n"
                 ")\n"
                 "\n"
-                'resp = agent.chat("List the layer names in this project in a short bullet list.")\n'
+                'resp = agent.chat("List the layer names in this project in a short '
+                'bullet list.")\n'
+                "print(resp.answer_text)\n"
+                'print("tools:", resp.executed_tools)'
+            ),
+            new_code_cell(
+                "from geoagent import for_qgis\n"
+                "import os\n"
+                "\n"
+                'if not os.environ.get("ANTHROPIC_API_KEY"):\n'
+                '    raise RuntimeError("Set ANTHROPIC_API_KEY")\n'
+                "\n"
+                f'MODEL = os.environ.get("ANTHROPIC_MODEL", "{DEFAULT_MODEL}")\n'
+                "\n"
+                "agent = for_qgis(\n"
+                "    iface,\n"
+                '    provider="anthropic",\n'
+                "    model_id=MODEL,\n"
+                "    fast=True,\n"
+                ")\n"
+                "\n"
+                'resp = agent.chat("List the layer names in this project in a short '
+                'bullet list.")\n'
+                "print(resp.answer_text)\n"
+                'print("tools:", resp.executed_tools)'
+            ),
+        ],
+    )
+
+    codex_nb = new_notebook(
+        metadata=meta,
+        cells=[
+            new_markdown_cell(
+                "# GeoAgent + ChatGPT/Codex OAuth\n\n"
+                "This notebook uses the same ChatGPT/Codex OAuth flow as the QGIS "
+                "plugin, but stores the login in GeoAgent's user config directory "
+                "for regular Python and Jupyter sessions.\n\n"
+                '- Install: `pip install "GeoAgent[openai]"`.\n'
+                "- Run the login cell once. Later notebooks can reuse the stored "
+                "login automatically."
+            ),
+            new_code_cell('%pip install -q "GeoAgent[openai]"'),
+            new_code_cell(
+                "from geoagent import ensure_openai_codex_environment\n"
+                "from geoagent import login_openai_codex\n"
+                "\n"
+                "try:\n"
+                "    ensure_openai_codex_environment()\n"
+                '    print("Using stored ChatGPT/Codex login.")\n'
+                "except RuntimeError:\n"
+                "    login_openai_codex()\n"
+                '    print("Logged in with ChatGPT/Codex OAuth.")'
+            ),
+            new_code_cell(
+                "import os\n"
+                "\n"
+                f'MODEL = os.environ.get("OPENAI_CODEX_MODEL", "{CODEX_MODEL}")\n'
+                'print("Using model:", MODEL)'
+            ),
+            new_code_cell(
+                "from geoagent import GeoAgent, GeoAgentConfig\n"
+                "\n"
+                "agent = GeoAgent(\n"
+                "    config=GeoAgentConfig(\n"
+                '        provider="openai-codex",\n'
+                "        model=MODEL,\n"
+                "        temperature=0.0,\n"
+                "        max_tokens=2048,\n"
+                "    ),\n"
+                ")\n"
+                "\n"
+                'resp = agent.chat("In one sentence, what is GeoAgent useful for?")\n'
+                'print("success:", resp.success)\n'
+                "print(resp.answer_text)\n"
+                'print("executed_tools:", resp.executed_tools)'
+            ),
+            new_markdown_cell("## Leafmap Example"),
+            new_code_cell('%pip install -q "GeoAgent[leafmap]" leafmap'),
+            new_code_cell(
+                "import leafmap.maplibregl as leafmap\n"
+                "from geoagent import for_leafmap\n"
+                "\n"
+                'm = leafmap.Map(center=[-83.92, 35.96], zoom=9, height="520px")\n'
+                "m"
+            ),
+            new_code_cell(
+                "map_agent = for_leafmap(\n"
+                "    m,\n"
+                '    provider="openai-codex",\n'
+                "    model_id=MODEL,\n"
+                "    fast=True,\n"
+                ")\n"
+                "\n"
+                "resp = map_agent.chat(\n"
+                '    "Using the current map state, describe the map center and zoom."\n'
+                ")\n"
                 "print(resp.answer_text)\n"
                 'print("tools:", resp.executed_tools)'
             ),
@@ -172,7 +327,11 @@ def main() -> None:
     nbformat.write(intro, "docs/examples/intro.ipynb")
     nbformat.write(live, "docs/examples/live_mapping.ipynb")
     nbformat.write(qgis_nb, "docs/examples/qgis_agent.ipynb")
-    print("Wrote docs/examples/intro.ipynb, live_mapping.ipynb, qgis_agent.ipynb")
+    nbformat.write(codex_nb, "docs/examples/openai_codex.ipynb")
+    print(
+        "Wrote docs/examples/intro.ipynb, live_mapping.ipynb, "
+        "qgis_agent.ipynb, openai_codex.ipynb"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -42,6 +42,33 @@ def test_chat_success_from_mocked_strands() -> None:
     mock_agent.assert_called_once()
 
 
+def test_chat_passes_multimodal_content_blocks_to_strands() -> None:
+    """Verify chat accepts Strands multimodal content blocks."""
+    m = MockLeafmap()
+    agent = for_leafmap(m, model=_MockModel())
+
+    metrics = SimpleNamespace(tool_metrics={})
+    msg = {"role": "assistant", "content": [{"text": "image described"}]}
+    fake_result = SimpleNamespace(
+        stop_reason="end_turn",
+        metrics=metrics,
+        message=msg,
+    )
+    content = [
+        {"text": "Describe this image."},
+        {"image": {"format": "png", "source": {"bytes": b"fake-png"}}},
+    ]
+
+    mock_agent = MagicMock(return_value=fake_result)
+    agent._strands = mock_agent  # noqa: SLF001
+
+    resp = agent.chat(content)
+
+    assert resp.success
+    assert resp.answer_text == "image described"
+    mock_agent.assert_called_once_with(content)
+
+
 def test_chat_json_parse_error_returns_actionable_guidance() -> None:
     """Verify malformed tool-call JSON gets user-facing correction guidance."""
     m = MockLeafmap()

--- a/tests/test_model_providers.py
+++ b/tests/test_model_providers.py
@@ -133,10 +133,35 @@ def test_resolve_openai_codex_model(monkeypatch) -> None:
     }
 
 
+def test_resolve_openai_codex_uses_stored_login(monkeypatch, tmp_path) -> None:
+    """Verify stored Codex OAuth tokens are loaded for Python sessions."""
+    fake_model = _install_fake_openai_responses_model(monkeypatch)
+    token_file = tmp_path / "codex.json"
+    token_file.write_text(
+        (
+            '{"access_token": "stored-token", "account_id": "account-456", '
+            '"expires_at": 4102444800}'
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OPENAI_CODEX_ACCESS_TOKEN", raising=False)
+    monkeypatch.setenv("GEOAGENT_CODEX_TOKEN_FILE", str(token_file))
+
+    model = resolve_model(GeoAgentConfig(provider="openai-codex", model="gpt-5.5"))
+
+    assert isinstance(model, fake_model)
+    assert model.kwargs["client_args"]["api_key"] == "stored-token"
+    assert (
+        model.kwargs["client_args"]["default_headers"]["ChatGPT-Account-Id"]
+        == "account-456"
+    )
+
+
 def test_openai_codex_requires_token(monkeypatch) -> None:
     """Verify missing Codex OAuth token gives a clear error."""
     _install_fake_openai_responses_model(monkeypatch)
     monkeypatch.delenv("OPENAI_CODEX_ACCESS_TOKEN", raising=False)
+    monkeypatch.setenv("GEOAGENT_CODEX_TOKEN_FILE", "/tmp/geoagent-missing-codex.json")
 
     with pytest.raises(ValueError, match="ChatGPT OAuth access token"):
         resolve_model(GeoAgentConfig(provider="openai-codex"))

--- a/tests/test_openai_codex_oauth.py
+++ b/tests/test_openai_codex_oauth.py
@@ -1,0 +1,126 @@
+"""Tests for package-level ChatGPT/Codex OAuth helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import pathlib
+import sys
+import stat
+import urllib.parse
+
+import pytest
+
+OPENAI_CODEX_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "geoagent"
+    / "core"
+    / "openai_codex.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "geoagent_openai_codex",
+    OPENAI_CODEX_PATH,
+)
+openai_codex = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = openai_codex
+SPEC.loader.exec_module(openai_codex)
+
+
+def test_generate_pkce_pair_uses_s256_challenge() -> None:
+    """Verify PKCE challenge generation."""
+    verifier, challenge = openai_codex.generate_pkce_pair()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+    assert len(verifier) >= 43
+    assert challenge == expected
+
+
+def test_codex_authorization_url_matches_registered_flow_shape() -> None:
+    """Verify Codex login uses the expected redirect and auth parameters."""
+    url = openai_codex.build_authorization_url(
+        openai_codex.OPENAI_CODEX_AUTHORIZATION_URL,
+        client_id=openai_codex.OPENAI_CODEX_CLIENT_ID,
+        redirect_uri="http://localhost:1455/auth/callback",
+        code_challenge="challenge",
+        state="state",
+        scope=openai_codex.OPENAI_CODEX_SCOPE,
+        extra_params=openai_codex.OPENAI_CODEX_AUTH_EXTRA_PARAMS,
+    )
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "auth.openai.com"
+    assert params["redirect_uri"] == ["http://localhost:1455/auth/callback"]
+    assert params["client_id"] == [openai_codex.OPENAI_CODEX_CLIENT_ID]
+    assert params["scope"] == ["openid profile email offline_access"]
+    assert params["id_token_add_organizations"] == ["true"]
+    assert params["codex_cli_simplified_flow"] == ["true"]
+    assert params["originator"] == ["pi"]
+
+
+def test_save_load_and_clear_token_payload(tmp_path) -> None:
+    """Verify local token file storage uses user-only permissions."""
+    token_file = tmp_path / "codex.json"
+    token = {
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "expires_at": 4102444800,
+    }
+
+    saved = openai_codex.save_token_payload(token, token_file=token_file)
+
+    assert saved == token_file
+    assert openai_codex.load_token_payload(token_file=token_file) == token
+    assert stat.S_IMODE(token_file.stat().st_mode) == 0o600
+
+    openai_codex.clear_token_payload(token_file=token_file)
+
+    assert not token_file.exists()
+
+
+def test_ensure_environment_refreshes_stored_token(monkeypatch, tmp_path) -> None:
+    """Verify expired stored tokens refresh and export environment variables."""
+    token_file = tmp_path / "codex.json"
+    token_file.write_text(
+        json.dumps(
+            {
+                "access_token": "old-access",
+                "refresh_token": "refresh",
+                "expires_at": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    refreshed = {
+        "access_token": "new-access",
+        "refresh_token": "refresh",
+        "expires_at": 4102444800,
+        "account_id": "account-123",
+    }
+    monkeypatch.delenv("OPENAI_CODEX_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        openai_codex,
+        "refresh_oauth_token",
+        lambda **kwargs: refreshed,
+    )
+
+    payload = openai_codex.ensure_openai_codex_environment(token_file=token_file)
+
+    assert payload == refreshed
+    assert openai_codex.os.environ["OPENAI_CODEX_ACCESS_TOKEN"] == "new-access"
+    assert openai_codex.os.environ["OPENAI_CODEX_ACCOUNT_ID"] == "account-123"
+    assert openai_codex.load_token_payload(token_file=token_file) == refreshed
+
+
+def test_load_token_payload_missing_file_raises(tmp_path) -> None:
+    """Verify missing local login has a clear error."""
+    with pytest.raises(RuntimeError, match="geoagent codex login"):
+        openai_codex.load_token_payload(token_file=tmp_path / "missing.json")

--- a/tests/test_openai_codex_oauth.py
+++ b/tests/test_openai_codex_oauth.py
@@ -6,9 +6,10 @@ import base64
 import hashlib
 import importlib.util
 import json
+import os
 import pathlib
-import sys
 import stat
+import sys
 import urllib.parse
 
 import pytest
@@ -79,7 +80,8 @@ def test_save_load_and_clear_token_payload(tmp_path) -> None:
 
     assert saved == token_file
     assert openai_codex.load_token_payload(token_file=token_file) == token
-    assert stat.S_IMODE(token_file.stat().st_mode) == 0o600
+    if os.name == "posix":
+        assert stat.S_IMODE(token_file.stat().st_mode) == 0o600
 
     openai_codex.clear_token_payload(token_file=token_file)
 


### PR DESCRIPTION
## Summary
- Add `geoagent codex login/status/logout` CLI and `login_openai_codex()` / `ensure_openai_codex_environment()` Python helpers that persist a Codex refresh token in the user config directory.
- Auto-load the stored login when the `openai-codex` provider is resolved, so notebooks and scripts no longer need to set `OPENAI_CODEX_ACCESS_TOKEN` manually.
- Document the flow in `README.md` / `docs/usage.md` and ship a runnable `docs/examples/openai_codex.ipynb` example.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/ -q` (131 passed)
- [ ] Manual: `geoagent codex login` followed by running the new `docs/examples/openai_codex.ipynb`