### PR TITLE
feat: stream QGIS chat output as it arrives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos,nd",
+                  "--ignore-words-list=pre-empt,alos,nd,hel",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: codespell
           args:
               [
-                  "--ignore-words-list=pre-empt,alos,nd,hel",
+                  "--ignore-words-list=pre-empt,alos,nd",
                   "--skip=*.csv,*.geojson,*.json,*.yml,*.min.js,*.bundle.js,*.html,*cff,*.pdf",
               ]

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-import time
+import asyncio
+import queue
 import threading
+import time
 from typing import Any, AsyncIterator, Optional
 
 from strands import Agent
@@ -304,12 +306,15 @@ class GeoAgent:
                     f"{label} streaming chat should be launched from a worker thread "
                     f"inside QGIS. Use {helper}."
                 )
-            raise RuntimeError(
-                "stream_chat() must not be called from the QGIS Qt GUI thread when "
-                "qgis_safe_mode=True. Launch streaming chat from a worker thread, "
-                "or use chat() from the GUI thread."
-            )
+            async for event in self._stream_chat_on_qgis_gui_thread(query):
+                yield event
+            return
 
+        async for event in self._stream_chat_impl(query):
+            yield event
+
+    async def _stream_chat_impl(self, query: Any) -> AsyncIterator[Any]:
+        """Run a streaming user turn on the current thread."""
         self._cancelled.clear()
         self._tool_calls.clear()
         try:
@@ -319,6 +324,48 @@ class GeoAgent:
             if _looks_like_json_parse_failure(exc):
                 raise RuntimeError(_format_chat_exception(exc)) from exc
             raise
