### PR TITLE
feat: add stream_chat for token-by-token GeoAgent output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ CLAUDE.md
 .codex
 *.zip
 docs/examples/codex_example_map.png
+scripts/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos,nd",
+                  "--ignore-words-list=pre-empt,alos,nd,hel",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos,nd,hel",
+                  "--ignore-words-list=pre-empt,alos,nd",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ resp = agent.chat("Explain STAC in two sentences.")
 print(resp.answer_text)
 ```
 
+Stream model output as it is generated:
+
+```python
+import asyncio
+from geoagent import GeoAgent
+
+agent = GeoAgent()
+
+async def main():
+    async for event in agent.stream_chat("Explain STAC in two sentences."):
+        if "data" in event:
+            print(event["data"], end="", flush=True)
+
+asyncio.run(main())
+```
+
 Bind an agent to a live `leafmap` map:
 
 ```python
@@ -375,6 +391,7 @@ Runnable notebooks live under `docs/examples/`:
 
 - `docs/examples/intro.ipynb` — basic GeoAgent usage.
 - `docs/examples/openai_codex.ipynb` — ChatGPT/Codex OAuth in Python/Jupyter.
+- `docs/examples/stream_chat_openai_codex.ipynb` — streamed ChatGPT/Codex output.
 - `docs/examples/live_mapping.ipynb` — live map workflow.
 - `docs/examples/qgis_agent.ipynb` — QGIS-oriented workflow using mocks.
 - `examples/nasa_opera_qgis.py` — NASA OPERA workflow for QGIS.

