### PR TITLE
feat: add run_pyqgis_script tool with Copy Script button

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Many geospatial libraries need the same agent features:
 - keep optional geospatial stacks optional;
 - ask for confirmation before deleting layers, saving files, or running
   expensive processing jobs;
+- support multimodal plugin workflows such as pasted images and screenshots
+  when the selected model provider supports vision;
 - provide a stable integration point for downstream packages and plugins.
 
 GeoAgent centralizes that layer so each package does not need to maintain its
@@ -227,6 +229,39 @@ print(resp.answer_text)
 `geoagent.tools.qgis` is import-safe outside QGIS. It imports QGIS classes only
 inside tool bodies, so tests and non-QGIS environments can import the module.
 
+The OpenGeoAgent QGIS plugin adds a dockable chat UI on top of this factory. It
+supports provider and model controls, streaming responses, pasted image
+attachments, screenshot capture from the map canvas, QGIS window, or selected
+screen regions, image preview and save actions, Markdown transcript copying,
+and copying the PyQGIS script used for an executed result.
+
+## QGIS Plugin
+
+OpenGeoAgent is the QGIS plugin interface for GeoAgent. It adds a dockable AI
+assistant to QGIS so you can inspect projects, navigate the map canvas, load
+data, run processing workflows, style layers, and execute confirmation-gated
+PyQGIS scripts from natural language.
+
+![OpenGeoAgent QGIS plugin](https://github.com/user-attachments/assets/3047e39c-ad0a-4d77-a822-9597da539775)
+
+Key plugin features:
+
+- provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth,
+  Anthropic, Google Gemini, Ollama, and LiteLLM;
+- project-aware QGIS tools for layers, selections, map navigation, processing,
+  project saving, and attribute table actions;
+- image-aware chat with clipboard paste and screenshot attachments for models
+  that support vision inputs;
+- screenshot capture from the map canvas, selected map regions, the QGIS
+  window, and selected screen regions;
+- image preview and save/export actions;
+- copy Markdown transcript and copy executed PyQGIS script actions;
+- confirmation-gated `run_pyqgis_script` fallback when a task needs QGIS API
+  operations that are not covered by a dedicated tool;
+- lazy dependency checks so opening the chat dock stays responsive.
+
+See the [QGIS plugin documentation](docs/qgis-plugin.md) for setup and usage.
+
 ## Built-In Tool Surfaces
 
 ### leafmap and anymap
@@ -262,10 +297,16 @@ marshaller:
   `set_layer_opacity`;
 - select and process: `select_features_by_expression`, `clear_selection`,
   `run_processing_algorithm`;
-- open QGIS UI and save: `open_attribute_table`, `save_project`.
+- open QGIS UI and save: `open_attribute_table`, `save_project`;
+- run confirmation-gated PyQGIS fallback scripts with `run_pyqgis_script`
+  when a task requires QGIS API operations that are not covered by a dedicated
+  tool.
 
 QGIS chat uses a sequential tool executor and GUI-thread marshalling so map
-canvas and layer-tree calls are routed safely.
+canvas and layer-tree calls are routed safely. The PyQGIS fallback receives
+the current `iface`, `project`, `canvas`, and `active_layer`, making it useful
+for actions such as raster band renderer changes, labeling tweaks, layer tree
+updates, and other QGIS API operations.
 
 ### NASA OPERA
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,9 @@ workflows.
   `for_leafmap`, `for_anymap`, `for_qgis`, and `create_agent`.
 - Built-in tools for live maps, QGIS projects, STAC-style workflows, Earth
   observation workflows, and optional geospatial packages.
+- OpenGeoAgent QGIS plugin UI with pasted image attachments, screenshot
+  capture, image preview/save actions, transcript copying, and PyQGIS script
+  copying.
 - Confirmation hooks for destructive, persistent, or long-running tools.
 - Mock map and QGIS objects so integrations can be tested without full desktop
   or widget environments.
@@ -150,6 +153,12 @@ agent.chat("Summarize this project and zoom to the active layer.")
 QGIS tools are import-safe outside QGIS and run through a Qt GUI-thread
 marshaller when used in QGIS.
 
+The OpenGeoAgent QGIS plugin adds a dockable multimodal chat panel. Users can
+paste images from the clipboard, capture the map canvas, capture the QGIS
+window, select map or screen regions, preview and save attached images, copy
+the Markdown transcript, and copy the PyQGIS script that produced an executed
+result.
+
 ## Built-In Tool Surfaces
 
 ### Map Widgets
@@ -176,7 +185,9 @@ marshaller when used in QGIS.
 - selecting features with QGIS expressions and clearing selections;
 - zooming to selected features;
 - running QGIS Processing algorithms;
-- opening attribute tables and saving projects.
+- opening attribute tables and saving projects;
+- running confirmation-gated PyQGIS fallback scripts when the requested QGIS
+  API operation is not covered by a dedicated tool.
 
 ### Custom and Package Tools
 
@@ -219,6 +230,7 @@ Qt dialog, notebook modal, web prompt, or CLI prompt.
 ## Learn More
 
 - [Installation](installation.md)
+- [QGIS Plugin](qgis-plugin.md)
 - [Usage](usage.md)
 - [Tools](tools.md)
 - [Safety](safety.md)

--- a/docs/qgis-plugin.md
+++ b/docs/qgis-plugin.md
@@ -1,0 +1,95 @@
+# QGIS Plugin
+
+[![QGIS Plugin](https://img.shields.io/badge/QGIS-Plugin-green.svg)](https://plugins.qgis.org/plugins/open_geoagent)
+
+OpenGeoAgent is the QGIS plugin interface for GeoAgent. It adds a dockable,
+project-aware AI assistant to QGIS and connects it to GeoAgent's QGIS tool
+surface.
+
+![OpenGeoAgent QGIS plugin](https://github.com/user-attachments/assets/3047e39c-ad0a-4d77-a822-9597da539775)
+
+## Install
+
+Install the plugin from the QGIS Plugin Manager by searching for
+**OpenGeoAgent**. For local development, install or symlink the plugin directory
+from `qgis_geoagent/open_geoagent` into your QGIS plugin profile.
+
+Open the plugin from the QGIS toolbar or plugin menu, then use
+**Settings > Dependencies** to install GeoAgent and provider clients into the
+plugin-managed environment. QGIS itself remains provided by your desktop QGIS
+installation.
+
+## Provider Setup
+
+OpenGeoAgent supports the same provider families as GeoAgent:
+
+- Bedrock
+- OpenAI
+- ChatGPT/Codex OAuth
+- Anthropic
+- Google Gemini
+- Ollama
+- LiteLLM
+
+Use the settings panel to configure API keys, hosts, model defaults, and
+dependency status. Vision features require a provider and model that support
+image inputs.
+
+## Chat With QGIS
+
+The chat dock is aware of the current QGIS project and active layer. It can
+inspect project state, summarize layers, navigate the map canvas, add vector,
+raster, and XYZ tile layers, select features, run QGIS Processing algorithms,
+open attribute tables, and save projects.
+
+Examples:
+
+- "Summarize all layers in this project."
+- "Zoom to the active layer and describe its CRS and extent."
+- "Select parcels where population is greater than 10000."
+- "Add this raster and set its opacity to 60 percent."
+- "Use a false color composite for the active NAIP layer."
+
+## Images And Screenshots
+
+OpenGeoAgent supports image attachments in chat messages. You can paste images
+from the clipboard directly into the chat input, or use the screenshot menu to
+attach visual context from QGIS.
+
+Screenshot options include:
+
+- capture the map canvas;
+- select a region on the map canvas;
+- capture the QGIS window;
+- select a region on the screen.
+
+Attached images appear as thumbnails in the chat. Click an image to open a
+larger preview, then use the save action or context menu to export it.
+
+## PyQGIS Fallback
+
+When a request needs QGIS API functionality that is not covered by a dedicated
+GeoAgent tool, the agent can use the confirmation-gated `run_pyqgis_script`
+fallback. The script runs in the QGIS GUI context with access to `iface`,
+`project`, `canvas`, and `active_layer`.
+
+This is useful for tasks such as raster band renderer changes, labeling
+updates, layer tree adjustments, and other PyQGIS operations. The plugin asks
+for confirmation before running the script.
+
+Use **Copy Script** to copy the PyQGIS code that produced the result. The
+copied snippet includes a QGIS-console-ready preamble so it can be inspected,
+shared, or rerun.
+
+## Copy And Review
+
+The chat dock includes actions for copying the Markdown transcript and the most
+recent executed PyQGIS script. These are intended for reproducibility,
+debugging, and sharing workflows outside the plugin.
+
+## Safety
+
+OpenGeoAgent uses GeoAgent's confirmation hook for destructive, persistent, or
+long-running operations. Actions such as deleting layers, saving projects,
+running processing jobs, and executing fallback PyQGIS scripts require user
+approval before they run.

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -153,6 +153,11 @@ Workflow guidance:
 - Use QGIS layer names as input values only when the layer is backed by a
   local file. Otherwise ask the user to export the layer or provide a file.
 - Generated outputs are added back to QGIS when possible.
+- When the user asks for a QGIS API operation that has no dedicated tool, such
+  as raster renderer/band styling, labeling, layer tree tweaks, or other
+  project/canvas changes, write a short PyQGIS script and run it with
+  run_pyqgis_script. Do not merely provide a script for the user to paste when
+  run_pyqgis_script can safely perform the requested QGIS change.
 - Keep responses concise and include the Whitebox tool name, output path, and
   loaded layer names when available.
 """

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -126,6 +126,22 @@ Workflow guidance:
   response in west,south,east,north order.
 """
 
+QGIS_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS with access to PyQGIS-backed tools.
+
+Workflow guidance:
+- Use QGIS layer names as input values only when the layer is backed by a
+  local file. Otherwise ask the user to export the layer or provide a file.
+- Generated outputs are added back to QGIS when possible.
+- When the user asks for a QGIS API operation that has no dedicated tool, such
+  as raster renderer/band styling, labeling, layer tree tweaks, or other
+  project/canvas changes, write a short PyQGIS script and run it with
+  run_pyqgis_script. Do not merely provide a script for the user to paste when
+  run_pyqgis_script can safely perform the requested QGIS change.
+- Keep responses concise and include the tool name, output path, and loaded
+  layer names when available.
+"""
+
 WHITEBOX_SYSTEM_PROMPT = """\
 You are an AI assistant embedded in QGIS with access to WhiteboxTools.
 WhiteboxTools exposes hundreds of geospatial analysis commands through a
@@ -376,7 +392,11 @@ def for_qgis(
     extra_tools: Optional[list[Any]] = None,
 ) -> GeoAgent:
     """Bind an agent to QGIS ``iface`` (and optional ``project``)."""
-    ctx = GeoAgentContext(qgis_iface=iface, qgis_project=project)
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={"system_prompt": QGIS_SYSTEM_PROMPT},
+    )
     tools, registry = assemble_tools(
         context=ctx,
         include_qgis=True,

--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -17,6 +17,9 @@ Typical usage from inside a QGIS plugin's Python console::
 
 from __future__ import annotations
 
+import ast
+import contextlib
+import io
 import tempfile
 from pathlib import Path
 from typing import Any, Optional
@@ -24,6 +27,98 @@ from urllib.parse import quote
 
 from geoagent.core.decorators import geo_tool
 from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+_PYQGIS_ALLOWED_IMPORTS = ("qgis", "math")
+_PYQGIS_BLOCKED_CALLS = {
+    "__import__",
+    "compile",
+    "eval",
+    "exec",
+    "input",
+    "open",
+}
+
+
+def _validate_pyqgis_script(code: str) -> None:
+    """Reject generated code that is outside the intended PyQGIS scope."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        raise ValueError(f"Invalid Python syntax: {exc}") from exc
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if not alias.name.startswith(_PYQGIS_ALLOWED_IMPORTS):
+                    raise ValueError(
+                        "Only qgis/PyQt and math imports are allowed in "
+                        "run_pyqgis_script."
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level or not module.startswith(_PYQGIS_ALLOWED_IMPORTS):
+                raise ValueError(
+                    "Only absolute qgis/PyQt and math imports are allowed in "
+                    "run_pyqgis_script."
+                )
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in _PYQGIS_BLOCKED_CALLS:
+                raise ValueError(
+                    f"Calling {node.func.id!r} is not allowed in run_pyqgis_script."
+                )
+        elif isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            raise ValueError("Dunder attribute access is not allowed.")
+        elif isinstance(node, ast.Name) and node.id in {
+            "__builtins__",
+            "__dict__",
+            "__globals__",
+            "__subclasses__",
+        }:
+            raise ValueError(f"Access to {node.id!r} is not allowed.")
+
+
+def _limited_pyqgis_import(
+    name: str,
+    globals: dict[str, Any] | None = None,
+    locals: dict[str, Any] | None = None,
+    fromlist: tuple[str, ...] = (),
+    level: int = 0,
+) -> Any:
+    """Allow imports needed for PyQGIS snippets and reject everything else."""
+    if level or not name.startswith(_PYQGIS_ALLOWED_IMPORTS):
+        raise ImportError(
+            f"Import {name!r} is not allowed in run_pyqgis_script. "
+            "Use QGIS/PyQt API imports only."
+        )
+    return __import__(name, globals, locals, fromlist, level)
+
+
+def _pyqgis_builtins() -> dict[str, Any]:
+    """Return a small builtins namespace for generated PyQGIS snippets."""
+    return {
+        "__import__": _limited_pyqgis_import,
+        "abs": abs,
+        "all": all,
+        "any": any,
+        "bool": bool,
+        "dict": dict,
+        "enumerate": enumerate,
+        "float": float,
+        "int": int,
+        "isinstance": isinstance,
+        "len": len,
+        "list": list,
+        "max": max,
+        "min": min,
+        "print": print,
+        "range": range,
+        "round": round,
+        "set": set,
+        "str": str,
+        "sum": sum,
+        "tuple": tuple,
+        "zip": zip,
+    }
 
 
 def _qcolor(value: Any) -> Any:
@@ -1393,6 +1488,81 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
     @geo_tool(
         category="qgis",
         requires_confirmation=True,
+        destructive=True,
+    )
+    def run_pyqgis_script(code: str, description: str = "") -> dict[str, Any]:
+        """Run a short PyQGIS script when no dedicated GeoAgent tool exists.
+
+        Use this for QGIS API operations that are not covered by a named
+        GeoAgent tool, such as raster renderer/band styling, labeling, layer
+        tree tweaks, or other project/canvas changes. The script runs on the
+        QGIS GUI thread with ``iface``, ``project``, ``canvas``, and
+        ``active_layer`` already defined.
+
+        Args:
+            code: Python code using the QGIS/PyQt API. Imports are limited to
+                qgis/PyQt and math modules. Do not use this for shell,
+                network, filesystem, or secret-handling operations.
+            description: One-sentence explanation of the intended QGIS change.
+
+        Returns:
+            A dict with success status, printed output, changed variable names,
+            and the executed code.
+        """
+        code = (code or "").strip()
+        if not code:
+            return {
+                "success": False,
+                "error": "No PyQGIS code was provided.",
+                "pyqgis_script": "",
+            }
+        _validate_pyqgis_script(code)
+
+        def _run() -> dict[str, Any]:
+            """Run the generated PyQGIS script on the GUI thread."""
+            proj = _project()
+            canvas = iface.mapCanvas() if hasattr(iface, "mapCanvas") else None
+            active_layer = (
+                iface.activeLayer() if hasattr(iface, "activeLayer") else None
+            )
+            namespace: dict[str, Any] = {
+                "__builtins__": _pyqgis_builtins(),
+                "iface": iface,
+                "project": proj,
+                "canvas": canvas,
+                "active_layer": active_layer,
+            }
+            stdout = io.StringIO()
+            try:
+                with contextlib.redirect_stdout(stdout):
+                    exec(  # nosec B102 - confirmation-gated PyQGIS tool.
+                        compile(code, "<geoagent_pyqgis_script>", "exec"),
+                        namespace,
+                    )
+            except Exception as exc:
+                return {
+                    "success": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "stdout": stdout.getvalue().strip(),
+                    "description": description,
+                    "pyqgis_script": code,
+                }
+
+            ignored = {"__builtins__", "iface", "project", "canvas", "active_layer"}
+            variables = sorted(k for k in namespace if k not in ignored)
+            return {
+                "success": True,
+                "message": description or "PyQGIS script executed.",
+                "stdout": stdout.getvalue().strip(),
+                "variables": variables,
+                "pyqgis_script": code,
+            }
+
+        return _on_gui(_run)
+
+    @geo_tool(
+        category="qgis",
+        requires_confirmation=True,
     )
     def save_project(path: Optional[str] = None) -> str:
         """Save the current QGIS project, optionally to a new file path."""
@@ -1445,6 +1615,7 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         buffer_active_layer,
         open_attribute_table,
         refresh_canvas,
+        run_pyqgis_script,
         save_project,
     ]
 

--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -28,7 +28,7 @@ from urllib.parse import quote
 from geoagent.core.decorators import geo_tool
 from geoagent.tools._qt_marshal import run_on_qt_gui_thread
 
-_PYQGIS_ALLOWED_IMPORTS = ("qgis", "math")
+_PYQGIS_ALLOWED_TOP_LEVEL = frozenset({"qgis", "math"})
 _PYQGIS_BLOCKED_CALLS = {
     "__import__",
     "compile",
@@ -37,6 +37,18 @@ _PYQGIS_BLOCKED_CALLS = {
     "input",
     "open",
 }
+
+
+def _is_allowed_pyqgis_module(name: str) -> bool:
+    """Return True only for the qgis/math packages and their submodules.
+
+    Matching on the top-level package (split on ``.``) avoids prefix
+    collisions with unrelated modules such as ``mathutils`` or ``qgisx``.
+    """
+    if not name:
+        return False
+    top, _, _ = name.partition(".")
+    return top in _PYQGIS_ALLOWED_TOP_LEVEL
 
 
 def _validate_pyqgis_script(code: str) -> None:
@@ -49,14 +61,14 @@ def _validate_pyqgis_script(code: str) -> None:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if not alias.name.startswith(_PYQGIS_ALLOWED_IMPORTS):
+                if not _is_allowed_pyqgis_module(alias.name):
                     raise ValueError(
                         "Only qgis/PyQt and math imports are allowed in "
                         "run_pyqgis_script."
                     )
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
-            if node.level or not module.startswith(_PYQGIS_ALLOWED_IMPORTS):
+            if node.level or not _is_allowed_pyqgis_module(module):
                 raise ValueError(
                     "Only absolute qgis/PyQt and math imports are allowed in "
                     "run_pyqgis_script."
@@ -85,7 +97,7 @@ def _limited_pyqgis_import(
     level: int = 0,
 ) -> Any:
     """Allow imports needed for PyQGIS snippets and reject everything else."""
-    if level or not name.startswith(_PYQGIS_ALLOWED_IMPORTS):
+    if level or not _is_allowed_pyqgis_module(name):
         raise ImportError(
             f"Import {name!r} is not allowed in run_pyqgis_script. "
             "Use QGIS/PyQt API imports only."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,9 +74,9 @@ markdown_extensions:
 
 nav:
     - Home: index.md
-    - Getting Started:
-        - Installation: installation.md
-        - Usage: usage.md
+    - Installation: installation.md
+    - Usage: usage.md
+    - QGIS Plugin: qgis-plugin.md
     - Changelog: https://github.com/opengeos/GeoAgent/releases
     - Report Issues: https://github.com/opengeos/GeoAgent/issues
     - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.1.1"
+version = "1.2.0"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -76,7 +76,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.1.1"
+current_version = "1.2.0"
 commit = true
 tag = true
 

--- a/qgis_geoagent/open_geoagent/__init__.py
+++ b/qgis_geoagent/open_geoagent/__init__.py
@@ -1,11 +1,6 @@
 """OpenGeoAgent QGIS plugin."""
 
-from .deps_manager import ensure_venv_packages_available
-
-# Add isolated dependency site-packages to sys.path before importing GeoAgent.
-ensure_venv_packages_available()
-
-from .open_geoagent import OpenGeoAgent  # noqa: E402
+from .open_geoagent import OpenGeoAgent
 
 
 def classFactory(iface):

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -168,7 +168,9 @@ def all_dependencies_met() -> bool:
     Returns:
         True if all dependencies are installed and importable.
     """
-    return all(_dependency_importable(import_name) for import_name, _ in REQUIRED_PACKAGES)
+    return all(
+        _dependency_importable(import_name) for import_name, _ in REQUIRED_PACKAGES
+    )
 
 
 def get_missing_packages() -> List[str]:

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -15,6 +15,7 @@ document this explicitly for the plugins.qgis.org Bandit scan.
 """
 
 import importlib
+import importlib.util
 import os
 import platform
 import shutil
@@ -138,13 +139,27 @@ def check_dependencies() -> List[Dict]:
             "version": None,
         }
         try:
-            mod = importlib.import_module(import_name)
+            spec = importlib.util.find_spec(import_name)
+            if spec is None:
+                raise ImportError(import_name)
             info["installed"] = True
-            info["version"] = getattr(mod, "__version__", "installed")
+            try:
+                mod = importlib.import_module(import_name)
+                info["version"] = getattr(mod, "__version__", "installed")
+            except Exception:
+                info["version"] = "installed"
         except ImportError:
             pass
         results.append(info)
     return results
+
+
+def _dependency_importable(import_name: str) -> bool:
+    """Return True when a dependency can be imported without importing it now."""
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
 
 
 def all_dependencies_met() -> bool:
@@ -153,7 +168,7 @@ def all_dependencies_met() -> bool:
     Returns:
         True if all dependencies are installed and importable.
     """
-    return all(dep["installed"] for dep in check_dependencies())
+    return all(_dependency_importable(import_name) for import_name, _ in REQUIRED_PACKAGES)
 
 
 def get_missing_packages() -> List[str]:

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -15,6 +15,7 @@ document this explicitly for the plugins.qgis.org Bandit scan.
 """
 
 import importlib
+import importlib.metadata
 import importlib.util
 import os
 import platform
@@ -124,41 +125,58 @@ def ensure_venv_packages_available() -> bool:
     return True
 
 
-def _dependency_importable(import_name: str) -> Tuple[bool, Optional[str]]:
-    """Return whether a dependency can actually be imported right now.
+def _dependency_discoverable(import_name: str) -> Tuple[bool, Optional[str]]:
+    """Return whether a dependency is discoverable on ``sys.path``.
 
-    ``importlib.util.find_spec`` only confirms the module is discoverable on
-    ``sys.path``; the import itself can still raise (missing native deps,
-    import-time exceptions, broken installs). This helper performs the real
-    import so callers reflect runtime importability rather than discoverability.
+    The plugin uses this lightweight check while opening the chat dock. Some
+    provider modules are expensive to import, so startup should only confirm
+    they are installed and leave full imports to the actual chat request.
 
     Args:
         import_name: Dotted module name to probe.
 
     Returns:
-        Tuple of (importable, error_message). ``error_message`` is ``None`` when
-        importable is ``True``.
+        Tuple of (discoverable, error_message). ``error_message`` is ``None``
+        when discoverable is ``True``.
     """
     try:
         if importlib.util.find_spec(import_name) is None:
             return False, f"No module named {import_name!r}"
     except (ImportError, ModuleNotFoundError, ValueError) as exc:
         return False, f"{type(exc).__name__}: {exc}"
-    try:
-        importlib.import_module(import_name)
-    except Exception as exc:
-        return False, f"{type(exc).__name__}: {exc}"
     return True, None
 
 
+def _distribution_name(pip_name: str) -> str:
+    """Return a best-effort distribution name from a pip requirement string."""
+    return (
+        pip_name.split("[", 1)[0]
+        .split(">", 1)[0]
+        .split("<", 1)[0]
+        .split("=", 1)[0]
+        .strip()
+    )
+
+
+def _dependency_version(pip_name: str) -> Optional[str]:
+    """Return an installed distribution version without importing the package."""
+    try:
+        return importlib.metadata.version(_distribution_name(pip_name))
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
 def check_dependencies() -> List[Dict]:
-    """Check if required Python packages are importable.
+    """Check if required Python packages are discoverable.
+
+    This intentionally avoids importing provider modules so opening the
+    settings panel stays responsive.
 
     Returns:
         List of dicts with keys: name, pip_name, installed, version, error.
-        ``error`` is populated when the package is discoverable but importing
-        it fails at runtime (e.g., missing native dependency).
+        ``error`` is populated when the package is not discoverable.
     """
+    ensure_venv_packages_available()
     results = []
     for import_name, pip_name in REQUIRED_PACKAGES:
         info: Dict = {
@@ -168,15 +186,10 @@ def check_dependencies() -> List[Dict]:
             "version": None,
             "error": None,
         }
-        importable, error = _dependency_importable(import_name)
-        if importable:
+        discoverable, error = _dependency_discoverable(import_name)
+        if discoverable:
             info["installed"] = True
-            try:
-                mod = importlib.import_module(import_name)
-                info["version"] = getattr(mod, "__version__", "installed")
-            except Exception as exc:  # pragma: no cover - defensive
-                info["installed"] = False
-                info["error"] = f"{type(exc).__name__}: {exc}"
+            info["version"] = _dependency_version(pip_name) or "installed"
         else:
             info["error"] = error
         results.append(info)
@@ -184,16 +197,19 @@ def check_dependencies() -> List[Dict]:
 
 
 def all_dependencies_met() -> bool:
-    """Return True if every required package can actually be imported.
+    """Return True if every required package is discoverable.
 
-    Uses a real ``importlib.import_module`` call (not just ``find_spec``) so
-    discoverable-but-broken installs do not falsely satisfy the gate.
+    This is used on the chat-dock opening path, so it must avoid importing
+    heavy provider packages. Full imports happen later when the user sends a
+    chat request, where any provider-specific import error can be reported in
+    the chat panel.
 
     Returns:
-        True if all dependencies import successfully.
+        True if all dependencies are discoverable on ``sys.path``.
     """
+    ensure_venv_packages_available()
     return all(
-        _dependency_importable(import_name)[0] for import_name, _ in REQUIRED_PACKAGES
+        _dependency_discoverable(import_name)[0] for import_name, _ in REQUIRED_PACKAGES
     )
 
 

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -124,11 +124,40 @@ def ensure_venv_packages_available() -> bool:
     return True
 
 
+def _dependency_importable(import_name: str) -> Tuple[bool, Optional[str]]:
+    """Return whether a dependency can actually be imported right now.
+
+    ``importlib.util.find_spec`` only confirms the module is discoverable on
+    ``sys.path``; the import itself can still raise (missing native deps,
+    import-time exceptions, broken installs). This helper performs the real
+    import so callers reflect runtime importability rather than discoverability.
+
+    Args:
+        import_name: Dotted module name to probe.
+
+    Returns:
+        Tuple of (importable, error_message). ``error_message`` is ``None`` when
+        importable is ``True``.
+    """
+    try:
+        if importlib.util.find_spec(import_name) is None:
+            return False, f"No module named {import_name!r}"
+    except (ImportError, ModuleNotFoundError, ValueError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    try:
+        importlib.import_module(import_name)
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return True, None
+
+
 def check_dependencies() -> List[Dict]:
     """Check if required Python packages are importable.
 
     Returns:
-        List of dicts with keys: name, pip_name, installed, version.
+        List of dicts with keys: name, pip_name, installed, version, error.
+        ``error`` is populated when the package is discoverable but importing
+        it fails at runtime (e.g., missing native dependency).
     """
     results = []
     for import_name, pip_name in REQUIRED_PACKAGES:
@@ -137,39 +166,34 @@ def check_dependencies() -> List[Dict]:
             "pip_name": pip_name,
             "installed": False,
             "version": None,
+            "error": None,
         }
-        try:
-            spec = importlib.util.find_spec(import_name)
-            if spec is None:
-                raise ImportError(import_name)
+        importable, error = _dependency_importable(import_name)
+        if importable:
             info["installed"] = True
             try:
                 mod = importlib.import_module(import_name)
                 info["version"] = getattr(mod, "__version__", "installed")
-            except Exception:
-                info["version"] = "installed"
-        except ImportError:
-            pass
+            except Exception as exc:  # pragma: no cover - defensive
+                info["installed"] = False
+                info["error"] = f"{type(exc).__name__}: {exc}"
+        else:
+            info["error"] = error
         results.append(info)
     return results
 
 
-def _dependency_importable(import_name: str) -> bool:
-    """Return True when a dependency can be imported without importing it now."""
-    try:
-        return importlib.util.find_spec(import_name) is not None
-    except (ImportError, ModuleNotFoundError, ValueError):
-        return False
-
-
 def all_dependencies_met() -> bool:
-    """Return True if all required packages are importable.
+    """Return True if every required package can actually be imported.
+
+    Uses a real ``importlib.import_module`` call (not just ``find_spec``) so
+    discoverable-but-broken installs do not falsely satisfy the gate.
 
     Returns:
-        True if all dependencies are installed and importable.
+        True if all dependencies import successfully.
     """
     return all(
-        _dependency_importable(import_name) for import_name, _ in REQUIRED_PACKAGES
+        _dependency_importable(import_name)[0] for import_name, _ in REQUIRED_PACKAGES
     )
 
 

--- a/qgis_geoagent/open_geoagent/dialogs/__init__.py
+++ b/qgis_geoagent/open_geoagent/dialogs/__init__.py
@@ -1,7 +1,24 @@
-"""OpenGeoAgent dock widgets and dialogs."""
+"""OpenGeoAgent dock widgets and dialogs.
 
-from .chat_dock import ChatDockWidget
-from .settings_dock import SettingsDockWidget
-from .update_checker import UpdateCheckerDialog
+The dialog classes are imported lazily so opening one panel does not import
+all plugin dialogs and their helper modules.
+"""
 
 __all__ = ["ChatDockWidget", "SettingsDockWidget", "UpdateCheckerDialog"]
+
+
+def __getattr__(name):
+    """Import dialog classes on first attribute access."""
+    if name == "ChatDockWidget":
+        from .chat_dock import ChatDockWidget
+
+        return ChatDockWidget
+    if name == "SettingsDockWidget":
+        from .settings_dock import SettingsDockWidget
+
+        return SettingsDockWidget
+    if name == "UpdateCheckerDialog":
+        from .update_checker import UpdateCheckerDialog
+
+        return UpdateCheckerDialog
+    raise AttributeError(name)

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -337,6 +337,53 @@ def _format_tool_calls(tool_calls):
     return "\n".join(lines) if len(lines) > 1 else ""
 
 
+def _latest_pyqgis_script(tool_calls):
+    """Return the last PyQGIS script found in recorded tool calls."""
+    for call in reversed(tool_calls or []):
+        if not isinstance(call, dict):
+            continue
+        if str(call.get("name") or "").strip() != "run_pyqgis_script":
+            continue
+        args = call.get("args")
+        if not isinstance(args, dict):
+            continue
+        code = str(args.get("code") or "").strip()
+        if code:
+            return code
+    return ""
+
+
+def _console_ready_pyqgis_script(code):
+    """Return PyQGIS code that can run in the QGIS Python Console."""
+    code = str(code or "").strip()
+    if not code:
+        return ""
+    preamble = """# OpenGeoAgent PyQGIS script.
+# This preamble makes scripts copied from GeoAgent runnable in the QGIS Python Console.
+try:
+    iface
+except NameError:
+    from qgis.utils import iface
+
+try:
+    project
+except NameError:
+    from qgis.core import QgsProject
+    project = QgsProject.instance()
+
+try:
+    canvas
+except NameError:
+    canvas = iface.mapCanvas()
+
+try:
+    active_layer
+except NameError:
+    active_layer = iface.activeLayer()
+"""
+    return f"{preamble}\n{code}\n"
+
+
 def _conversation_markdown(messages):
     """Return the full chat transcript as Markdown."""
     blocks = []
@@ -884,6 +931,7 @@ class ChatDockWidget(QDockWidget):
         self._prompt_history = []
         self._history_index = None
         self._messages = []
+        self._last_pyqgis_script = ""
         self._image_attachments = []
         self._streaming_message_index = None
         self._streaming_answer = ""
@@ -1031,6 +1079,14 @@ class ChatDockWidget(QDockWidget):
         self.copy_md_btn.setEnabled(False)
         self.copy_md_btn.clicked.connect(self._copy_transcript_markdown)
         primary_button_layout.addWidget(self.copy_md_btn)
+
+        self.copy_script_btn = QPushButton("Copy Script")
+        self.copy_script_btn.setEnabled(False)
+        self.copy_script_btn.setToolTip(
+            "Copy the most recent PyQGIS script executed by GeoAgent."
+        )
+        self.copy_script_btn.clicked.connect(self._copy_last_pyqgis_script)
+        primary_button_layout.addWidget(self.copy_script_btn)
         layout.addLayout(primary_button_layout)
 
         self.status_label = QLabel("Ready. Ctrl+Enter sends. Up/Down cycles prompts.")
@@ -1571,7 +1627,12 @@ class ChatDockWidget(QDockWidget):
         elif result.get("success"):
             answer = result.get("answer") or "(No text response.)"
             details = []
-            tool_inputs = _format_tool_calls(result.get("tool_calls") or [])
+            tool_calls = result.get("tool_calls") or []
+            pyqgis_script = _latest_pyqgis_script(tool_calls)
+            if pyqgis_script:
+                self._last_pyqgis_script = pyqgis_script
+                self.copy_script_btn.setEnabled(True)
+            tool_inputs = _format_tool_calls(tool_calls)
             if tool_inputs:
                 details.append(tool_inputs)
             if result.get("tools"):
@@ -1735,9 +1796,24 @@ class ChatDockWidget(QDockWidget):
             self.status_label.setText("Copied chat history as Markdown.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
+    def _copy_last_pyqgis_script(self):
+        """Copy the most recent executed PyQGIS script to the clipboard."""
+        script = _console_ready_pyqgis_script(self._last_pyqgis_script)
+        if not script:
+            self.status_label.setText("No PyQGIS script is available to copy.")
+            self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+            return
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(script)
+            self.status_label.setText("Copied PyQGIS script.")
+            self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
     def _clear_transcript(self):
         """Clear all rendered chat messages."""
         self._messages = []
+        self._last_pyqgis_script = ""
+        self.copy_script_btn.setEnabled(False)
         self.copy_md_btn.setEnabled(False)
         self.transcript.clear()
 

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -2,20 +2,26 @@
 name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
-description=GeoAgent-powered AI chatbot for QGIS projects.
-version=0.1.0
+description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
+version=1.0.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
-about=OpenGeoAgent provides a dockable chatbot interface for QGIS that builds on GeoAgent's QGIS tool surface.
+about=OpenGeoAgent provides a dockable multimodal chatbot interface for QGIS that builds on GeoAgent's QGIS tool surface.
 
     Features:
     - Dockable chat panel for asking questions about the current QGIS project
     - QGIS-safe GeoAgent tools for layer inspection, map navigation, data loading, selection, processing, and project operations
+    - Confirmation-gated PyQGIS script execution fallback for QGIS API tasks without a dedicated tool
     - Provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, and LiteLLM
+    - Image-aware chat with clipboard paste support for providers and models that support vision inputs
+    - Screenshot attachments from the map canvas, selected map regions, the QGIS window, and selected screen regions
+    - Clickable image previews with save/export actions
+    - Copy Markdown transcript and copy executed PyQGIS script actions
     - Sample prompts, prompt history with Up/Down, and Ctrl+Enter sending
     - Settings panel for API keys, hosts, model defaults, and dependency status
     - One-click dependency installer using uv with an isolated virtual environment
+    - Lazy startup checks to keep opening the chat dock responsive
     - GitHub update checker
     - Local installation and packaging scripts
 
@@ -27,7 +33,7 @@ repository=https://github.com/opengeos/GeoAgent
 
 hasProcessingProvider=no
 
-tags=ai, agent, qgis, geospatial, chatbot, geoagent, llm, gemini
+tags=ai, agent, qgis, geospatial, chatbot, geoagent, llm, gemini, pyqgis, vision, multimodal, screenshot
 
 homepage=https://github.com/opengeos/GeoAgent
 category=Plugins
@@ -37,6 +43,14 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.0.0 - Initial stable OpenGeoAgent release
+        - Added clipboard image paste support for chat attachments
+        - Added screenshot capture for map canvas, selected map regions, QGIS window, and selected screen regions
+        - Added image preview, save, and export actions
+        - Added confirmation-gated PyQGIS script execution fallback
+        - Added copy Markdown transcript and copy executed PyQGIS script actions
+        - Improved chat dock startup with lazy imports and lightweight dependency checks
+
     0.1.0 - Initial OpenGeoAgent plugin
         - Added GeoAgent-backed QGIS chat dock
         - Added provider/model settings and credential fields

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -5,11 +5,13 @@ from qgis.PyQt.QtGui import QColor, QImage
 
 from open_geoagent.dialogs.chat_dock import (
     _build_chat_content,
+    _console_ready_pyqgis_script,
     _conversation_markdown,
     _format_tool_calls,
     _grab_screen_rect,
     _grab_widget_global_rect,
     _image_to_png_bytes,
+    _latest_pyqgis_script,
     _normalized_crop_rect,
 )
 
@@ -72,6 +74,35 @@ def test_build_chat_content_adds_image_blocks() -> None:
         {"text": "Describe this map screenshot."},
         {"image": {"format": "png", "source": {"bytes": b"png-bytes"}}},
     ]
+
+
+def test_latest_pyqgis_script_extracts_last_run_script() -> None:
+    """Verify the copy-script button gets the full latest PyQGIS snippet."""
+    script = _latest_pyqgis_script(
+        [
+            {"name": "get_active_layer", "args": {}},
+            {
+                "name": "run_pyqgis_script",
+                "args": {"code": "print('first')"},
+            },
+            {
+                "name": "run_pyqgis_script",
+                "args": {"code": "active_layer.triggerRepaint()"},
+            },
+        ]
+    )
+
+    assert script == "active_layer.triggerRepaint()"
+
+
+def test_console_ready_pyqgis_script_defines_geoagent_context_names() -> None:
+    """Verify copied scripts can run in the QGIS Python Console."""
+    script = _console_ready_pyqgis_script("layer = active_layer\ncanvas.refresh()")
+
+    assert "from qgis.utils import iface" in script
+    assert "QgsProject.instance()" in script
+    assert "active_layer = iface.activeLayer()" in script
+    assert script.endswith("layer = active_layer\ncanvas.refresh()\n")
 
 
 def test_normalized_crop_rect_clamps_reversed_selection() -> None:

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -1,0 +1,45 @@
+"""Startup-path tests for the OpenGeoAgent QGIS plugin."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def test_plugin_package_import_does_not_import_dependency_manager() -> None:
+    """Importing the plugin package should not run dependency checks."""
+    for module_name in list(sys.modules):
+        if module_name == "open_geoagent" or module_name.startswith("open_geoagent."):
+            sys.modules.pop(module_name, None)
+
+    importlib.import_module("open_geoagent")
+
+    assert "open_geoagent.deps_manager" not in sys.modules
+
+
+def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
+    """The chat-open dependency gate must not import provider packages."""
+    from open_geoagent import deps_manager
+
+    monkeypatch.setattr(
+        deps_manager,
+        "REQUIRED_PACKAGES",
+        [("geoagent", "GeoAgent[providers]>=1.0.0"), ("openai", "openai>=1.0")],
+    )
+    monkeypatch.setattr(deps_manager, "ensure_venv_packages_available", lambda: True)
+
+    checked: list[str] = []
+
+    def fake_find_spec(import_name: str):
+        checked.append(import_name)
+        return types.SimpleNamespace(name=import_name)
+
+    def fail_import_module(import_name: str):
+        raise AssertionError(f"unexpected import of {import_name}")
+
+    monkeypatch.setattr(deps_manager.importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(deps_manager.importlib, "import_module", fail_import_module)
+
+    assert deps_manager.all_dependencies_met() is True
+    assert checked == ["geoagent", "openai"]

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -586,6 +586,50 @@ def test_set_layer_symbology_does_not_reassign_renderer_owned_symbol() -> None:
     assert layer.repaint_count == 1
 
 
+def test_run_pyqgis_script_executes_on_qgis_context() -> None:
+    """Verify fallback PyQGIS snippets can mutate active QGIS objects."""
+    project = MockQGISProject()
+    layer = MockQGISLayer("NAIP", "/tmp/naip.tif", "raster")
+    project.addMapLayer(layer)
+    iface = MockQGISIface(project=project)
+    iface.setActiveLayer(layer)
+    tools = {t.tool_name: t for t in qgis_tools(iface, project)}
+
+    result = tools["run_pyqgis_script"].__wrapped__(
+        "active_layer.setOpacity(0.5)\n"
+        "canvas.refresh()\n"
+        "print(active_layer.name())",
+        description="Set active layer opacity.",
+    )
+
+    assert result["success"] is True
+    assert result["message"] == "Set active layer opacity."
+    assert result["stdout"] == "NAIP"
+    assert layer.opacity() == 0.5
+    assert iface.mapCanvas().refresh_count == 1
+
+
+def test_run_pyqgis_script_rejects_non_qgis_imports() -> None:
+    """Verify generated snippets cannot import non-QGIS modules."""
+    tools = {t.tool_name: t for t in qgis_tools(MockQGISIface(), MockQGISProject())}
+
+    try:
+        tools["run_pyqgis_script"].__wrapped__("import os\nos.getcwd()")
+    except ValueError as exc:
+        assert "Only qgis/PyQt and math imports" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("Expected unsafe import to be rejected")
+
+
+def test_run_pyqgis_script_requires_confirmation() -> None:
+    """Verify arbitrary PyQGIS execution is confirmation-gated."""
+    tools = {t.tool_name: t for t in qgis_tools(MockQGISIface(), MockQGISProject())}
+    meta = getattr(tools["run_pyqgis_script"], "_geoagent_meta")
+
+    assert meta.requires_confirmation is True
+    assert meta.destructive is True
+
+
 def test_qgis_tools_route_calls_through_gui_marshal(monkeypatch) -> None:
     """Verify that qgis tools route calls through gui marshal."""
     iface = MockQGISIface()

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -621,6 +621,19 @@ def test_run_pyqgis_script_rejects_non_qgis_imports() -> None:
         raise AssertionError("Expected unsafe import to be rejected")
 
 
+def test_run_pyqgis_script_rejects_prefix_collision_imports() -> None:
+    """Verify modules whose names share a prefix with qgis/math are blocked."""
+    tools = {t.tool_name: t for t in qgis_tools(MockQGISIface(), MockQGISProject())}
+
+    for snippet in ("import qgisx", "import mathutils", "from mathutils import foo"):
+        try:
+            tools["run_pyqgis_script"].__wrapped__(snippet)
+        except ValueError as exc:
+            assert "qgis/PyQt and math imports" in str(exc)
+        else:  # pragma: no cover - defensive assertion
+            raise AssertionError(f"Expected {snippet!r} to be rejected")
+
+
 def test_run_pyqgis_script_requires_confirmation() -> None:
     """Verify arbitrary PyQGIS execution is confirmation-gated."""
     tools = {t.tool_name: t for t in qgis_tools(MockQGISIface(), MockQGISProject())}

--- a/tests/test_whitebox_tools.py
+++ b/tests/test_whitebox_tools.py
@@ -720,3 +720,11 @@ def test_for_whitebox_registers_tools_and_respects_fast_mode(monkeypatch) -> Non
     assert "search_whitebox_tools" in fast_names
     assert "get_whitebox_tool_info" in fast_names
     assert "run_whitebox_tool" not in fast_names
+
+
+def test_whitebox_prompt_instructs_pyqgis_fallback() -> None:
+    """Verify QGIS API fallback execution stays in the Whitebox prompt."""
+    from geoagent.core.factory import WHITEBOX_SYSTEM_PROMPT
+
+    assert "run_pyqgis_script" in WHITEBOX_SYSTEM_PROMPT
+    assert "Do not merely provide a script" in WHITEBOX_SYSTEM_PROMPT

--- a/tests/test_whitebox_tools.py
+++ b/tests/test_whitebox_tools.py
@@ -728,3 +728,11 @@ def test_whitebox_prompt_instructs_pyqgis_fallback() -> None:
 
     assert "run_pyqgis_script" in WHITEBOX_SYSTEM_PROMPT
     assert "Do not merely provide a script" in WHITEBOX_SYSTEM_PROMPT
+
+
+def test_qgis_default_prompt_instructs_pyqgis_fallback() -> None:
+    """Verify the default for_qgis prompt also points the agent at run_pyqgis_script."""
+    from geoagent.core.factory import QGIS_SYSTEM_PROMPT
+
+    assert "run_pyqgis_script" in QGIS_SYSTEM_PROMPT
+    assert "Do not merely provide a script" in QGIS_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
- Add `run_pyqgis_script`, a confirmation-gated PyQGIS fallback tool with AST validation that limits imports to qgis/PyQt/math and blocks dangerous builtins.
- Update the QGIS factory prompt so the agent runs short PyQGIS snippets through the new tool instead of just printing them for the user to paste.
- Add a Copy Script button to the chat dock that copies the last executed PyQGIS script with a preamble that makes it runnable in the QGIS Python Console.

## Test plan
- [x] `pytest tests/test_qgis_tools.py tests/test_whitebox_tools.py qgis_geoagent/tests/test_chat_tool_inputs.py`
- [x] `pre-commit run --all-files`
- [ ] Manual: run a styling-only request inside QGIS, confirm the script executes after approval, then click Copy Script and paste into the Python Console.