### PR TITLE
chore: bump qgis_geoagent dependency to GeoAgent>=1.2.0

### DIFF
--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -70,7 +70,7 @@ required Python packages. The installer creates an isolated environment under
 Manual fallback:
 
 ```bash
-pip install "GeoAgent[providers]>=1.0.0"
+pip install "GeoAgent[providers]>=1.2.0"
 ```
 
 ## Provider Configuration

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -29,7 +29,7 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 
 # Required packages: (import_name, pip_install_name)
 REQUIRED_PACKAGES = [
-    ("geoagent", "GeoAgent[providers]>=1.0.0"),
+    ("geoagent", "GeoAgent[providers]>=1.2.0"),
     ("whitebox", "whitebox>=2.3.6"),
     ("openai", "openai>=1.0"),
     ("anthropic", "anthropic>=0.40"),
@@ -563,7 +563,7 @@ def create_venv(venv_dir: str) -> str:
         "This can happen when QGIS bundles Python in a way that prevents\n"
         "standard venv creation.\n\n"
         "You can try installing manually with:\n"
-        '  pip install "GeoAgent[providers]>=1.0.0"\n\n'
+        '  pip install "GeoAgent[providers]>=1.2.0"\n\n'
         "Details:\n" + "\n".join(f"  {d}" for d in details)
     )
 
@@ -697,7 +697,7 @@ class DepsInstallWorker(QThread):
                         False,
                         "pip is not available in the virtual environment.\n"
                         "Please install dependencies manually:\n"
-                        'pip install "GeoAgent[providers]>=1.0.0"',
+                        'pip install "GeoAgent[providers]>=1.2.0"',
                     )
                     return
             self.progress.emit(15, "Package installer ready.")

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -464,7 +464,7 @@ class SettingsDockWidget(QDockWidget):
                 self,
                 "Installation Failed",
                 f"Failed to install dependencies:\n\n{message}\n\n"
-                'Manual fallback: pip install "GeoAgent[providers]>=1.0.0"',
+                'Manual fallback: pip install "GeoAgent[providers]>=1.2.0"',
             )
 
         self._deps_worker = None

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -25,7 +25,7 @@ def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
     monkeypatch.setattr(
         deps_manager,
         "REQUIRED_PACKAGES",
-        [("geoagent", "GeoAgent[providers]>=1.0.0"), ("openai", "openai>=1.0")],
+        [("geoagent", "GeoAgent[providers]>=1.2.0"), ("openai", "openai>=1.0")],
     )
     monkeypatch.setattr(deps_manager, "ensure_venv_packages_available", lambda: True)
 


### PR DESCRIPTION
## Summary
- Bumps the QGIS plugin's required `GeoAgent[providers]` version from `>=1.0.0` to `>=1.2.0` in `deps_manager.py`, install instructions in `README.md` and `settings_dock.py`, and the startup performance test fixture.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] Reinstall plugin dependencies in QGIS and confirm the manager picks up GeoAgent 1.2.0