+
+    async def _stream_chat_on_qgis_gui_thread(self, query: Any) -> AsyncIterator[Any]:
+        """Stream QGIS chat from a worker thread while pumping Qt events."""
+        events: queue.Queue[tuple[str, Any]] = queue.Queue()
+
+        async def _run_stream() -> None:
+            """Execute async streaming work off the GUI thread."""
+            async for event in self._stream_chat_impl(query):
+                events.put(("event", event))
+
+        def _worker() -> None:
+            """Run the async stream and forward events to the GUI thread."""
+            try:
+                asyncio.run(_run_stream())
+            except BaseException as exc:  # pragma: no cover - defensive path
+                events.put(("error", exc))
+            finally:
+                events.put(("done", None))
+
+        thread = threading.Thread(
+            target=_worker,
+            daemon=True,
+            name="GeoAgent-QGIS-stream-chat",
+        )
+        thread.start()
+
+        while True:
+            try:
+                kind, payload = events.get_nowait()
+            except queue.Empty:
+                process_qt_events()
+                await asyncio.sleep(0.05)
+                continue
+
+            if kind == "event":
+                yield payload
+            elif kind == "error":
+                thread.join(timeout=0)
+                raise payload
+            elif kind == "done":
+                thread.join(timeout=0)
+                return
 
     def _chat_on_qgis_gui_thread(self, query: Any) -> GeoAgentResponse:
         """Run sync QGIS chat without starving the Qt event loop.

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -103,6 +103,7 @@ Default models:
 ## Chat Workflow
 
 - Type a prompt and press **Ctrl+Enter** to send it.
+- **Stream output** is enabled by default and shows model text as it arrives.
 - Press **Up** or **Down** in the prompt editor to cycle through previous prompts.
 - Choose a prompt from **Sample prompts...** and click **Insert** to load it into
   the editor before sending.

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -557,6 +557,10 @@ class ChatDockWidget(QDockWidget):
         self._status_timer = QTimer(self)
         self._status_timer.setInterval(500)
         self._status_timer.timeout.connect(self._update_running_status)
+        self._stream_render_timer = QTimer(self)
+        self._stream_render_timer.setSingleShot(True)
+        self._stream_render_timer.setInterval(75)
+        self._stream_render_timer.timeout.connect(self._flush_streaming_render)
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -858,6 +862,8 @@ class ChatDockWidget(QDockWidget):
     def _on_worker_finished(self, result):
         """Render the completed chat worker result."""
         self._stop_running_status()
+        if self._stream_render_timer.isActive():
+            self._stream_render_timer.stop()
         if result.get("cancelled_by_user"):
             self._append_message("OpenGeoAgent", "Cancelled by user.", markdown=False)
             self.status_label.setText("Cancelled")
@@ -900,7 +906,7 @@ class ChatDockWidget(QDockWidget):
         self._streaming_answer = ""
 
     def _on_worker_chunk(self, chunk):
-        """Render a streamed model text chunk."""
+        """Buffer a streamed model text chunk and schedule a debounced render."""
         if not chunk:
             return
         if self._streaming_message_index is None:
@@ -910,6 +916,13 @@ class ChatDockWidget(QDockWidget):
             )
             self.copy_md_btn.setEnabled(True)
         self._streaming_answer += chunk
+        if not self._stream_render_timer.isActive():
+            self._stream_render_timer.start()
+
+    def _flush_streaming_render(self):
+        """Render the latest buffered streaming answer."""
+        if self._streaming_message_index is None:
+            return
         self._update_message(
             self._streaming_message_index,
             self._streaming_answer,
@@ -976,7 +989,7 @@ class ChatDockWidget(QDockWidget):
         """Update an existing chat message and refresh the transcript."""
         if index < 0 or index >= len(self._messages):
             return
-        self._messages[index]["body"] = message.strip()
+        self._messages[index]["body"] = message
         self._messages[index]["markdown"] = markdown
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -1,5 +1,6 @@
 """Dockable OpenGeoAgent chat interface."""
 
+import asyncio
 import os
 import html
 import json
@@ -351,6 +352,7 @@ class ChatWorker(QThread):
     """Run GeoAgent chat without blocking the QGIS UI."""
 
     finished = pyqtSignal(dict)
+    chunk_received = pyqtSignal(str)
 
     def __init__(
         self,
@@ -361,6 +363,7 @@ class ChatWorker(QThread):
         fast,
         max_tokens,
         auto_approve_tools=False,
+        stream=False,
         parent=None,
     ):
         super().__init__(parent)
@@ -371,6 +374,7 @@ class ChatWorker(QThread):
         self.fast = fast
         self.max_tokens = max_tokens
         self.auto_approve_tools = bool(auto_approve_tools)
+        self.stream = bool(stream)
 
     def run(self):
         """Create a GeoAgent QGIS agent and execute one chat turn."""
@@ -397,6 +401,10 @@ class ChatWorker(QThread):
                 fast=self.fast,
                 confirm=self._confirm_tool,
             )
+            if self.stream:
+                self._run_streaming_chat(agent)
+                return
+
             response = agent.chat(self.prompt)
 
             if self.isInterruptionRequested():
@@ -438,6 +446,53 @@ class ChatWorker(QThread):
                     "cancelled_by_user": self.isInterruptionRequested(),
                 }
             )
+
+    def _run_streaming_chat(self, agent):
+        """Stream one chat turn and emit text chunks as they arrive."""
+        started_at = time.time()
+        chunks = []
+        final_result = None
+
+        async def _collect_stream():
+            nonlocal final_result
+            async for event in agent.stream_chat(self.prompt):
+                if self.isInterruptionRequested():
+                    break
+                if not isinstance(event, dict):
+                    continue
+                if "data" in event:
+                    chunk = str(event["data"])
+                    chunks.append(chunk)
+                    self.chunk_received.emit(chunk)
+                if "result" in event:
+                    final_result = event["result"]
+
+        asyncio.run(_collect_stream())
+
+        tool_metrics = getattr(
+            getattr(final_result, "metrics", None), "tool_metrics", {}
+        )
+        executed_tools = (
+            list(tool_metrics.keys()) if isinstance(tool_metrics, dict) else []
+        )
+        stop_reason = str(getattr(final_result, "stop_reason", "end_turn"))
+        success = stop_reason not in ("cancelled", "guardrail_intervened")
+        if self.isInterruptionRequested():
+            success = False
+
+        self.finished.emit(
+            {
+                "success": success,
+                "answer": "".join(chunks),
+                "error": "" if success else f"stop_reason={stop_reason}",
+                "tools": ", ".join(executed_tools),
+                "tool_calls": list(getattr(agent, "_tool_calls", []) or []),
+                "cancelled": ", ".join(getattr(agent, "_cancelled", []) or []),
+                "elapsed": f"{time.time() - started_at:.2f}s",
+                "cancelled_by_user": self.isInterruptionRequested(),
+                "streamed": True,
+            }
+        )
 
     def _confirm_tool(self, request):
         """Ask the QGIS user before running confirmation-required tools."""
@@ -494,6 +549,8 @@ class ChatDockWidget(QDockWidget):
         self._prompt_history = []
         self._history_index = None
         self._messages = []
+        self._streaming_message_index = None
+        self._streaming_answer = ""
         self._status_started_at = None
         self._status_base_text = "Running"
         self._status_frame = 0
@@ -538,12 +595,17 @@ class ChatDockWidget(QDockWidget):
         model_layout.addRow("Model:", self.model_input)
 
         self.fast_check = QCheckBox("Fast mode")
+        self.stream_check = QCheckBox("Stream output")
         self.auto_approve_tools_check = QCheckBox("Auto approve running tools")
         self.auto_approve_tools_check.setToolTip(
             "Run confirmation-required tools without prompting for this session."
         )
+        self.stream_check.setToolTip(
+            "Show model text as it arrives instead of waiting for the full response."
+        )
         mode_layout = QHBoxLayout()
         mode_layout.addWidget(self.fast_check)
+        mode_layout.addWidget(self.stream_check)
         mode_layout.addWidget(self.auto_approve_tools_check)
         mode_layout.addStretch(1)
         model_layout.addRow("", mode_layout)
@@ -630,6 +692,7 @@ class ChatDockWidget(QDockWidget):
         self.model_input.setText(model)
 
         self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
+        self.stream_check.setChecked(_setting(self.settings, "stream_chat", True, bool))
         self.auto_approve_tools_check.setChecked(
             _setting(self.settings, "auto_approve_tools", False, bool)
         )
@@ -644,6 +707,9 @@ class ChatDockWidget(QDockWidget):
         self.settings.setValue(f"{SETTINGS_PREFIX}model", model)
         self.settings.setValue(
             f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}stream_chat", self.stream_check.isChecked()
         )
         self.settings.setValue(
             f"{SETTINGS_PREFIX}auto_approve_tools",
@@ -693,14 +759,19 @@ class ChatDockWidget(QDockWidget):
         if model_id and not self.model_input.text().strip():
             self.model_input.setText(model_id)
         fast = self.fast_check.isChecked()
+        stream = self.stream_check.isChecked()
         auto_approve_tools = self.auto_approve_tools_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         prompt_with_context = self._build_prompt_with_context(prompt)
 
         self._append_message("You", prompt, markdown=False)
+        self._streaming_message_index = None
+        self._streaming_answer = ""
         self.prompt_input.clear()
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
-        self._start_running_status("Running GeoAgent")
+        self._start_running_status(
+            "Streaming GeoAgent" if stream else "Running GeoAgent"
+        )
         self.send_btn.setEnabled(False)
         self.cancel_btn.setEnabled(True)
 
@@ -712,8 +783,10 @@ class ChatDockWidget(QDockWidget):
             fast,
             max_tokens,
             auto_approve_tools,
+            stream,
             self,
         )
+        self._worker.chunk_received.connect(self._on_worker_chunk)
         self._worker.finished.connect(self._on_worker_finished)
         self._worker.start()
 
@@ -801,7 +874,14 @@ class ChatDockWidget(QDockWidget):
                 details.append(f"Elapsed: {result['elapsed']}")
             if details:
                 answer = f"{answer}\n\n" + "\n".join(details)
-            self._append_message("OpenGeoAgent", answer, markdown=True)
+            if result.get("streamed") and self._streaming_message_index is not None:
+                self._update_message(
+                    self._streaming_message_index,
+                    answer,
+                    markdown=True,
+                )
+            else:
+                self._append_message("OpenGeoAgent", answer, markdown=True)
             self.status_label.setText("Ready")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
         else:
@@ -816,6 +896,25 @@ class ChatDockWidget(QDockWidget):
         self.send_btn.setEnabled(True)
         self.cancel_btn.setEnabled(False)
         self._worker = None
+        self._streaming_message_index = None
+        self._streaming_answer = ""
+
+    def _on_worker_chunk(self, chunk):
+        """Render a streamed model text chunk."""
+        if not chunk:
+            return
+        if self._streaming_message_index is None:
+            self._streaming_message_index = len(self._messages)
+            self._messages.append(
+                {"sender": "OpenGeoAgent", "body": "", "markdown": True}
+            )
+            self.copy_md_btn.setEnabled(True)
+        self._streaming_answer += chunk
+        self._update_message(
+            self._streaming_message_index,
+            self._streaming_answer,
+            markdown=True,
+        )
 
     def _cancel_running_task(self):
         """Request cancellation of the in-flight chat worker."""
@@ -873,6 +972,15 @@ class ChatDockWidget(QDockWidget):
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
 
+    def _update_message(self, index, message, markdown=False):
+        """Update an existing chat message and refresh the transcript."""
+        if index < 0 or index >= len(self._messages):
+            return
+        self._messages[index]["body"] = message.strip()
+        self._messages[index]["markdown"] = markdown
+        self.copy_md_btn.setEnabled(bool(self._messages))
+        self._render_transcript()
+
     def _render_transcript(self):
         """Render the stored chat messages as HTML."""
         blocks = []
@@ -888,6 +996,7 @@ class ChatDockWidget(QDockWidget):
                 f"{body}"
                 "</div>"
             )
+        blocks.append("<div style='height: 1em;'>&nbsp;</div>")
         self.transcript.setHtml("\n".join(blocks))
         end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
         self.transcript.moveCursor(end_cursor)

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -90,9 +90,9 @@ def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
     class _StubAgent:
         async def stream_chat(self, prompt: str):
             captured["prompt"] = prompt
-            yield {"data": "hel"}
+            yield {"data": "he"}
             await asyncio.sleep(0)
-            yield {"data": "lo"}
+            yield {"data": "llo"}
 
     def _stub_factory(iface, **kwargs):
         captured["iface"] = iface
@@ -128,7 +128,7 @@ def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
     assert captured.get("iface") is sentinel_iface
     assert captured["prompt"] == "stream please"
     assert captured["kwargs"]["fast"] is True
-    assert chunks == ["hel", "lo"]
+    assert chunks == ["he", "llo"]
     assert emitted["payload"]["success"] is True
     assert emitted["payload"]["answer"] == "hello"
     assert emitted["payload"]["streamed"] is True

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from typing import Any
@@ -77,3 +78,57 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
     assert captured["kwargs"]["confirm"](types.SimpleNamespace(args={})) is True
     assert emitted["payload"]["success"] is True
     assert any("WhiteboxTools" in prompt for prompt in SAMPLE_PROMPTS)
+
+
+def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
+    """ChatWorker.run streams deltas through chunk_received when enabled."""
+    import geoagent
+    from open_geoagent.dialogs.chat_dock import ChatWorker
+
+    captured: dict[str, Any] = {}
+
+    class _StubAgent:
+        async def stream_chat(self, prompt: str):
+            captured["prompt"] = prompt
+            yield {"data": "hel"}
+            await asyncio.sleep(0)
+            yield {"data": "lo"}
+
+    def _stub_factory(iface, **kwargs):
+        captured["iface"] = iface
+        captured["kwargs"] = kwargs
+        return _StubAgent()
+
+    monkeypatch.setattr(geoagent, "for_whitebox", _stub_factory)
+    monkeypatch.setitem(
+        sys.modules,
+        "qgis.core",
+        types.SimpleNamespace(QgsProject=types.SimpleNamespace(instance=lambda: None)),
+    )
+
+    sentinel_iface = object()
+    worker = ChatWorker(
+        iface=sentinel_iface,
+        prompt="stream please",
+        provider="openai-codex",
+        model_id="gpt-5.5",
+        fast=True,
+        max_tokens=1024,
+        auto_approve_tools=True,
+        stream=True,
+    )
+
+    chunks: list[str] = []
+    emitted: dict[str, Any] = {}
+    worker.chunk_received.connect(chunks.append)
+    worker.finished.connect(lambda payload: emitted.setdefault("payload", payload))
+
+    worker.run()
+
+    assert captured.get("iface") is sentinel_iface
+    assert captured["prompt"] == "stream please"
+    assert captured["kwargs"]["fast"] is True
+    assert chunks == ["hel", "lo"]
+    assert emitted["payload"]["success"] is True
+    assert emitted["payload"]["answer"] == "hello"
+    assert emitted["payload"]["streamed"] is True

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -34,6 +34,81 @@ class _MockStreamingAgent:
             yield event
 
 
+def _install_fake_qgis_qt(monkeypatch, calls: dict[str, int] | None = None) -> None:
+    """Install fake qgis.PyQt modules that report the current thread as GUI."""
+
+    class _FakeThread:
+        """Provide a test double for FakeThread."""
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, _FakeThread)
+
+    class _QThread:
+        """Provide a test double for QThread."""
+
+        @staticmethod
+        def currentThread():
+            """Return the current thread."""
+            return _FakeThread()
+
+    class _App:
+        """Provide a test double for App."""
+
+        def thread(self):
+            """Return the associated thread."""
+            return _FakeThread()
+
+        def processEvents(self):
+            """Process events."""
+            if calls is not None:
+                calls["process_events"] += 1
+
+    app = _App()
+
+    class _QApplication:
+        """Provide a test double for QApplication."""
+
+        @staticmethod
+        def instance():
+            """Return the singleton instance."""
+            return app
+
+    class _QObject:
+        """Provide a test double for QObject."""
+
+        def moveToThread(self, _thread):
+            """Move to thread."""
+            return None
+
+    class _QMetaObject:
+        """Provide a test double for QMetaObject."""
+
+        @staticmethod
+        def invokeMethod(*_args, **_kwargs):
+            """Invoke method."""
+            return True
+
+    class _Qt:
+        """Provide a test double for Qt."""
+
+        BlockingQueuedConnection = 0
+
+    fake_qt_core = types.SimpleNamespace(
+        QMetaObject=_QMetaObject,
+        QObject=_QObject,
+        QThread=_QThread,
+        Qt=_Qt,
+        pyqtSlot=lambda *args, **kwargs: lambda fn: fn,
+    )
+    fake_qt_widgets = types.SimpleNamespace(QApplication=_QApplication)
+    fake_pyqt = types.SimpleNamespace(QtCore=fake_qt_core, QtWidgets=fake_qt_widgets)
+    fake_qgis = types.SimpleNamespace(PyQt=fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis", fake_qgis)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt", fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtCore", fake_qt_core)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtWidgets", fake_qt_widgets)
+
+
 def test_chat_success_from_mocked_strands() -> None:
     """Verify that chat success from mocked strands."""
     m = MockLeafmap()
@@ -175,75 +250,17 @@ def test_qgis_chat_on_gui_thread_runs_worker_and_pumps_events(monkeypatch) -> No
     main_thread = threading.current_thread()
     processed = threading.Event()
     calls = {"process_events": 0}
+    _install_fake_qgis_qt(monkeypatch, calls)
 
-    class _FakeThread:
-        """Provide a test double for FakeThread."""
+    def _mark_processed():
+        processed.set()
+        calls["process_events"] += 1
 
-        def __eq__(self, other: object) -> bool:
-            return isinstance(other, _FakeThread)
-
-    class _QThread:
-        """Provide a test double for QThread."""
-
-        @staticmethod
-        def currentThread():
-            """Return the current thread."""
-            return _FakeThread()
-
-    class _App:
-        """Provide a test double for App."""
-
-        def thread(self):
-            """Return the associated thread."""
-            return _FakeThread()
-
-        def processEvents(self):
-            """Process events."""
-            calls["process_events"] += 1
-            processed.set()
-
-    class _QApplication:
-        """Provide a test double for QApplication."""
-
-        @staticmethod
-        def instance():
-            """Return the singleton instance."""
-            return _App()
-
-    class _QObject:
-        """Provide a test double for QObject."""
-
-        def moveToThread(self, _thread):
-            """Move to thread."""
-            return None
-
-    class _QMetaObject:
-        """Provide a test double for QMetaObject."""
-
-        @staticmethod
-        def invokeMethod(*_args, **_kwargs):
-            """Invoke method."""
-            return True
-
-    class _Qt:
-        """Provide a test double for Qt."""
-
-        BlockingQueuedConnection = 0
-
-    fake_qt_core = types.SimpleNamespace(
-        QMetaObject=_QMetaObject,
-        QObject=_QObject,
-        QThread=_QThread,
-        Qt=_Qt,
-        pyqtSlot=lambda *args, **kwargs: lambda fn: fn,
+    # Replace the fake processEvents method for this test so the mocked Strands
+    # call can wait until the GUI event loop has been pumped at least once.
+    sys.modules["qgis.PyQt.QtWidgets"].QApplication.instance().processEvents = (
+        _mark_processed
     )
-    fake_qt_widgets = types.SimpleNamespace(QApplication=_QApplication)
-    fake_pyqt = types.SimpleNamespace(QtCore=fake_qt_core, QtWidgets=fake_qt_widgets)
-    fake_qgis = types.SimpleNamespace(PyQt=fake_pyqt)
-    monkeypatch.setitem(sys.modules, "qgis", fake_qgis)
-    monkeypatch.setitem(sys.modules, "qgis.PyQt", fake_pyqt)
-    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtCore", fake_qt_core)
-    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtWidgets", fake_qt_widgets)
 
     agent = for_qgis(MockQGISIface(), MockQGISProject(), model=_MockModel())
     worker_thread: list[threading.Thread] = []
@@ -268,5 +285,48 @@ def test_qgis_chat_on_gui_thread_runs_worker_and_pumps_events(monkeypatch) -> No
 
     assert resp.success is True
     assert resp.answer_text == "done"
+    assert worker_thread[0] is not main_thread
+    assert calls["process_events"] > 0
+
+
+def test_qgis_stream_chat_on_gui_thread_runs_worker_and_pumps_events(
+    monkeypatch,
+) -> None:
+    """Verify qgis stream_chat on gui thread streams via worker."""
+    main_thread = threading.current_thread()
+    processed = threading.Event()
+    calls = {"process_events": 0}
+    _install_fake_qgis_qt(monkeypatch, calls)
+
+    agent = for_qgis(MockQGISIface(), MockQGISProject(), model=_MockModel())
+    worker_thread: list[threading.Thread] = []
+
+    class _DelayedStreamingAgent:
+        """Provide a streaming agent that waits for Qt event pumping."""
+
+        async def stream_async(self, _query: str):
+            """Yield after the GUI side has pumped Qt events."""
+            worker_thread.append(threading.current_thread())
+            deadline = time.time() + 2.0
+            while not processed.is_set() and time.time() < deadline:
+                await asyncio.sleep(0.01)
+            yield {"data": "do"}
+            yield {"data": "ne"}
+
+    def _process_events():
+        calls["process_events"] += 1
+        processed.set()
+
+    sys.modules["qgis.PyQt.QtWidgets"].QApplication.instance().processEvents = (
+        _process_events
+    )
+    agent._strands = _DelayedStreamingAgent()  # noqa: SLF001
+
+    async def _collect():
+        return [event async for event in agent.stream_chat("list layers")]
+
+    seen = asyncio.run(_collect())
+
+    assert seen == [{"data": "do"}, {"data": "ne"}]
     assert worker_thread[0] is not main_thread
     assert calls["process_events"] > 0


### PR DESCRIPTION
## Summary
- Add a Stream output toggle to the QGIS chat dock so model text renders incrementally instead of only after the turn ends.
- Allow stream_chat to be driven from the QGIS GUI thread via a worker thread that keeps Qt events pumping, matching the existing sync chat behavior.

## Test plan
- [x] pre-commit run --all-files
- [ ] pytest tests/test_geoagent_chat_mock.py qgis_geoagent/tests/test_whitebox_integration.py
- [ ] Manual: enable Stream output in the QGIS dock and confirm tokens render incrementally without freezing the UI.