--- a/docs/examples/stream_chat_openai_codex.ipynb
+++ b/docs/examples/stream_chat_openai_codex.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# GeoAgent stream_chat + ChatGPT/Codex OAuth\n",
+    "\n",
+    "This notebook demonstrates streaming model output from `agent.stream_chat(...)` with the `openai-codex` provider.\n",
+    "\n",
+    "- Install: `pip install \"GeoAgent[openai]\"`.\n",
+    "- Run the login cell once. Later notebooks can reuse the stored ChatGPT/Codex login automatically.\n",
+    "- Jupyter supports top-level `await`, so the streaming cell can use `async for` directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"GeoAgent[openai]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import ensure_openai_codex_environment\n",
+    "from geoagent import login_openai_codex\n",
+    "\n",
+    "try:\n",
+    "    ensure_openai_codex_environment()\n",
+    "    print(\"Using stored ChatGPT/Codex login.\")\n",
+    "except RuntimeError:\n",
+    "    login_openai_codex()\n",
+    "    print(\"Logged in with ChatGPT/Codex OAuth.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "MODEL = os.environ.get(\"OPENAI_CODEX_MODEL\", \"gpt-5.5\")\n",
+    "print(\"Using model:\", MODEL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoagent import GeoAgent, GeoAgentConfig\n",
+    "\n",
+    "agent = GeoAgent(\n",
+    "    config=GeoAgentConfig(\n",
+    "        provider=\"openai-codex\",\n",
+    "        model=MODEL,\n",
+    "        temperature=0.0,\n",
+    "        max_tokens=2048,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Stream a response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunks = []\n",
+    "tool_names = set()\n",
+    "final_result = None\n",
+    "\n",
+    "async for event in agent.stream_chat(\n",
+    "    \"Explain GeoAgent streaming in three concise bullets.\"\n",
+    "):\n",
+    "    if \"current_tool_use\" in event:\n",
+    "        tool_name = event[\"current_tool_use\"].get(\"name\")\n",
+    "        if tool_name:\n",
+    "            tool_names.add(tool_name)\n",
+    "            print(f\"\\n[Using tool: {tool_name}]\\n\", flush=True)\n",
+    "\n",
+    "    if \"data\" in event:\n",
+    "        chunks.append(event[\"data\"])\n",
+    "        print(event[\"data\"], end=\"\", flush=True)\n",
+    "\n",
+    "    if \"result\" in event:\n",
+    "        final_result = event[\"result\"]\n",
+    "\n",
+    "print(\"\\n\\nstreamed_chars:\", len(\"\".join(chunks)))\n",
+    "print(\"tools:\", sorted(tool_names))\n",
+    "if final_result is not None:\n",
+    "    print(\"stop_reason:\", getattr(final_result, \"stop_reason\", None))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,19 @@ resp = agent.chat("Your prompt")
 print(resp.answer_text)
 ```
 
+For token-by-token output, use the async streaming sibling:
+
+```python
+import asyncio
+
+async def main():
+    async for event in agent.stream_chat("Your prompt"):
+        if "data" in event:
+            print(event["data"], end="", flush=True)
+
+asyncio.run(main())
+```
+
 Use `fast=True` with `GeoAgent(..., fast=True)` or `for_leafmap(m, fast=True)` for a smaller prompt and fewer tools.
 
 Access the underlying Strands agent as `agent.strands_agent`.

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -283,28 +283,31 @@ class GeoAgent:
                 yield event
             return
 
-        if (
-            self._context.metadata.get("integration")
-            in {"nasa_earthdata", "nasa_opera"}
-            and self._qgis_safe_mode
-            and is_qt_gui_thread()
-        ):
+        if self._qgis_safe_mode and is_qt_gui_thread():
             integration = self._context.metadata.get("integration")
-            label = (
-                "NASA Earthdata" if integration == "nasa_earthdata" else "NASA OPERA"
-            )
-            helper = (
-                "the NASA Earthdata AI Assistant panel"
-                if integration == "nasa_earthdata"
-                else (
-                    "the NASA OPERA AI Assistant panel or "
-                    "geoagent.tools.nasa_opera.submit_nasa_opera_search_task(...) "
-                    "for direct QGIS-console workflows"
+            if integration in {"nasa_earthdata", "nasa_opera"}:
+                label = (
+                    "NASA Earthdata"
+                    if integration == "nasa_earthdata"
+                    else "NASA OPERA"
                 )
-            )
+                helper = (
+                    "the NASA Earthdata AI Assistant panel"
+                    if integration == "nasa_earthdata"
+                    else (
+                        "the NASA OPERA AI Assistant panel or "
+                        "geoagent.tools.nasa_opera.submit_nasa_opera_search_task(...) "
+                        "for direct QGIS-console workflows"
+                    )
+                )
+                raise RuntimeError(
+                    f"{label} streaming chat should be launched from a worker thread "
+                    f"inside QGIS. Use {helper}."
+                )
             raise RuntimeError(
-                f"{label} streaming chat should be launched from a worker thread "
-                f"inside QGIS. Use {helper}."
+                "stream_chat() must not be called from the QGIS Qt GUI thread when "
+                "qgis_safe_mode=True. Launch streaming chat from a worker thread, "
+                "or use chat() from the GUI thread."
             )
 
         self._cancelled.clear()

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 import threading
-from typing import Any, Optional
+from typing import Any, AsyncIterator, Optional
 
 from strands import Agent
 from strands.tools.executors.sequential import SequentialToolExecutor
@@ -258,6 +258,64 @@ class GeoAgent:
                 cancelled_tools=list(self._cancelled),
                 map=self._context.map_obj,
             )
+
+    async def stream_chat(
+        self,
+        query: Any,
+        target_map: Any = None,
+    ) -> AsyncIterator[Any]:
+        """Stream a single user turn as raw Strands events.
+
+        Text deltas are emitted in events containing ``"data"``. The final
+        Strands result is emitted in the event containing ``"result"``.
+        """
+        if target_map is not None and target_map is not self._context.map_obj:
+            from geoagent.core.factory import for_leafmap
+
+            other = for_leafmap(
+                target_map,
+                config=self._config,
+                model=self._model,
+                fast=self._fast,
+                confirm=self._confirm,
+            )
+            async for event in other.stream_chat(query):
+                yield event
+            return
+
+        if (
+            self._context.metadata.get("integration")
+            in {"nasa_earthdata", "nasa_opera"}
+            and self._qgis_safe_mode
+            and is_qt_gui_thread()
+        ):
+            integration = self._context.metadata.get("integration")
+            label = (
+                "NASA Earthdata" if integration == "nasa_earthdata" else "NASA OPERA"
+            )
+            helper = (
+                "the NASA Earthdata AI Assistant panel"
+                if integration == "nasa_earthdata"
+                else (
+                    "the NASA OPERA AI Assistant panel or "
+                    "geoagent.tools.nasa_opera.submit_nasa_opera_search_task(...) "
+                    "for direct QGIS-console workflows"
+                )
+            )
+            raise RuntimeError(
+                f"{label} streaming chat should be launched from a worker thread "
+                f"inside QGIS. Use {helper}."
+            )
+
+        self._cancelled.clear()
+        self._tool_calls.clear()
+        try:
+            async for event in self._strands.stream_async(query):
+                yield event
+        except Exception as exc:
+            if _looks_like_json_parse_failure(exc):
+                raise RuntimeError(_format_chat_exception(exc)) from exc
+            raise
 
     def _chat_on_qgis_gui_thread(self, query: Any) -> GeoAgentResponse:
         """Run sync QGIS chat without starving the Qt event loop.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - Examples:
         - examples/intro.ipynb
         - examples/openai_codex.ipynb
+        - examples/stream_chat_openai_codex.ipynb
         - examples/live_mapping.ipynb
         - examples/qgis_agent.ipynb
     - API Reference:

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -107,8 +107,8 @@ def test_stream_chat_yields_mocked_strands_events() -> None:
     m = MockLeafmap()
     agent = for_leafmap(m, model=_MockModel())
     events = [
-        {"data": "hel"},
-        {"data": "lo"},
+        {"data": "he"},
+        {"data": "llo"},
         {"current_tool_use": {"name": "list_layers"}},
         {"result": SimpleNamespace(stop_reason="end_turn")},
     ]

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import time
 import types
@@ -17,6 +18,20 @@ class _MockModel:
     """Provide a test double for MockModel."""
 
     stateful = False
+
+
+class _MockStreamingAgent:
+    """Provide a test double for a Strands agent with stream_async."""
+
+    def __init__(self, events):
+        self.events = events
+        self.calls = []
+
+    async def stream_async(self, query):
+        """Yield mocked streaming events."""
+        self.calls.append(query)
+        for event in self.events:
+            yield event
 
 
 def test_chat_success_from_mocked_strands() -> None:
@@ -85,6 +100,45 @@ def test_chat_json_parse_error_returns_actionable_guidance() -> None:
     assert "malformed or incomplete JSON" in resp.error_message
     assert "Original error:" in resp.error_message
     assert "Break a long workflow into smaller steps" in resp.error_message
+
+
+def test_stream_chat_yields_mocked_strands_events() -> None:
+    """Verify stream_chat yields Strands streaming events."""
+    m = MockLeafmap()
+    agent = for_leafmap(m, model=_MockModel())
+    events = [
+        {"data": "hel"},
+        {"data": "lo"},
+        {"current_tool_use": {"name": "list_layers"}},
+        {"result": SimpleNamespace(stop_reason="end_turn")},
+    ]
+    mock_agent = _MockStreamingAgent(events)
+    agent._strands = mock_agent  # noqa: SLF001
+
+    async def _collect():
+        return [event async for event in agent.stream_chat("list layers")]
+
+    seen = asyncio.run(_collect())
+
+    assert seen == events
+    assert mock_agent.calls == ["list layers"]
+
+
+def test_stream_chat_clears_previous_run_state() -> None:
+    """Verify stream_chat starts from fresh cancellation/tool-call state."""
+    m = MockLeafmap()
+    agent = for_leafmap(m, model=_MockModel())
+    agent._cancelled.append("old_tool")  # noqa: SLF001
+    agent._tool_calls.append({"name": "old_tool"})  # noqa: SLF001
+    agent._strands = _MockStreamingAgent([{"data": "done"}])  # noqa: SLF001
+
+    async def _drain():
+        return [event async for event in agent.stream_chat("hello")]
+
+    asyncio.run(_drain())
+
+    assert agent._cancelled == []  # noqa: SLF001
+    assert agent._tool_calls == []  # noqa: SLF001
 
 
 def test_chat_in_background_returns_and_invokes_callback() -> None:
@@ -181,7 +235,7 @@ def test_qgis_chat_on_gui_thread_runs_worker_and_pumps_events(monkeypatch) -> No
         QObject=_QObject,
         QThread=_QThread,
         Qt=_Qt,
-        pyqtSlot=lambda *args, **kwargs: (lambda fn: fn),
+        pyqtSlot=lambda *args, **kwargs: lambda fn: fn,
     )
     fake_qt_widgets = types.SimpleNamespace(QApplication=_QApplication)
     fake_pyqt = types.SimpleNamespace(QtCore=fake_qt_core, QtWidgets=fake_qt_widgets)


### PR DESCRIPTION
## Summary
- Add async `GeoAgent.stream_chat()` that yields raw Strands events (text deltas, tool-use signals, final result) for incremental rendering.
- Add `docs/examples/stream_chat_openai_codex.ipynb` and short README/usage snippets showing the streaming pattern.
- Add mock-based tests covering event passthrough and per-run state reset.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_geoagent_chat_mock.py -q`
- [ ] Run the new notebook end-to-end with the `openai-codex` provider and confirm tokens stream live.