### PR TITLE
feat: agent modes, permission profiles, and diagnostics for QGIS plugin

### DIFF
--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -197,6 +197,8 @@ def _filter_by_imports(tools: list[Any]) -> list[Any]:
 def _permission_allows_tool(permission_profile: str | None, tool: Any) -> bool:
     """Return whether a QGIS/plugin tool should be exposed for a profile."""
     profile = permission_profile or "Trusted auto-approve"
+    if profile == "Execute PyQGIS":
+        profile = "Execute Scripts"
     name = (
         getattr(tool, "tool_name", "")
         or getattr(tool, "__name__", "")
@@ -210,14 +212,14 @@ def _permission_allows_tool(permission_profile: str | None, tool: Any) -> bool:
 
     if profile == "Trusted auto-approve":
         return True
-    if profile == "Execute PyQGIS":
+    if profile == "Execute Scripts":
         return True
     if name == "run_pyqgis_script":
         return False
     if profile == "Run processing":
         return True
     if category in {"whitebox", "nasa_earthdata", "nasa_opera", "gee_data_catalogs"}:
-        return profile in {"Run processing", "Execute PyQGIS", "Trusted auto-approve"}
+        return profile in {"Run processing", "Execute Scripts", "Trusted auto-approve"}
     if profile == "Edit layers":
         return not destructive and name != "run_processing_algorithm"
     return not (requires_confirmation or destructive or long_running)

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -194,6 +194,44 @@ def _filter_by_imports(tools: list[Any]) -> list[Any]:
     return out
 
 
+def _permission_allows_tool(permission_profile: str | None, tool: Any) -> bool:
+    """Return whether a QGIS/plugin tool should be exposed for a profile."""
+    profile = permission_profile or "Trusted auto-approve"
+    name = (
+        getattr(tool, "tool_name", "")
+        or getattr(tool, "__name__", "")
+        or getattr(tool, "name", "")
+    )
+    meta = getattr(tool, "_geoagent_meta", None)
+    category = str(getattr(meta, "category", "") or "")
+    requires_confirmation = bool(getattr(meta, "requires_confirmation", False))
+    destructive = bool(getattr(meta, "destructive", False))
+    long_running = bool(getattr(meta, "long_running", False))
+
+    if profile == "Trusted auto-approve":
+        return True
+    if profile == "Execute PyQGIS":
+        return True
+    if name == "run_pyqgis_script":
+        return False
+    if profile == "Run processing":
+        return True
+    if category in {"whitebox", "nasa_earthdata", "nasa_opera", "gee_data_catalogs"}:
+        return profile in {"Run processing", "Execute PyQGIS", "Trusted auto-approve"}
+    if profile == "Edit layers":
+        return not destructive and name != "run_processing_algorithm"
+    return not (requires_confirmation or destructive or long_running)
+
+
+def _filter_by_permission(
+    tools: list[Any], permission_profile: str | None
+) -> list[Any]:
+    """Filter QGIS-related tool surfaces according to a permission profile."""
+    if not permission_profile:
+        return tools
+    return [tool for tool in tools if _permission_allows_tool(permission_profile, tool)]
+
+
 def register_all_tools(registry: GeoToolRegistry, tools: Iterable[Any]) -> None:
     """Populate registry from decorated tools."""
     for t in tools:
@@ -216,6 +254,7 @@ def assemble_tools(
     nasa_earthdata_plugin: Any | None = None,
     gee_data_catalogs_plugin: Any | None = None,
     fast: bool = False,
+    permission_profile: str | None = None,
 ) -> tuple[list[Any], GeoToolRegistry]:
     """Collect tools for a context and build a metadata registry."""
     registry = GeoToolRegistry()
@@ -266,6 +305,7 @@ def assemble_tools(
     if extra_tools:
         register_all_tools(registry, extra_tools)
         collected.extend(extra_tools)
+    collected = _filter_by_permission(collected, permission_profile)
     tools = collect_tools_for_context(collected, fast=fast, registry=registry)
     return tools, registry
 
@@ -390,6 +430,7 @@ def for_qgis(
     fast: bool = False,
     confirm: ConfirmCallback | None = None,
     extra_tools: Optional[list[Any]] = None,
+    permission_profile: str | None = None,
 ) -> GeoAgent:
     """Bind an agent to QGIS ``iface`` (and optional ``project``)."""
     ctx = GeoAgentContext(
@@ -402,6 +443,7 @@ def for_qgis(
         include_qgis=True,
         extra_tools=extra_tools,
         fast=fast,
+        permission_profile=permission_profile,
     )
     cfg = config or GeoAgentConfig()
     if provider is not None:
@@ -434,6 +476,7 @@ def for_nasa_opera(
     confirm: ConfirmCallback | None = None,
     extra_tools: Optional[list[Any]] = None,
     include_qgis: bool = True,
+    permission_profile: str | None = None,
 ) -> GeoAgent:
     """Bind an agent to the NASA OPERA QGIS plugin runtime.
 
@@ -454,6 +497,7 @@ def for_nasa_opera(
         include_nasa_opera=True,
         extra_tools=extra_tools,
         fast=fast,
+        permission_profile=permission_profile,
     )
     cfg = config or GeoAgentConfig()
     if provider is not None:
@@ -487,6 +531,7 @@ def for_nasa_earthdata(
     confirm: ConfirmCallback | None = None,
     extra_tools: Optional[list[Any]] = None,
     include_qgis: bool = True,
+    permission_profile: str | None = None,
 ) -> GeoAgent:
     """Bind an agent to the NASA Earthdata QGIS plugin runtime.
 
@@ -508,6 +553,7 @@ def for_nasa_earthdata(
         nasa_earthdata_plugin=plugin,
         extra_tools=extra_tools,
         fast=fast,
+        permission_profile=permission_profile,
     )
     cfg = config or GeoAgentConfig()
     if provider is not None:
@@ -541,6 +587,7 @@ def for_gee_data_catalogs(
     confirm: ConfirmCallback | None = None,
     extra_tools: Optional[list[Any]] = None,
     include_qgis: bool = True,
+    permission_profile: str | None = None,
 ) -> GeoAgent:
     """Bind an agent to the QGIS GEE Data Catalogs plugin runtime.
 
@@ -562,6 +609,7 @@ def for_gee_data_catalogs(
         gee_data_catalogs_plugin=plugin,
         extra_tools=extra_tools,
         fast=fast,
+        permission_profile=permission_profile,
     )
     cfg = config or GeoAgentConfig()
     if provider is not None:
@@ -594,6 +642,7 @@ def for_whitebox(
     confirm: ConfirmCallback | None = None,
     extra_tools: Optional[list[Any]] = None,
     include_qgis: bool = True,
+    permission_profile: str | None = None,
 ) -> GeoAgent:
     """Bind an agent to QGIS with WhiteboxTools analysis support.
 
@@ -614,6 +663,7 @@ def for_whitebox(
         include_whitebox=True,
         extra_tools=extra_tools,
         fast=fast,
+        permission_profile=permission_profile,
     )
     cfg = config or GeoAgentConfig()
     if provider is not None:

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -8,6 +8,40 @@ from typing import Any
 from geoagent.core.config import GeoAgentConfig, ProviderName
 
 
+def _openai_token_params(model_id: str, max_tokens: int) -> dict[str, int]:
+    """Return the token-limit parameter supported by the OpenAI model family."""
+    normalized = str(model_id or "").lower()
+    completion_prefixes = (
+        "gpt-5",
+        "gpt-4.1",
+        "gpt-4o",
+        "chatgpt-4o",
+        "o1",
+        "o3",
+        "o4",
+    )
+    if normalized.startswith(completion_prefixes):
+        return {"max_completion_tokens": max_tokens}
+    return {"max_tokens": max_tokens}
+
+
+def _model_uses_default_temperature_only(model_id: str) -> bool:
+    """Return True for model families that reject explicit temperature values."""
+    normalized = str(model_id or "").lower()
+    return normalized.startswith(
+        (
+            "gpt-5",
+            "openai/gpt-5",
+            "o1",
+            "openai/o1",
+            "o3",
+            "openai/o3",
+            "o4",
+            "openai/o4",
+        )
+    )
+
+
 def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any:
     """Build a Strands model from :class:`GeoAgentConfig` or kwargs overrides.
 
@@ -35,10 +69,14 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
 
         model_id = cfg.model or os.environ.get("OPENAI_MODEL", "gpt-5.5")
         client_args = dict(cfg.client_args)
+        params = {}
+        if not _model_uses_default_temperature_only(model_id):
+            params["temperature"] = cfg.temperature
+        params.update(_openai_token_params(model_id, cfg.max_tokens))
         return OpenAIModel(
             client_args=client_args or None,
             model_id=model_id,
-            params={"temperature": cfg.temperature, "max_tokens": cfg.max_tokens},
+            params=params,
         )
 
     if provider == "openai-codex":
@@ -140,10 +178,13 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         base_url = cfg.litellm_base_url or os.environ.get("LITELLM_BASE_URL")
         if base_url and "base_url" not in client_args:
             client_args["base_url"] = base_url
+        params = {"max_tokens": cfg.max_tokens}
+        if not _model_uses_default_temperature_only(model_id):
+            params["temperature"] = cfg.temperature
         return LiteLLMModel(
             client_args=client_args or None,
             model_id=model_id,
-            params={"temperature": cfg.temperature, "max_tokens": cfg.max_tokens},
+            params=params,
         )
 
     raise ValueError(f"Unknown provider: {provider}")

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -115,7 +115,7 @@ Default models:
 - Choose a **Permissions** profile. The default **Inspect only** profile hides
   mutating, long-running, and PyQGIS execution tools from the model. Use broader
   profiles only when you want GeoAgent to edit layers, run processing, execute
-  PyQGIS, or auto-approve trusted actions.
+  PyQGIS/Earth Engine snippets, or auto-approve trusted actions.
 - **Stream output** is enabled by default and shows model text as it arrives.
 - Press **Up** or **Down** in the prompt editor to cycle through previous prompts.
 - Choose a prompt from **Sample prompts...** and click **Insert** to load it into

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -15,8 +15,14 @@ GitHub update checker.
 - Dockable OpenGeoAgent chat panel with Ctrl+Enter sending
 - Up/Down prompt history while the prompt editor is focused
 - Built-in sample prompt picker for common QGIS workflows
+- Agent modes for General QGIS, WhiteboxTools, NASA Earthdata, NASA OPERA,
+  GEE Data Catalogs, and STAC guidance workflows
+- Tool permission profiles, defaulting to inspect-only project access
+- Project-scoped chat history with Markdown import/export
+- Compact jobs panel for active and completed GeoAgent requests
 - Provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, and LiteLLM
-- Settings panel for model defaults, API keys, hosts, and AWS region
+- Settings panel for model defaults, API keys, hosts, AWS region, provider
+  smoke tests, and redacted diagnostics export
 - Dependency installer that installs `GeoAgent[providers]` into
   `~/.open_geoagent/`
 - QGIS 3.28+ and QGIS 4 compatible plugin structure
@@ -103,10 +109,34 @@ Default models:
 ## Chat Workflow
 
 - Type a prompt and press **Ctrl+Enter** to send it.
+- Choose an **Agent mode** for the workflow you want. STAC mode provides
+  guided search/loading steps and dependency diagnostics; it does not add a
+  separate STAC loader beyond the current GeoAgent tool surface.
+- Choose a **Permissions** profile. The default **Inspect only** profile hides
+  mutating, long-running, and PyQGIS execution tools from the model. Use broader
+  profiles only when you want GeoAgent to edit layers, run processing, execute
+  PyQGIS, or auto-approve trusted actions.
 - **Stream output** is enabled by default and shows model text as it arrives.
 - Press **Up** or **Down** in the prompt editor to cycle through previous prompts.
 - Choose a prompt from **Sample prompts...** and click **Insert** to load it into
   the editor before sending.
+- Use **Export**, **Import**, and **Copy Markdown** to move project chat history
+  between sessions. The plugin stores chat history per QGIS project.
+- The **Jobs** panel records submitted requests with status, mode, prompt,
+  elapsed time, and tool summary. Completed jobs can be selected and rerun.
+
+## Diagnostics
+
+The Settings panel includes:
+
+- **Test Provider** for a tiny no-tool model smoke test using the selected
+  provider and model.
+- **Copy Diagnostics** and **Save Diagnostics** for redacted JSON containing
+  plugin version, QGIS/Python details, isolated environment paths, uv status,
+  dependency status, selected model settings, credential presence booleans, and
+  latest installer/provider-test status.
+
+Diagnostics never include raw API keys, OAuth tokens, or passwords.
 
 ## Key Functionality
 

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -30,6 +30,8 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 # Required packages: (import_name, pip_install_name)
 REQUIRED_PACKAGES = [
     ("geoagent", "GeoAgent[providers]>=1.2.0"),
+    ("strands", "strands-agents>=1.37"),
+    ("pydantic", "pydantic>=2.0"),
     ("whitebox", "whitebox>=2.3.6"),
     ("openai", "openai>=1.0"),
     ("anthropic", "anthropic>=0.40"),
@@ -257,6 +259,19 @@ def _get_subprocess_kwargs() -> dict:
     return {}
 
 
+def _uv_usable() -> bool:
+    """Return True when the cached uv binary exists and verifies successfully."""
+    try:
+        from .uv_manager import uv_exists, verify_uv
+
+        if not uv_exists():
+            return False
+        success, _message = verify_uv()
+        return bool(success)
+    except Exception:
+        return False
+
+
 def _find_python_executable() -> str:
     """Find a working Python executable for subprocess calls.
 
@@ -469,7 +484,7 @@ def create_venv(venv_dir: str) -> str:
     Raises:
         RuntimeError: If venv creation fails after all strategies.
     """
-    from .uv_manager import get_uv_path, uv_exists
+    from .uv_manager import get_uv_path
 
     os.makedirs(os.path.dirname(venv_dir), exist_ok=True)
 
@@ -478,7 +493,7 @@ def create_venv(venv_dir: str) -> str:
     kwargs = _get_subprocess_kwargs()
 
     # Strategy 0: Use uv venv when available (fastest, no pip needed)
-    if uv_exists():
+    if _uv_usable():
         uv_path = get_uv_path()
         python_exe = _find_python_executable()
         cmd = [uv_path, "venv", "--python", python_exe, venv_dir]
@@ -586,13 +601,13 @@ def install_packages(
     Returns:
         Tuple of (success, message).
     """
-    from .uv_manager import get_uv_path, uv_exists
+    from .uv_manager import get_uv_path
 
     python_path = get_venv_python_path(venv_dir)
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
-    use_uv = uv_exists()
+    use_uv = _uv_usable()
     if use_uv:
         uv_path = get_uv_path()
         cmd = [
@@ -647,13 +662,13 @@ class DepsInstallWorker(QThread):
     def run(self):
         """Execute uv download, venv creation, and dependency installation."""
         try:
-            from .uv_manager import download_uv, uv_exists
+            from .uv_manager import download_uv
 
             start_time = time.time()
             venv_dir = get_venv_dir()
 
             # Step 0: Download uv if needed (fast package installer)
-            if not uv_exists():
+            if not _uv_usable():
                 self.progress.emit(2, "Downloading uv package installer...")
                 success, msg = download_uv(
                     progress_callback=lambda p, m: self.progress.emit(
@@ -677,7 +692,7 @@ class DepsInstallWorker(QThread):
             self.progress.emit(10, "Virtual environment ready.")
 
             # Step 2: Verify pip (only needed when not using uv)
-            use_uv = uv_exists()
+            use_uv = _uv_usable()
             if not use_uv:
                 self.progress.emit(12, "Verifying pip...")
                 python_path = get_venv_python_path(venv_dir)

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -1167,7 +1167,6 @@ class ChatWorker(QThread):
                     raise
                 kwargs.pop("permission_profile", None)
                 agent = factory(self.iface, **kwargs)
-                agent = _filter_tools_for_permission(agent, self.permission_profile)
             agent = _filter_tools_for_permission(agent, self.permission_profile)
             if self.agent_mode == "STAC":
                 self.prompt = (
@@ -1470,6 +1469,12 @@ class ChatDockWidget(QDockWidget):
         self.jobs_table.setMaximumHeight(120)
         self.jobs_table.setSelectionBehavior(
             _enum_value(QAbstractItemView, "SelectionBehavior", "SelectRows")
+        )
+        self.jobs_table.setSelectionMode(
+            _enum_value(QAbstractItemView, "SelectionMode", "SingleSelection")
+        )
+        self.jobs_table.setEditTriggers(
+            _enum_value(QAbstractItemView, "EditTrigger", "NoEditTriggers")
         )
         jobs_header = self.jobs_table.horizontalHeader()
         if jobs_header is not None:

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -1180,7 +1180,7 @@ class ChatDockWidget(QDockWidget):
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
         )
-        self.setMinimumWidth(280)
+        self.setMinimumWidth(220)
 
         self._setup_ui()
         self._load_settings()
@@ -1193,12 +1193,21 @@ class ChatDockWidget(QDockWidget):
         layout = QVBoxLayout(main_widget)
         layout.setSpacing(8)
 
-        model_group = QGroupBox("Model")
-        model_layout = QFormLayout(model_group)
+        self.model_group = QGroupBox("Model")
+        self.model_group.setCheckable(True)
+        self.model_group.setChecked(True)
+        self.model_group.toggled.connect(self._on_model_section_toggled)
+        model_group_layout = QVBoxLayout(self.model_group)
+        model_group_layout.setContentsMargins(8, 8, 8, 8)
+
+        self.model_controls = QWidget()
+        model_layout = QFormLayout(self.model_controls)
+        model_layout.setContentsMargins(0, 0, 0, 0)
+        model_group_layout.addWidget(self.model_controls)
 
         self.provider_combo = QComboBox()
         self.provider_combo.addItems(PROVIDERS)
-        self.provider_combo.setMinimumContentsLength(10)
+        self.provider_combo.setMinimumContentsLength(8)
         self.provider_combo.setSizeAdjustPolicy(
             _enum_value(
                 QComboBox,
@@ -1206,20 +1215,36 @@ class ChatDockWidget(QDockWidget):
                 "AdjustToMinimumContentsLengthWithIcon",
             )
         )
+        self.provider_combo.setSizePolicy(
+            _enum_value(QSizePolicy, "Policy", "Ignored"),
+            _enum_value(QSizePolicy, "Policy", "Fixed"),
+        )
         self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
         model_layout.addRow("Provider:", self.provider_combo)
 
         self.model_input = QLineEdit()
         self.model_input.setPlaceholderText("Use provider default")
+        self.model_input.setSizePolicy(
+            _enum_value(QSizePolicy, "Policy", "Ignored"),
+            _enum_value(QSizePolicy, "Policy", "Fixed"),
+        )
         model_layout.addRow("Model:", self.model_input)
 
         self.agent_mode_combo = QComboBox()
         self.agent_mode_combo.addItems(AGENT_MODES)
+        self.agent_mode_combo.setSizePolicy(
+            _enum_value(QSizePolicy, "Policy", "Ignored"),
+            _enum_value(QSizePolicy, "Policy", "Fixed"),
+        )
         self.agent_mode_combo.currentTextChanged.connect(self._on_agent_mode_changed)
         model_layout.addRow("Agent mode:", self.agent_mode_combo)
 
         self.permission_combo = QComboBox()
         self.permission_combo.addItems(PERMISSION_PROFILES)
+        self.permission_combo.setSizePolicy(
+            _enum_value(QSizePolicy, "Policy", "Ignored"),
+            _enum_value(QSizePolicy, "Policy", "Fixed"),
+        )
         model_layout.addRow("Permissions:", self.permission_combo)
 
         self.fast_check = QCheckBox("Fast mode")
@@ -1238,13 +1263,13 @@ class ChatDockWidget(QDockWidget):
         mode_layout.addStretch(1)
         model_layout.addRow("", mode_layout)
 
-        layout.addWidget(model_group)
+        layout.addWidget(self.model_group)
 
         sample_layout = QHBoxLayout()
         self.sample_combo = QComboBox()
         self.sample_combo.addItem("Sample prompts...")
         self.sample_combo.addItems(_all_sample_prompts())
-        self.sample_combo.setMinimumContentsLength(22)
+        self.sample_combo.setMinimumContentsLength(14)
         self.sample_combo.setSizeAdjustPolicy(
             _enum_value(
                 QComboBox,
@@ -1260,8 +1285,15 @@ class ChatDockWidget(QDockWidget):
         sample_layout.addWidget(self.sample_combo, 1)
         layout.addLayout(sample_layout)
 
-        jobs_group = QGroupBox("Jobs")
-        jobs_layout = QVBoxLayout(jobs_group)
+        self.jobs_group = QGroupBox("Jobs")
+        self.jobs_group.setCheckable(True)
+        self.jobs_group.setChecked(True)
+        self.jobs_group.toggled.connect(self._on_jobs_section_toggled)
+        jobs_layout = QVBoxLayout(self.jobs_group)
+
+        self.jobs_controls = QWidget()
+        jobs_controls_layout = QVBoxLayout(self.jobs_controls)
+        jobs_controls_layout.setContentsMargins(0, 0, 0, 0)
         self.jobs_table = QTableWidget(0, 4)
         self.jobs_table.setHorizontalHeaderLabels(
             ["Status", "Mode", "Prompt", "Details"]
@@ -1270,7 +1302,7 @@ class ChatDockWidget(QDockWidget):
         self.jobs_table.setSelectionBehavior(
             _enum_value(QAbstractItemView, "SelectionBehavior", "SelectRows")
         )
-        jobs_layout.addWidget(self.jobs_table)
+        jobs_controls_layout.addWidget(self.jobs_table)
         jobs_btn_layout = QHBoxLayout()
         self.rerun_job_btn = QPushButton("Rerun Job")
         self.rerun_job_btn.clicked.connect(self._rerun_selected_job)
@@ -1280,8 +1312,9 @@ class ChatDockWidget(QDockWidget):
         self.cancel_job_btn.setEnabled(False)
         jobs_btn_layout.addWidget(self.cancel_job_btn)
         jobs_btn_layout.addStretch(1)
-        jobs_layout.addLayout(jobs_btn_layout)
-        layout.addWidget(jobs_group)
+        jobs_controls_layout.addLayout(jobs_btn_layout)
+        jobs_layout.addWidget(self.jobs_controls)
+        layout.addWidget(self.jobs_group)
 
         self.transcript = QTextEdit()
         self.transcript.setReadOnly(True)
@@ -1383,6 +1416,12 @@ class ChatDockWidget(QDockWidget):
         self.auto_approve_tools_check.setChecked(
             _setting(self.settings, "auto_approve_tools", False, bool)
         )
+        expanded = _setting(self.settings, "model_section_expanded", True, bool)
+        self.model_group.setChecked(expanded)
+        self.model_controls.setVisible(expanded)
+        jobs_expanded = _setting(self.settings, "jobs_section_expanded", True, bool)
+        self.jobs_group.setChecked(jobs_expanded)
+        self.jobs_controls.setVisible(jobs_expanded)
         mode = _setting(self.settings, "agent_mode", DEFAULT_AGENT_MODE)
         index = self.agent_mode_combo.findText(mode)
         self.agent_mode_combo.setCurrentIndex(index if index >= 0 else 0)
@@ -1419,10 +1458,29 @@ class ChatDockWidget(QDockWidget):
         self.settings.setValue(
             f"{SETTINGS_PREFIX}permission_profile", self.permission_combo.currentText()
         )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}model_section_expanded", self.model_group.isChecked()
+        )
 
     def _on_provider_changed(self, provider):
         """Update the model field when the provider changes."""
         self.model_input.setText(_default_model_for_provider(provider))
+
+    def _on_model_section_toggled(self, expanded):
+        """Show or hide model controls to keep the dock compact."""
+        if hasattr(self, "model_controls"):
+            self.model_controls.setVisible(bool(expanded))
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}model_section_expanded", bool(expanded)
+        )
+
+    def _on_jobs_section_toggled(self, expanded):
+        """Show or hide job controls to keep the dock compact."""
+        if hasattr(self, "jobs_controls"):
+            self.jobs_controls.setVisible(bool(expanded))
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}jobs_section_expanded", bool(expanded)
+        )
 
     def _on_agent_mode_changed(self, mode):
         """Load a mode-specific workflow prompt when useful."""
@@ -2243,6 +2301,9 @@ class ChatDockWidget(QDockWidget):
             ]
             for col, value in enumerate(values):
                 self.jobs_table.setItem(row, col, QTableWidgetItem(str(value)))
+        if self._jobs:
+            self.jobs_table.scrollToBottom()
+            self.jobs_table.selectRow(len(self._jobs) - 1)
 
     def _selected_job_index(self):
         """Return the selected job row or None."""

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -29,6 +29,7 @@ from qgis.PyQt.QtGui import QCursor, QGuiApplication, QPixmap, QTextCursor
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QAbstractItemView,
+    QHeaderView,
     QComboBox,
     QDialog,
     QDockWidget,
@@ -1470,6 +1471,10 @@ class ChatDockWidget(QDockWidget):
         self.jobs_table.setSelectionBehavior(
             _enum_value(QAbstractItemView, "SelectionBehavior", "SelectRows")
         )
+        jobs_header = self.jobs_table.horizontalHeader()
+        if jobs_header is not None:
+            stretch = _enum_value(QHeaderView, "ResizeMode", "Stretch")
+            jobs_header.setSectionResizeMode(stretch)
         jobs_controls_layout.addWidget(self.jobs_table)
         jobs_btn_layout = QHBoxLayout()
         self.rerun_job_btn = QPushButton("Rerun Job")

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -246,7 +246,9 @@ def _project_history_key(iface):
             path = project.fileName() if project is not None else ""
         except Exception:
             path = ""
-    raw = path or "unsaved-project"
+    if not path:
+        return ""
+    raw = path
     digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
     return f"{SETTINGS_PREFIX}history/{digest}"
 
@@ -2449,6 +2451,8 @@ class ChatDockWidget(QDockWidget):
 
     def _load_project_history(self):
         """Load persisted chat messages for the current QGIS project."""
+        if not self._history_key:
+            return
         raw = self.settings.value(self._history_key, "", type=str)
         if not raw:
             return
@@ -2468,6 +2472,8 @@ class ChatDockWidget(QDockWidget):
 
     def _save_project_history(self):
         """Persist chat messages for the current QGIS project."""
+        if not self._history_key:
+            return
         try:
             payload = json.dumps(self._messages[-80:])
             self.settings.setValue(self._history_key, payload)

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -115,9 +115,12 @@ PERMISSION_PROFILES = [
     "Inspect only",
     "Edit layers",
     "Run processing",
-    "Execute PyQGIS",
+    "Execute Scripts",
     "Trusted auto-approve",
 ]
+PERMISSION_PROFILE_ALIASES = {
+    "Execute PyQGIS": "Execute Scripts",
+}
 DEFAULT_PERMISSION_PROFILE = "Inspect only"
 WORKFLOW_PROMPTS = {
     "NASA Earthdata": [
@@ -179,14 +182,15 @@ def _permission_allows_tool(permission_profile, tool_name, meta=None):
 
     if profile == "Trusted auto-approve":
         return True
-    if profile == "Execute PyQGIS":
+    profile = PERMISSION_PROFILE_ALIASES.get(profile, profile)
+    if profile == "Execute Scripts":
         return True
     if name == "run_pyqgis_script":
         return False
     if profile == "Run processing":
         return True
     if category in {"whitebox", "nasa_earthdata", "nasa_opera", "gee_data_catalogs"}:
-        return profile in {"Run processing", "Execute PyQGIS", "Trusted auto-approve"}
+        return profile in {"Run processing", "Execute Scripts", "Trusted auto-approve"}
     if profile == "Edit layers":
         return not destructive and name != "run_processing_algorithm"
     return not (requires_confirmation or destructive or long_running)
@@ -533,20 +537,174 @@ def _format_tool_calls(tool_calls):
     return "\n".join(lines) if len(lines) > 1 else ""
 
 
-def _latest_pyqgis_script(tool_calls):
-    """Return the last PyQGIS script found in recorded tool calls."""
+SCRIPT_SPECS = {
+    "run_pyqgis_script": {
+        "arg_keys": ("code",),
+        "result_keys": ("pyqgis_script",),
+        "kind": "PyQGIS",
+    },
+    "run_gee_python_snippet": {
+        "arg_keys": ("code",),
+        "result_keys": ("earth_engine_python_snippet",),
+        "kind": "Earth Engine",
+    },
+}
+RESULT_SCRIPT_KEYS = {
+    "pyqgis_script": "PyQGIS",
+    "earth_engine_python_snippet": "Earth Engine",
+}
+
+
+def _python_literal(value):
+    """Return a compact Python literal for copied snippets."""
+    try:
+        return repr(value)
+    except Exception:
+        return repr(str(value))
+
+
+def _coerce_optional_float(value):
+    """Return a float for non-empty numeric values, otherwise None."""
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _gee_load_dataset_snippet_from_args(args):
+    """Build a simple Earth Engine snippet from load_gee_dataset arguments."""
+    if not isinstance(args, dict):
+        return ""
+    asset_id = str(args.get("asset_id") or "").strip()
+    if not asset_id:
+        return ""
+    asset_type = str(args.get("asset_type") or "Image").strip() or "Image"
+    layer_name = str(args.get("layer_name") or asset_id.split("/")[-1]).strip()
+    method = str(args.get("method") or args.get("reducer") or "mosaic").strip()
+    bands = args.get("bands")
+    vis_params = {}
+    if bands not in (None, ""):
+        vis_params["bands"] = bands
+    min_value = _coerce_optional_float(args.get("min_value"))
+    max_value = _coerce_optional_float(args.get("max_value"))
+    palette = args.get("palette")
+    if min_value is not None:
+        vis_params["min"] = min_value
+    if max_value is not None:
+        vis_params["max"] = max_value
+    if palette not in (None, ""):
+        vis_params["palette"] = palette
+
+    lines = [
+        "import ee",
+        "import geemap",
+        "",
+        "m = geemap.Map()",
+        f"asset_id = {_python_literal(asset_id)}",
+    ]
+    if asset_type == "ImageCollection":
+        lines.append("collection = ee.ImageCollection(asset_id)")
+        start_date = args.get("start_date")
+        end_date = args.get("end_date")
+        if start_date and end_date:
+            lines.append(
+                "collection = collection.filterDate("
+                f"{_python_literal(start_date)}, {_python_literal(end_date)})"
+            )
+        bbox = args.get("bbox")
+        if bbox:
+            lines.append(f"bbox = {_python_literal(bbox)}")
+            lines.append(
+                "collection = collection.filterBounds(ee.Geometry.Rectangle(bbox))"
+            )
+        if method == "mosaic":
+            lines.append("image = collection.mosaic()")
+        elif method == "mode":
+            lines.append("image = collection.reduce(ee.Reducer.mode())")
+        else:
+            lines.append(f"image = collection.{method}()")
+    elif asset_type == "FeatureCollection":
+        lines.append("image = ee.FeatureCollection(asset_id)")
+    else:
+        lines.append("image = ee.Image(asset_id)")
+    lines.extend(
+        [
+            f"vis_params = {_python_literal(vis_params)}",
+            f"m.add_layer(image, vis_params, {_python_literal(layer_name)})",
+            "m",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _script_from_tool_args(tool_name, args):
+    """Return a copyable script derived from tool arguments alone."""
+    if tool_name == "load_gee_dataset":
+        return {
+            "kind": "Earth Engine",
+            "tool_name": tool_name,
+            "code": _gee_load_dataset_snippet_from_args(args),
+        }
+    return {}
+
+
+def _first_script_value(mapping, keys):
+    """Return the first non-empty script-like value for keys in mapping."""
+    if not isinstance(mapping, dict):
+        return ""
+    for key in keys:
+        value = str(mapping.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _latest_executable_snippet(tool_calls):
+    """Return the latest copyable code snippet found in recorded tool calls."""
     for call in reversed(tool_calls or []):
         if not isinstance(call, dict):
             continue
-        if str(call.get("name") or "").strip() != "run_pyqgis_script":
-            continue
-        args = call.get("args")
-        if not isinstance(args, dict):
-            continue
-        code = str(args.get("code") or "").strip()
-        if code:
-            return code
-    return ""
+        name = str(call.get("name") or "").strip()
+        spec = SCRIPT_SPECS.get(name)
+        if spec is not None:
+            code = _first_script_value(call.get("args"), spec["arg_keys"])
+            if not code:
+                code = _first_script_value(call.get("result"), spec["result_keys"])
+            if code:
+                return {
+                    "kind": spec["kind"],
+                    "tool_name": name,
+                    "code": code,
+                }
+        result = call.get("result")
+        if isinstance(result, dict):
+            for key, kind in RESULT_SCRIPT_KEYS.items():
+                code = str(result.get(key) or "").strip()
+                if code:
+                    return {
+                        "kind": kind,
+                        "tool_name": name,
+                        "code": code,
+                    }
+        snippet = _script_from_tool_args(name, call.get("args"))
+        if snippet.get("code"):
+            return snippet
+    return {}
+
+
+def _latest_pyqgis_script(tool_calls):
+    """Return the last PyQGIS script found in recorded tool calls."""
+    snippet = _latest_executable_snippet(
+        [
+            call
+            for call in tool_calls or []
+            if isinstance(call, dict)
+            and str(call.get("name") or "").strip() == "run_pyqgis_script"
+        ]
+    )
+    return str(snippet.get("code") or "")
 
 
 def _console_ready_pyqgis_script(code):
@@ -578,6 +736,16 @@ except NameError:
     active_layer = iface.activeLayer()
 """
     return f"{preamble}\n{code}\n"
+
+
+def _copy_ready_snippet(snippet):
+    """Return clipboard-ready code for a discovered executable snippet."""
+    code = str(snippet.get("code") or "").strip()
+    if not code:
+        return ""
+    if snippet.get("kind") == "PyQGIS":
+        return _console_ready_pyqgis_script(code)
+    return f"# OpenGeoAgent {snippet.get('kind', 'Python')} snippet.\n{code}\n"
 
 
 def _conversation_markdown(messages):
@@ -1159,7 +1327,7 @@ class ChatDockWidget(QDockWidget):
         self._prompt_history = []
         self._history_index = None
         self._messages = []
-        self._last_pyqgis_script = ""
+        self._last_script_snippet = {}
         self._image_attachments = []
         self._streaming_message_index = None
         self._streaming_answer = ""
@@ -1340,7 +1508,12 @@ class ChatDockWidget(QDockWidget):
         layout.addWidget(self.attachment_bar)
         layout.addWidget(self.prompt_input)
 
+        button_rows = QVBoxLayout()
+        button_rows.setSpacing(4)
         primary_button_layout = QHBoxLayout()
+        primary_button_layout.setSpacing(6)
+        secondary_button_layout = QHBoxLayout()
+        secondary_button_layout.setSpacing(6)
         self.send_btn = QPushButton("Send")
         self.send_btn.clicked.connect(self._send_prompt)
         primary_button_layout.addWidget(self.send_btn)
@@ -1373,25 +1546,45 @@ class ChatDockWidget(QDockWidget):
 
         self.export_md_btn = QPushButton("Export")
         self.export_md_btn.clicked.connect(self._export_transcript_markdown)
-        primary_button_layout.addWidget(self.export_md_btn)
+        secondary_button_layout.addWidget(self.export_md_btn)
 
         self.import_md_btn = QPushButton("Import")
         self.import_md_btn.clicked.connect(self._import_transcript_markdown)
-        primary_button_layout.addWidget(self.import_md_btn)
+        secondary_button_layout.addWidget(self.import_md_btn)
 
-        self.copy_md_btn = QPushButton("Copy Markdown")
+        self.copy_md_btn = QPushButton("Copy MD")
         self.copy_md_btn.setEnabled(False)
+        self.copy_md_btn.setToolTip("Copy the full chat transcript as Markdown.")
         self.copy_md_btn.clicked.connect(self._copy_transcript_markdown)
-        primary_button_layout.addWidget(self.copy_md_btn)
+        secondary_button_layout.addWidget(self.copy_md_btn)
 
         self.copy_script_btn = QPushButton("Copy Script")
         self.copy_script_btn.setEnabled(False)
         self.copy_script_btn.setToolTip(
-            "Copy the most recent PyQGIS script executed by GeoAgent."
+            "Copy the most recent executable script or snippet from GeoAgent."
         )
-        self.copy_script_btn.clicked.connect(self._copy_last_pyqgis_script)
-        primary_button_layout.addWidget(self.copy_script_btn)
-        layout.addLayout(primary_button_layout)
+        self.copy_script_btn.clicked.connect(self._copy_last_script_snippet)
+        secondary_button_layout.addWidget(self.copy_script_btn)
+
+        for button in (
+            self.send_btn,
+            self.screenshot_btn,
+            self.cancel_btn,
+            self.clear_btn,
+            self.export_md_btn,
+            self.import_md_btn,
+            self.copy_md_btn,
+            self.copy_script_btn,
+        ):
+            button.setMinimumWidth(0)
+            button.setSizePolicy(
+                _enum_value(QSizePolicy, "Policy", "Ignored"),
+                _enum_value(QSizePolicy, "Policy", "Fixed"),
+            )
+
+        button_rows.addLayout(primary_button_layout)
+        button_rows.addLayout(secondary_button_layout)
+        layout.addLayout(button_rows)
 
         self.status_label = QLabel("Ready. Ctrl+Enter sends. Up/Down cycles prompts.")
         self.status_label.setWordWrap(True)
@@ -1430,6 +1623,7 @@ class ChatDockWidget(QDockWidget):
             "permission_profile",
             DEFAULT_PERMISSION_PROFILE,
         )
+        profile = PERMISSION_PROFILE_ALIASES.get(profile, profile)
         index = self.permission_combo.findText(profile)
         self.permission_combo.setCurrentIndex(index if index >= 0 else 0)
         self._load_project_history()
@@ -2005,9 +2199,9 @@ class ChatDockWidget(QDockWidget):
             answer = result.get("answer") or "(No text response.)"
             details = []
             tool_calls = result.get("tool_calls") or []
-            pyqgis_script = _latest_pyqgis_script(tool_calls)
-            if pyqgis_script:
-                self._last_pyqgis_script = pyqgis_script
+            snippet = _latest_executable_snippet(tool_calls)
+            if snippet:
+                self._last_script_snippet = snippet
                 self.copy_script_btn.setEnabled(True)
             tool_inputs = _format_tool_calls(tool_calls)
             if tool_inputs:
@@ -2180,17 +2374,18 @@ class ChatDockWidget(QDockWidget):
             self.status_label.setText("Copied chat history as Markdown.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
-    def _copy_last_pyqgis_script(self):
-        """Copy the most recent executed PyQGIS script to the clipboard."""
-        script = _console_ready_pyqgis_script(self._last_pyqgis_script)
+    def _copy_last_script_snippet(self):
+        """Copy the most recent executable script/snippet to the clipboard."""
+        script = _copy_ready_snippet(self._last_script_snippet)
         if not script:
-            self.status_label.setText("No PyQGIS script is available to copy.")
+            self.status_label.setText("No executable script is available to copy.")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
             return
         clipboard = QGuiApplication.clipboard()
         if clipboard is not None:
             clipboard.setText(script)
-            self.status_label.setText("Copied PyQGIS script.")
+            kind = self._last_script_snippet.get("kind", "script")
+            self.status_label.setText(f"Copied {kind} script.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
     def _export_transcript_markdown(self):
@@ -2236,7 +2431,7 @@ class ChatDockWidget(QDockWidget):
     def _clear_transcript(self):
         """Clear all rendered chat messages."""
         self._messages = []
-        self._last_pyqgis_script = ""
+        self._last_script_snippet = {}
         self.copy_script_btn.setEnabled(False)
         self.copy_md_btn.setEnabled(False)
         self.transcript.clear()

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -1,6 +1,7 @@
 """Dockable OpenGeoAgent chat interface."""
 
 import asyncio
+import hashlib
 import os
 import html
 import json
@@ -27,6 +28,7 @@ from qgis.PyQt.QtCore import (
 from qgis.PyQt.QtGui import QCursor, QGuiApplication, QPixmap, QTextCursor
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
+    QAbstractItemView,
     QComboBox,
     QDialog,
     QDockWidget,
@@ -43,6 +45,8 @@ from qgis.PyQt.QtWidgets import (
     QRubberBand,
     QScrollArea,
     QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -76,16 +80,208 @@ IMAGE_THUMBNAIL_SIZE = 72
 SAMPLE_PROMPTS = [
     "Summarize the current QGIS project layers, CRS, extents, and feature counts.",
     "Zoom to the active layer and describe what it contains.",
-    "List visible layers and identify any layers with no features or invalid data sources.",
+    (
+        "List visible layers and identify any layers with no features or "
+        "invalid data sources."
+    ),
     "Add an OpenStreetMap basemap and zoom to the project extent.",
-    "Inspect the active vector layer fields and suggest useful styling or labeling options.",
-    "Select features in the active layer where population is greater than 100000, then zoom to the selected features.",
-    "Run a buffer around the active layer by 1000 meters and add the output to the project.",
+    (
+        "Inspect the active vector layer fields and suggest useful styling or "
+        "labeling options."
+    ),
+    (
+        "Select features in the active layer where population is greater than "
+        "100000, then zoom to the selected features."
+    ),
+    (
+        "Run a buffer around the active layer by 1000 meters and add the "
+        "output to the project."
+    ),
     "Find a WhiteboxTools command for calculating slope from the active DEM layer.",
     "Run a WhiteboxTools hillshade analysis on a local DEM and add the result to QGIS.",
     "Search WhiteboxTools for watershed or flow accumulation tools.",
     "Create a concise map QA checklist for this project before I export it.",
 ]
+AGENT_MODES = [
+    "General QGIS",
+    "WhiteboxTools",
+    "NASA Earthdata",
+    "NASA OPERA",
+    "GEE Data Catalogs",
+    "STAC",
+]
+DEFAULT_AGENT_MODE = "General QGIS"
+PERMISSION_PROFILES = [
+    "Inspect only",
+    "Edit layers",
+    "Run processing",
+    "Execute PyQGIS",
+    "Trusted auto-approve",
+]
+DEFAULT_PERMISSION_PROFILE = "Inspect only"
+WORKFLOW_PROMPTS = {
+    "NASA Earthdata": [
+        (
+            "Search NASA Earthdata for datasets about surface water in the "
+            "current map extent."
+        ),
+        (
+            "Search NASA Earthdata granules for the selected dataset, display "
+            "footprints, and summarize available raster links."
+        ),
+    ],
+    "NASA OPERA": [
+        "List available NASA OPERA datasets and recommend one for water mapping.",
+        (
+            "Search OPERA DSWx data for the current map extent and display "
+            "matching footprints."
+        ),
+    ],
+    "GEE Data Catalogs": [
+        (
+            "Search the Earth Engine data catalog for Sentinel-2 surface "
+            "reflectance datasets."
+        ),
+        (
+            "Find a dataset for land cover mapping and explain how it can be "
+            "loaded into QGIS."
+        ),
+    ],
+    "STAC": [
+        (
+            "Guide me through searching a STAC catalog for imagery over the "
+            "current map extent."
+        ),
+        (
+            "Check STAC-related dependencies and outline the steps to add a "
+            "STAC raster layer in QGIS."
+        ),
+    ],
+}
+
+
+def _all_sample_prompts():
+    """Return general sample prompts plus guided workflow prompts."""
+    prompts = list(SAMPLE_PROMPTS)
+    for mode_prompts in WORKFLOW_PROMPTS.values():
+        prompts.extend(mode_prompts)
+    return prompts
+
+
+def _permission_allows_tool(permission_profile, tool_name, meta=None):
+    """Return whether a QGIS-related tool may be exposed for a profile."""
+    profile = permission_profile or DEFAULT_PERMISSION_PROFILE
+    name = str(tool_name or "")
+    category = str(getattr(meta, "category", "") or "")
+    requires_confirmation = bool(getattr(meta, "requires_confirmation", False))
+    destructive = bool(getattr(meta, "destructive", False))
+    long_running = bool(getattr(meta, "long_running", False))
+
+    if profile == "Trusted auto-approve":
+        return True
+    if profile == "Execute PyQGIS":
+        return True
+    if name == "run_pyqgis_script":
+        return False
+    if profile == "Run processing":
+        return True
+    if category in {"whitebox", "nasa_earthdata", "nasa_opera", "gee_data_catalogs"}:
+        return profile in {"Run processing", "Execute PyQGIS", "Trusted auto-approve"}
+    if profile == "Edit layers":
+        return not destructive and name != "run_processing_algorithm"
+    return not (requires_confirmation or destructive or long_running)
+
+
+def _filter_tools_for_permission(agent, permission_profile):
+    """Filter an agent's tool surface when the core factory lacks profile support."""
+    try:
+        registry = getattr(agent, "tool_registry", None)
+        strands_agent = getattr(agent, "strands_agent", None)
+        tools = list(
+            getattr(strands_agent, "tools", None) or getattr(agent, "_tool_list", [])
+        )
+        if not tools:
+            return agent
+        filtered = []
+        for tool in tools:
+            name = (
+                getattr(tool, "tool_name", "")
+                or getattr(tool, "__name__", "")
+                or getattr(tool, "name", "")
+            )
+            meta = getattr(tool, "_geoagent_meta", None)
+            if meta is None and registry is not None and name:
+                try:
+                    meta = registry.get(name)
+                except Exception:
+                    meta = None
+            if _permission_allows_tool(permission_profile, name, meta):
+                filtered.append(tool)
+        if len(filtered) != len(tools) and hasattr(agent, "_tool_list"):
+            agent._tool_list = filtered
+            if hasattr(agent, "_rebuild_strands_agent"):
+                agent._rebuild_strands_agent()
+    except Exception:
+        pass
+    return agent
+
+
+def _project_history_key(iface):
+    """Return a stable QSettings key suffix for the current QGIS project."""
+    path = ""
+    try:
+        from qgis.core import QgsProject
+
+        path = QgsProject.instance().fileName() or ""
+    except Exception:
+        path = ""
+    if not path:
+        try:
+            project = getattr(iface, "project", lambda: None)()
+            path = project.fileName() if project is not None else ""
+        except Exception:
+            path = ""
+    raw = path or "unsaved-project"
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+    return f"{SETTINGS_PREFIX}history/{digest}"
+
+
+def _parse_markdown_transcript(text):
+    """Parse exported Markdown transcript blocks back into chat messages."""
+    messages = []
+    sender = None
+    body_lines = []
+    for line in str(text or "").splitlines():
+        if line.startswith("## "):
+            if sender is not None:
+                body = "\n".join(body_lines).strip()
+                if body:
+                    messages.append(
+                        {"sender": sender, "body": body, "markdown": sender != "You"}
+                    )
+            sender = line[3:].strip() or "OpenGeoAgent"
+            body_lines = []
+        else:
+            body_lines.append(line)
+    if sender is not None:
+        body = "\n".join(body_lines).strip()
+        if body:
+            messages.append(
+                {"sender": sender, "body": body, "markdown": sender != "You"}
+            )
+    return messages
+
+
+def _job_status_text(job):
+    """Return compact text for one recorded job."""
+    tools = job.get("tools") or ""
+    error = job.get("error") or ""
+    parts = [job.get("status", "")]
+    if tools:
+        parts.append(f"tools: {tools}")
+    if error:
+        parts.append(f"error: {error[:120]}")
+    return "; ".join(part for part in parts if part)
 
 
 def _default_model_for_provider(provider):
@@ -744,6 +940,8 @@ class ChatWorker(QThread):
         max_tokens,
         auto_approve_tools=False,
         stream=False,
+        agent_mode=DEFAULT_AGENT_MODE,
+        permission_profile=DEFAULT_PERMISSION_PROFILE,
         parent=None,
     ):
         super().__init__(parent)
@@ -755,12 +953,14 @@ class ChatWorker(QThread):
         self.max_tokens = max_tokens
         self.auto_approve_tools = bool(auto_approve_tools)
         self.stream = bool(stream)
+        self.agent_mode = agent_mode or DEFAULT_AGENT_MODE
+        self.permission_profile = permission_profile or DEFAULT_PERMISSION_PROFILE
 
     def run(self):
         """Create a GeoAgent QGIS agent and execute one chat turn."""
         try:
             from geoagent import GeoAgentConfig
-            from geoagent import for_whitebox
+            import geoagent
 
             try:
                 from qgis.core import QgsProject
@@ -774,13 +974,40 @@ class ChatWorker(QThread):
                 model=self.model_id,
                 max_tokens=self.max_tokens,
             )
-            agent = for_whitebox(
-                self.iface,
-                project=project,
-                config=config,
-                fast=self.fast,
-                confirm=self._confirm_tool,
-            )
+            factory_name = {
+                "General QGIS": "for_qgis",
+                "WhiteboxTools": "for_whitebox",
+                "NASA Earthdata": "for_nasa_earthdata",
+                "NASA OPERA": "for_nasa_opera",
+                "GEE Data Catalogs": "for_gee_data_catalogs",
+                "STAC": "for_qgis",
+            }.get(self.agent_mode, "for_qgis")
+            factory = getattr(geoagent, factory_name)
+            kwargs = {
+                "project": project,
+                "config": config,
+                "fast": self.fast,
+                "confirm": self._confirm_tool,
+            }
+            if self.permission_profile:
+                kwargs["permission_profile"] = self.permission_profile
+            try:
+                agent = factory(self.iface, **kwargs)
+            except TypeError as exc:
+                if "permission_profile" not in str(exc):
+                    raise
+                kwargs.pop("permission_profile", None)
+                agent = factory(self.iface, **kwargs)
+                agent = _filter_tools_for_permission(agent, self.permission_profile)
+            agent = _filter_tools_for_permission(agent, self.permission_profile)
+            if self.agent_mode == "STAC":
+                self.prompt = (
+                    "You are in STAC guidance mode. The current GeoAgent STAC "
+                    "tool surface is limited, so provide dependency checks, "
+                    "catalog-search steps, and QGIS loading guidance without "
+                    "pretending to run missing STAC loader tools.\n\n"
+                    f"{self.prompt}"
+                )
             if self.stream:
                 self._run_streaming_chat(agent)
                 return
@@ -889,9 +1116,10 @@ class ChatWorker(QThread):
                 parent = self.iface.mainWindow()
             except Exception as exc:
                 QgsMessageLog.logMessage(
-                    f"Could not resolve QGIS main window for confirmation dialog: {exc}",
+                    "Could not resolve QGIS main window for confirmation dialog: "
+                    f"{exc}",
                     "OpenGeoAgent",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
 
             arg_lines = []
@@ -945,6 +1173,9 @@ class ChatDockWidget(QDockWidget):
         self._stream_render_timer.setSingleShot(True)
         self._stream_render_timer.setInterval(75)
         self._stream_render_timer.timeout.connect(self._flush_streaming_render)
+        self._history_key = _project_history_key(iface)
+        self._jobs = []
+        self._active_job_index = None
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -982,6 +1213,15 @@ class ChatDockWidget(QDockWidget):
         self.model_input.setPlaceholderText("Use provider default")
         model_layout.addRow("Model:", self.model_input)
 
+        self.agent_mode_combo = QComboBox()
+        self.agent_mode_combo.addItems(AGENT_MODES)
+        self.agent_mode_combo.currentTextChanged.connect(self._on_agent_mode_changed)
+        model_layout.addRow("Agent mode:", self.agent_mode_combo)
+
+        self.permission_combo = QComboBox()
+        self.permission_combo.addItems(PERMISSION_PROFILES)
+        model_layout.addRow("Permissions:", self.permission_combo)
+
         self.fast_check = QCheckBox("Fast mode")
         self.stream_check = QCheckBox("Stream output")
         self.auto_approve_tools_check = QCheckBox("Auto approve running tools")
@@ -1003,7 +1243,7 @@ class ChatDockWidget(QDockWidget):
         sample_layout = QHBoxLayout()
         self.sample_combo = QComboBox()
         self.sample_combo.addItem("Sample prompts...")
-        self.sample_combo.addItems(SAMPLE_PROMPTS)
+        self.sample_combo.addItems(_all_sample_prompts())
         self.sample_combo.setMinimumContentsLength(22)
         self.sample_combo.setSizeAdjustPolicy(
             _enum_value(
@@ -1019,6 +1259,29 @@ class ChatDockWidget(QDockWidget):
         self.sample_combo.currentTextChanged.connect(self._select_sample_prompt)
         sample_layout.addWidget(self.sample_combo, 1)
         layout.addLayout(sample_layout)
+
+        jobs_group = QGroupBox("Jobs")
+        jobs_layout = QVBoxLayout(jobs_group)
+        self.jobs_table = QTableWidget(0, 4)
+        self.jobs_table.setHorizontalHeaderLabels(
+            ["Status", "Mode", "Prompt", "Details"]
+        )
+        self.jobs_table.setMaximumHeight(120)
+        self.jobs_table.setSelectionBehavior(
+            _enum_value(QAbstractItemView, "SelectionBehavior", "SelectRows")
+        )
+        jobs_layout.addWidget(self.jobs_table)
+        jobs_btn_layout = QHBoxLayout()
+        self.rerun_job_btn = QPushButton("Rerun Job")
+        self.rerun_job_btn.clicked.connect(self._rerun_selected_job)
+        jobs_btn_layout.addWidget(self.rerun_job_btn)
+        self.cancel_job_btn = QPushButton("Cancel Active")
+        self.cancel_job_btn.clicked.connect(self._cancel_running_task)
+        self.cancel_job_btn.setEnabled(False)
+        jobs_btn_layout.addWidget(self.cancel_job_btn)
+        jobs_btn_layout.addStretch(1)
+        jobs_layout.addLayout(jobs_btn_layout)
+        layout.addWidget(jobs_group)
 
         self.transcript = QTextEdit()
         self.transcript.setReadOnly(True)
@@ -1075,6 +1338,14 @@ class ChatDockWidget(QDockWidget):
         self.clear_btn.clicked.connect(self._clear_transcript)
         primary_button_layout.addWidget(self.clear_btn)
 
+        self.export_md_btn = QPushButton("Export")
+        self.export_md_btn.clicked.connect(self._export_transcript_markdown)
+        primary_button_layout.addWidget(self.export_md_btn)
+
+        self.import_md_btn = QPushButton("Import")
+        self.import_md_btn.clicked.connect(self._import_transcript_markdown)
+        primary_button_layout.addWidget(self.import_md_btn)
+
         self.copy_md_btn = QPushButton("Copy Markdown")
         self.copy_md_btn.setEnabled(False)
         self.copy_md_btn.clicked.connect(self._copy_transcript_markdown)
@@ -1112,6 +1383,17 @@ class ChatDockWidget(QDockWidget):
         self.auto_approve_tools_check.setChecked(
             _setting(self.settings, "auto_approve_tools", False, bool)
         )
+        mode = _setting(self.settings, "agent_mode", DEFAULT_AGENT_MODE)
+        index = self.agent_mode_combo.findText(mode)
+        self.agent_mode_combo.setCurrentIndex(index if index >= 0 else 0)
+        profile = _setting(
+            self.settings,
+            "permission_profile",
+            DEFAULT_PERMISSION_PROFILE,
+        )
+        index = self.permission_combo.findText(profile)
+        self.permission_combo.setCurrentIndex(index if index >= 0 else 0)
+        self._load_project_history()
 
     def _save_model_settings(self):
         """Persist the selected provider, model, and fast-mode setting."""
@@ -1131,10 +1413,24 @@ class ChatDockWidget(QDockWidget):
             f"{SETTINGS_PREFIX}auto_approve_tools",
             self.auto_approve_tools_check.isChecked(),
         )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}agent_mode", self.agent_mode_combo.currentText()
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}permission_profile", self.permission_combo.currentText()
+        )
 
     def _on_provider_changed(self, provider):
         """Update the model field when the provider changes."""
         self.model_input.setText(_default_model_for_provider(provider))
+
+    def _on_agent_mode_changed(self, mode):
+        """Load a mode-specific workflow prompt when useful."""
+        if not hasattr(self, "prompt_input"):
+            return
+        prompts = WORKFLOW_PROMPTS.get(mode, [])
+        if prompts and not self.prompt_input.toPlainText().strip():
+            self.prompt_input.setPlainText(prompts[0])
 
     def _add_clipboard_image(self, image):
         """Attach an image pasted into the prompt editor."""
@@ -1401,7 +1697,8 @@ class ChatDockWidget(QDockWidget):
         self._region_capture = capture
         capture.start()
         self.status_label.setText(
-            "Drag over the map canvas to attach a screenshot region. Press Esc to cancel."
+            "Drag over the map canvas to attach a screenshot region. "
+            "Press Esc to cancel."
         )
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
 
@@ -1445,7 +1742,8 @@ class ChatDockWidget(QDockWidget):
         self._screen_region_capture = capture
         capture.start()
         self.status_label.setText(
-            "Drag anywhere on the screen to attach a screenshot region. Press Esc to cancel."
+            "Drag anywhere on the screen to attach a screenshot region. "
+            "Press Esc to cancel."
         )
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
 
@@ -1507,6 +1805,10 @@ class ChatDockWidget(QDockWidget):
         fast = self.fast_check.isChecked()
         stream = self.stream_check.isChecked()
         auto_approve_tools = self.auto_approve_tools_check.isChecked()
+        agent_mode = self.agent_mode_combo.currentText()
+        permission_profile = self.permission_combo.currentText()
+        if permission_profile == "Trusted auto-approve":
+            auto_approve_tools = True
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         if not prompt:
             prompt = "Describe the attached image."
@@ -1534,6 +1836,20 @@ class ChatDockWidget(QDockWidget):
         )
         self.send_btn.setEnabled(False)
         self.cancel_btn.setEnabled(True)
+        self.cancel_job_btn.setEnabled(True)
+        self._active_job_index = self._add_job(
+            {
+                "prompt": prompt,
+                "provider": provider,
+                "model": model_id,
+                "mode": agent_mode,
+                "permission_profile": permission_profile,
+                "status": "Running",
+                "started_at": time.time(),
+                "tools": "",
+                "error": "",
+            }
+        )
 
         self._worker = ChatWorker(
             self.iface,
@@ -1544,6 +1860,8 @@ class ChatDockWidget(QDockWidget):
             max_tokens,
             auto_approve_tools,
             stream,
+            agent_mode,
+            permission_profile,
             self,
         )
         self._worker.chunk_received.connect(self._on_worker_chunk)
@@ -1624,6 +1942,7 @@ class ChatDockWidget(QDockWidget):
             self._append_message("OpenGeoAgent", "Cancelled by user.", markdown=False)
             self.status_label.setText("Cancelled")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+            self._finish_active_job("Cancelled", result)
         elif result.get("success"):
             answer = result.get("answer") or "(No text response.)"
             details = []
@@ -1651,6 +1970,7 @@ class ChatDockWidget(QDockWidget):
                 self._append_message("OpenGeoAgent", answer, markdown=True)
             self.status_label.setText("Ready")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+            self._finish_active_job("Succeeded", result)
         else:
             error = result.get("error") or "Unknown error"
             cancelled = result.get("cancelled")
@@ -1659,12 +1979,15 @@ class ChatDockWidget(QDockWidget):
             self._append_message("OpenGeoAgent", f"Error:\n{error}", markdown=False)
             self.status_label.setText("Error")
             self.status_label.setStyleSheet("color: red; font-size: 10px;")
+            self._finish_active_job("Failed", result)
 
         self.send_btn.setEnabled(True)
         self.cancel_btn.setEnabled(False)
+        self.cancel_job_btn.setEnabled(False)
         self._worker = None
         self._streaming_message_index = None
         self._streaming_answer = ""
+        self._active_job_index = None
 
     def _on_worker_chunk(self, chunk):
         """Buffer a streamed model text chunk and schedule a debounced render."""
@@ -1697,6 +2020,7 @@ class ChatDockWidget(QDockWidget):
             return
         worker.requestInterruption()
         self.cancel_btn.setEnabled(False)
+        self.cancel_job_btn.setEnabled(False)
         self.status_label.setText(
             "Cancellation requested. Waiting for the current model "
             "call or tool to finish before stopping."
@@ -1754,6 +2078,7 @@ class ChatDockWidget(QDockWidget):
         self._messages.append(entry)
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
+        self._save_project_history()
 
     def _update_message(self, index, message, markdown=False):
         """Update an existing chat message and refresh the transcript."""
@@ -1763,6 +2088,7 @@ class ChatDockWidget(QDockWidget):
         self._messages[index]["markdown"] = markdown
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
+        self._save_project_history()
 
     def _render_transcript(self):
         """Render the stored chat messages as HTML."""
@@ -1809,6 +2135,46 @@ class ChatDockWidget(QDockWidget):
             self.status_label.setText("Copied PyQGIS script.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
+    def _export_transcript_markdown(self):
+        """Save the chat transcript as Markdown."""
+        transcript = _conversation_markdown(self._messages)
+        if not transcript:
+            return
+        path, _selected_filter = QFileDialog.getSaveFileName(
+            self,
+            "Export Chat Transcript",
+            "open_geoagent_chat.md",
+            "Markdown (*.md);;Text (*.txt)",
+        )
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(transcript)
+        self.status_label.setText("Exported chat transcript.")
+        self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
+    def _import_transcript_markdown(self):
+        """Import a Markdown transcript into the current project history."""
+        path, _selected_filter = QFileDialog.getOpenFileName(
+            self,
+            "Import Chat Transcript",
+            "",
+            "Markdown (*.md);;Text (*.txt);;All files (*)",
+        )
+        if not path:
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            messages = _parse_markdown_transcript(f.read())
+        if not messages:
+            QMessageBox.information(self, "OpenGeoAgent", "No chat messages found.")
+            return
+        self._messages = messages
+        self.copy_md_btn.setEnabled(True)
+        self._render_transcript()
+        self._save_project_history()
+        self.status_label.setText("Imported chat transcript.")
+        self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
     def _clear_transcript(self):
         """Clear all rendered chat messages."""
         self._messages = []
@@ -1816,6 +2182,98 @@ class ChatDockWidget(QDockWidget):
         self.copy_script_btn.setEnabled(False)
         self.copy_md_btn.setEnabled(False)
         self.transcript.clear()
+        self._save_project_history()
+
+    def _load_project_history(self):
+        """Load persisted chat messages for the current QGIS project."""
+        raw = self.settings.value(self._history_key, "", type=str)
+        if not raw:
+            return
+        try:
+            messages = json.loads(raw)
+        except (TypeError, ValueError):
+            return
+        if not isinstance(messages, list):
+            return
+        self._messages = [
+            item
+            for item in messages
+            if isinstance(item, dict) and item.get("sender") and item.get("body")
+        ]
+        self.copy_md_btn.setEnabled(bool(self._messages))
+        self._render_transcript()
+
+    def _save_project_history(self):
+        """Persist chat messages for the current QGIS project."""
+        try:
+            payload = json.dumps(self._messages[-80:])
+            self.settings.setValue(self._history_key, payload)
+        except Exception:
+            pass
+
+    def _add_job(self, job):
+        """Record a submitted chat job and refresh the jobs table."""
+        self._jobs.append(dict(job))
+        self._render_jobs()
+        return len(self._jobs) - 1
+
+    def _finish_active_job(self, status, result):
+        """Attach final status details to the active job."""
+        if self._active_job_index is None:
+            return
+        if self._active_job_index < 0 or self._active_job_index >= len(self._jobs):
+            return
+        job = self._jobs[self._active_job_index]
+        job["status"] = status
+        job["elapsed"] = result.get("elapsed", "")
+        job["tools"] = result.get("tools", "")
+        job["tool_calls"] = result.get("tool_calls", [])
+        job["error"] = result.get("error", "")
+        self._render_jobs()
+
+    def _render_jobs(self):
+        """Refresh the compact jobs table."""
+        self.jobs_table.setRowCount(len(self._jobs))
+        for row, job in enumerate(self._jobs):
+            values = [
+                job.get("status", ""),
+                job.get("mode", ""),
+                job.get("prompt", ""),
+                _job_status_text(job),
+            ]
+            for col, value in enumerate(values):
+                self.jobs_table.setItem(row, col, QTableWidgetItem(str(value)))
+
+    def _selected_job_index(self):
+        """Return the selected job row or None."""
+        ranges = self.jobs_table.selectedRanges()
+        if not ranges:
+            return None
+        row = ranges[0].topRow()
+        if row < 0 or row >= len(self._jobs):
+            return None
+        return row
+
+    def _rerun_selected_job(self):
+        """Copy a completed job prompt/settings back into the controls and send it."""
+        index = self._selected_job_index()
+        if index is None:
+            return
+        job = self._jobs[index]
+        self.prompt_input.setPlainText(job.get("prompt", ""))
+        for combo, key in (
+            (self.provider_combo, "provider"),
+            (self.agent_mode_combo, "mode"),
+            (self.permission_combo, "permission_profile"),
+        ):
+            value = job.get(key, "")
+            found = combo.findText(value)
+            if found >= 0:
+                combo.setCurrentIndex(found)
+        model = job.get("model", "")
+        if model:
+            self.model_input.setText(model)
+        self._send_prompt()
 
     def _shutdown_running_state(self):
         """Stop the animated status timer when the dock is dismissed."""
@@ -1831,7 +2289,7 @@ class ChatDockWidget(QDockWidget):
             QgsMessageLog.logMessage(
                 f"Failed to stop running status timer during dock shutdown: {exc}",
                 "OpenGeoAgent",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
 
     def hideEvent(self, event):

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -81,6 +81,22 @@ def _plugin_version(plugin_dir):
     return "Unknown"
 
 
+def _model_requires_default_temperature(provider, model_id):
+    """Return True when the selected model rejects non-default temperature."""
+    normalized = str(model_id or "").lower()
+    prefixes = (
+        "gpt-5",
+        "openai/gpt-5",
+        "o1",
+        "openai/o1",
+        "o3",
+        "openai/o3",
+        "o4",
+        "openai/o4",
+    )
+    return provider in {"openai", "litellm"} and normalized.startswith(prefixes)
+
+
 def collect_diagnostics(
     settings,
     plugin_dir,
@@ -163,24 +179,41 @@ class ProviderTestWorker(QThread):
         self.settings = settings
 
     def run(self):
-        """Create a no-tool GeoAgent and send a short prompt."""
+        """Create a minimal no-tool Strands agent and send a short prompt."""
         try:
             _apply_environment_from_settings(self.settings)
             if self.provider == "openai-codex":
                 from ..oauth import ensure_openai_oauth_environment
 
                 ensure_openai_oauth_environment(self.settings, codex=True)
-            from geoagent import GeoAgent, GeoAgentConfig
+            from geoagent import GeoAgentConfig
+            from geoagent.core.model import resolve_model
+            from strands import Agent
 
+            token_floor = 4096 if self.provider == "ollama" else 1024
             cfg = GeoAgentConfig(
                 provider=self.provider,
                 model=self.model_id or None,
-                max_tokens=min(int(self.max_tokens or 128), 128),
+                temperature=(
+                    1
+                    if _model_requires_default_temperature(
+                        self.provider, self.model_id
+                    )
+                    else 0
+                ),
+                max_tokens=max(int(self.max_tokens or token_floor), token_floor),
             )
-            agent = GeoAgent(config=cfg, tools=[])
-            response = agent.chat("Reply with exactly: ok")
-            if not response.success:
-                raise RuntimeError(response.error_message or "Provider test failed")
+            model = resolve_model(cfg)
+            agent = Agent(
+                model=model,
+                tools=[],
+                system_prompt="You are a provider connectivity test. Reply briefly.",
+                callback_handler=None,
+            )
+            prompt = "Reply with exactly: ok"
+            if self.provider == "ollama":
+                prompt = "/no_think\nReply with exactly: ok"
+            agent(prompt)
             self.finished.emit({"success": True, "message": "Provider test succeeded."})
         except Exception as exc:
             self.finished.emit({"success": False, "message": str(exc)})

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -51,19 +51,10 @@ ENV_FALLBACKS = {
 
 def _apply_environment_from_settings(settings):
     """Apply saved provider credentials to the current process."""
-    env_map = {
-        "openai_api_key": ("OPENAI_API_KEY",),
-        "anthropic_api_key": ("ANTHROPIC_API_KEY",),
-        "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-        "aws_region": ("AWS_REGION",),
-        "ollama_host": ("OLLAMA_HOST",),
-        "litellm_api_key": ("LITELLM_API_KEY",),
-        "litellm_base_url": ("LITELLM_BASE_URL",),
-    }
-    for key, env_names in env_map.items():
+    for key, env_names in ENV_FALLBACKS.items():
         value = settings.value(f"{SETTINGS_PREFIX}{key}", "", type=str).strip()
         if not value:
-            value = _env_fallback(*ENV_FALLBACKS.get(key, ()))
+            value = _env_fallback(*env_names)
         if value:
             for env_name in env_names:
                 os.environ[env_name] = value

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -196,9 +196,7 @@ class ProviderTestWorker(QThread):
                 model=self.model_id or None,
                 temperature=(
                     1
-                    if _model_requires_default_temperature(
-                        self.provider, self.model_id
-                    )
+                    if _model_requires_default_temperature(self.provider, self.model_id)
                     else 0
                 ),
                 max_tokens=max(int(self.max_tokens or token_floor), token_floor),

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -1,13 +1,18 @@
 """Settings and dependency management for OpenGeoAgent."""
 
+import json
 import os
+import platform
+import sys
 import time
 
 from qgis.PyQt.QtCore import Qt, QSettings, QThread, QTimer, QUrl, pyqtSignal
+from qgis.PyQt.QtGui import QDesktopServices, QFont, QGuiApplication
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDockWidget,
+    QFileDialog,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
@@ -21,7 +26,6 @@ from qgis.PyQt.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qgis.PyQt.QtGui import QDesktopServices, QFont
 
 from .chat_dock import DEFAULT_MODELS, DEFAULT_PROVIDER, PROVIDERS, SETTINGS_PREFIX
 from ..oauth import (
@@ -43,6 +47,143 @@ ENV_FALLBACKS = {
     "litellm_api_key": ("LITELLM_API_KEY",),
     "litellm_base_url": ("LITELLM_BASE_URL",),
 }
+
+
+def _apply_environment_from_settings(settings):
+    """Apply saved provider credentials to the current process."""
+    env_map = {
+        "openai_api_key": ("OPENAI_API_KEY",),
+        "anthropic_api_key": ("ANTHROPIC_API_KEY",),
+        "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "aws_region": ("AWS_REGION",),
+        "ollama_host": ("OLLAMA_HOST",),
+        "litellm_api_key": ("LITELLM_API_KEY",),
+        "litellm_base_url": ("LITELLM_BASE_URL",),
+    }
+    for key, env_names in env_map.items():
+        value = settings.value(f"{SETTINGS_PREFIX}{key}", "", type=str).strip()
+        if not value:
+            value = _env_fallback(*ENV_FALLBACKS.get(key, ()))
+        if value:
+            for env_name in env_names:
+                os.environ[env_name] = value
+
+
+def _plugin_version(plugin_dir):
+    """Read the plugin metadata version."""
+    try:
+        with open(os.path.join(plugin_dir, "metadata.txt"), "r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("version="):
+                    return line.split("=", 1)[1].strip()
+    except OSError:
+        pass
+    return "Unknown"
+
+
+def collect_diagnostics(
+    settings,
+    plugin_dir,
+    latest_install_status="",
+    latest_test_status="",
+):
+    """Return redacted OpenGeoAgent diagnostics as a JSON-friendly dict."""
+    from ..deps_manager import (
+        check_dependencies,
+        get_venv_dir,
+        get_venv_site_packages,
+        venv_exists,
+    )
+    from ..uv_manager import get_uv_path, verify_uv
+
+    try:
+        uv_ok, uv_message = verify_uv()
+    except Exception as exc:
+        uv_ok, uv_message = False, str(exc)
+    try:
+        from qgis.core import Qgis
+
+        qgis_version = getattr(Qgis, "QGIS_VERSION", "Unknown")
+    except Exception:
+        qgis_version = "Unknown"
+
+    credential_presence = {}
+    for key, env_names in ENV_FALLBACKS.items():
+        saved = settings.value(f"{SETTINGS_PREFIX}{key}", "", type=str).strip()
+        env_value = _env_fallback(*env_names)
+        credential_presence[key] = {
+            "saved": bool(saved),
+            "environment": bool(env_value),
+        }
+
+    return {
+        "plugin_version": _plugin_version(plugin_dir),
+        "qgis_version": qgis_version,
+        "python": {
+            "executable": sys.executable,
+            "version": sys.version.split()[0],
+            "platform": platform.platform(),
+        },
+        "venv": {
+            "exists": venv_exists(),
+            "path": get_venv_dir(),
+            "site_packages": get_venv_site_packages(),
+        },
+        "uv": {
+            "path": get_uv_path(),
+            "verified": bool(uv_ok),
+            "message": uv_message,
+        },
+        "dependencies": check_dependencies(),
+        "model": {
+            "provider": settings.value(
+                f"{SETTINGS_PREFIX}provider", DEFAULT_PROVIDER, type=str
+            ),
+            "model": settings.value(f"{SETTINGS_PREFIX}model", "", type=str),
+            "max_tokens": settings.value(
+                f"{SETTINGS_PREFIX}max_tokens", 4096, type=int
+            ),
+        },
+        "credential_presence": credential_presence,
+        "latest_install_status": latest_install_status,
+        "latest_provider_test_status": latest_test_status,
+    }
+
+
+class ProviderTestWorker(QThread):
+    """Run a tiny provider smoke test outside the QGIS UI thread."""
+
+    finished = pyqtSignal(dict)
+
+    def __init__(self, provider, model_id, max_tokens, settings, parent=None):
+        super().__init__(parent)
+        self.provider = provider
+        self.model_id = model_id
+        self.max_tokens = max_tokens
+        self.settings = settings
+
+    def run(self):
+        """Create a no-tool GeoAgent and send a short prompt."""
+        try:
+            _apply_environment_from_settings(self.settings)
+            if self.provider == "openai-codex":
+                from ..oauth import ensure_openai_oauth_environment
+
+                ensure_openai_oauth_environment(self.settings, codex=True)
+            from geoagent import GeoAgent, GeoAgentConfig
+
+            cfg = GeoAgentConfig(
+                provider=self.provider,
+                model=self.model_id or None,
+                max_tokens=min(int(self.max_tokens or 128), 128),
+            )
+            agent = GeoAgent(config=cfg, tools=[])
+            response = agent.chat("Reply with exactly: ok")
+            if not response.success:
+                raise RuntimeError(response.error_message or "Provider test failed")
+            self.finished.emit({"success": True, "message": "Provider test succeeded."})
+        except Exception as exc:
+            self.finished.emit({"success": False, "message": str(exc)})
 
 
 def _enum_value(cls, enum_name, member_name):
@@ -132,6 +273,9 @@ class SettingsDockWidget(QDockWidget):
         self.settings = QSettings()
         self._deps_worker = None
         self._oauth_worker = None
+        self._provider_test_worker = None
+        self._latest_install_status = ""
+        self._latest_provider_test_status = ""
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -168,10 +312,24 @@ class SettingsDockWidget(QDockWidget):
         self.save_btn.clicked.connect(self._save_settings)
         button_layout.addWidget(self.save_btn)
 
+        self.test_provider_btn = QPushButton("Test Provider")
+        self.test_provider_btn.clicked.connect(self._test_provider)
+        button_layout.addWidget(self.test_provider_btn)
+
         self.reset_btn = QPushButton("Reset Defaults")
         self.reset_btn.clicked.connect(self._reset_defaults)
         button_layout.addWidget(self.reset_btn)
         layout.addLayout(button_layout)
+
+        diagnostics_layout = QHBoxLayout()
+        self.copy_diagnostics_btn = QPushButton("Copy Diagnostics")
+        self.copy_diagnostics_btn.clicked.connect(self._copy_diagnostics)
+        diagnostics_layout.addWidget(self.copy_diagnostics_btn)
+
+        self.save_diagnostics_btn = QPushButton("Save Diagnostics")
+        self.save_diagnostics_btn.clicked.connect(self._save_diagnostics)
+        diagnostics_layout.addWidget(self.save_diagnostics_btn)
+        layout.addLayout(diagnostics_layout)
 
         self.status_label = QLabel("Settings loaded")
         self.status_label.setStyleSheet("color: gray; font-size: 10px;")
@@ -440,6 +598,7 @@ class SettingsDockWidget(QDockWidget):
         self.refresh_deps_btn.setEnabled(True)
 
         if success:
+            self._latest_install_status = message
             self.deps_overall_label.setText(message)
             self.deps_overall_label.setStyleSheet(
                 "color: green; font-weight: bold; padding: 5px;"
@@ -455,6 +614,7 @@ class SettingsDockWidget(QDockWidget):
                 "Restart QGIS if the plugin cannot import them immediately.",
             )
         else:
+            self._latest_install_status = message
             self.deps_overall_label.setText("Installation failed.")
             self.deps_overall_label.setStyleSheet(
                 "color: red; font-weight: bold; padding: 5px;"
@@ -673,6 +833,74 @@ class SettingsDockWidget(QDockWidget):
         self.status_label.setText("Settings saved")
         self.status_label.setStyleSheet("color: green; font-size: 10px;")
         self.iface.messageBar().pushSuccess("OpenGeoAgent", "Settings saved.")
+
+    def _test_provider(self):
+        """Run a tiny provider smoke test in a background worker."""
+        if self._provider_test_worker is not None:
+            return
+        self._save_settings()
+        provider = self.provider_combo.currentText()
+        model_id = self.model_input.text().strip() or DEFAULT_MODELS.get(provider, "")
+        self.test_provider_btn.setEnabled(False)
+        self.status_label.setText("Testing provider...")
+        self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
+        self._provider_test_worker = ProviderTestWorker(
+            provider,
+            model_id,
+            self.max_tokens_spin.value(),
+            self.settings,
+            self,
+        )
+        self._provider_test_worker.finished.connect(self._on_provider_test_finished)
+        self._provider_test_worker.start()
+
+    def _on_provider_test_finished(self, result):
+        """Display provider smoke-test result."""
+        self.test_provider_btn.setEnabled(True)
+        self._provider_test_worker = None
+        message = result.get("message", "")
+        self._latest_provider_test_status = message
+        if result.get("success"):
+            self.status_label.setText(message)
+            self.status_label.setStyleSheet("color: green; font-size: 10px;")
+            self.iface.messageBar().pushSuccess("OpenGeoAgent", message)
+        else:
+            self.status_label.setText("Provider test failed")
+            self.status_label.setStyleSheet("color: red; font-size: 10px;")
+            QMessageBox.critical(self, "Provider Test Failed", message)
+
+    def _diagnostics_text(self):
+        """Return redacted diagnostics as pretty JSON."""
+        payload = collect_diagnostics(
+            self.settings,
+            os.path.dirname(os.path.dirname(__file__)),
+            self._latest_install_status,
+            self._latest_provider_test_status,
+        )
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+    def _copy_diagnostics(self):
+        """Copy redacted diagnostics to the clipboard."""
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(self._diagnostics_text())
+        self.status_label.setText("Copied diagnostics.")
+        self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
+    def _save_diagnostics(self):
+        """Save redacted diagnostics to a JSON file."""
+        path, _selected_filter = QFileDialog.getSaveFileName(
+            self,
+            "Save OpenGeoAgent Diagnostics",
+            "open_geoagent_diagnostics.json",
+            "JSON (*.json);;Text (*.txt)",
+        )
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self._diagnostics_text())
+        self.status_label.setText("Saved diagnostics.")
+        self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
     def _reset_defaults(self):
         """Reset saved model settings after user confirmation."""

--- a/qgis_geoagent/open_geoagent/open_geoagent.py
+++ b/qgis_geoagent/open_geoagent/open_geoagent.py
@@ -150,7 +150,7 @@ class OpenGeoAgent:
                 QgsMessageLog.logMessage(
                     f"Failed to push dependency warning to message bar: {exc}",
                     "OpenGeoAgent",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
             return
 

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -16,6 +16,7 @@ from open_geoagent.dialogs.chat_dock import (
     _normalized_crop_rect,
     _parse_markdown_transcript,
     _permission_allows_tool,
+    _project_history_key,
 )
 
 
@@ -327,6 +328,24 @@ def test_parse_markdown_transcript_round_trips_exported_history() -> None:
         {"sender": "You", "body": "hello", "markdown": False},
         {"sender": "OpenGeoAgent", "body": "**ok**", "markdown": True},
     ]
+
+
+def test_unsaved_project_has_no_history_key(monkeypatch) -> None:
+    """Untitled QGIS projects should not load shared chat history."""
+    import sys
+    import types
+
+    monkeypatch.setitem(
+        sys.modules,
+        "qgis.core",
+        types.SimpleNamespace(
+            QgsProject=types.SimpleNamespace(
+                instance=lambda: types.SimpleNamespace(fileName=lambda: "")
+            )
+        ),
+    )
+
+    assert _project_history_key(None) == ""
 
 
 def test_permission_profiles_filter_sensitive_tools() -> None:

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -13,6 +13,8 @@ from open_geoagent.dialogs.chat_dock import (
     _image_to_png_bytes,
     _latest_pyqgis_script,
     _normalized_crop_rect,
+    _parse_markdown_transcript,
+    _permission_allows_tool,
 )
 
 
@@ -231,3 +233,29 @@ def test_format_tool_calls_collapses_repeated_noop_defaults() -> None:
     assert "`method=fill_depressions_wang_and_liu`" in text
     assert "max_depth" not in text
     assert "fill_pits" not in text
+
+
+def test_parse_markdown_transcript_round_trips_exported_history() -> None:
+    """Verify imported Markdown becomes project history messages."""
+    messages = _parse_markdown_transcript(
+        "## You\n\nhello\n\n## OpenGeoAgent\n\n**ok**\n"
+    )
+
+    assert messages == [
+        {"sender": "You", "body": "hello", "markdown": False},
+        {"sender": "OpenGeoAgent", "body": "**ok**", "markdown": True},
+    ]
+
+
+def test_permission_profiles_filter_sensitive_tools() -> None:
+    """Verify inspect-only mode hides mutating/long-running tools."""
+
+    class _Meta:
+        category = "qgis"
+        requires_confirmation = True
+        destructive = False
+        long_running = False
+
+    assert not _permission_allows_tool("Inspect only", "run_pyqgis_script", _Meta())
+    assert _permission_allows_tool("Execute PyQGIS", "run_pyqgis_script", _Meta())
+    assert _permission_allows_tool("Trusted auto-approve", "run_pyqgis_script", _Meta())

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -11,6 +11,7 @@ from open_geoagent.dialogs.chat_dock import (
     _grab_screen_rect,
     _grab_widget_global_rect,
     _image_to_png_bytes,
+    _latest_executable_snippet,
     _latest_pyqgis_script,
     _normalized_crop_rect,
     _parse_markdown_transcript,
@@ -95,6 +96,87 @@ def test_latest_pyqgis_script_extracts_last_run_script() -> None:
     )
 
     assert script == "active_layer.triggerRepaint()"
+
+
+def test_latest_executable_snippet_supports_gee_and_results() -> None:
+    """Verify Copy Script can find non-PyQGIS executable snippets."""
+    snippet = _latest_executable_snippet(
+        [
+            {
+                "name": "run_pyqgis_script",
+                "args": {"code": "iface.mapCanvas().refresh()"},
+            },
+            {
+                "name": "load_gee_dataset",
+                "args": {},
+                "result": {
+                    "earth_engine_python_snippet": "image = ee.Image('NASA/NASADEM')"
+                },
+            },
+            {
+                "name": "run_gee_python_snippet",
+                "args": {"code": "add_layer(ee.Image('x'), {}, 'x')"},
+            },
+        ]
+    )
+
+    assert snippet == {
+        "kind": "Earth Engine",
+        "tool_name": "run_gee_python_snippet",
+        "code": "add_layer(ee.Image('x'), {}, 'x')",
+    }
+
+
+def test_latest_executable_snippet_finds_gee_loader_result() -> None:
+    """Verify GEE load tools enable Copy Script from returned snippets."""
+    snippet = _latest_executable_snippet(
+        [
+            {
+                "name": "load_gee_dataset",
+                "args": {"asset_id": "NASA/NASADEM_HGT/001"},
+                "result": {
+                    "success": True,
+                    "earth_engine_python_snippet": (
+                        "asset_id = 'NASA/NASADEM_HGT/001'\n"
+                        "image = ee.Image(asset_id)"
+                    ),
+                },
+            }
+        ]
+    )
+
+    assert snippet == {
+        "kind": "Earth Engine",
+        "tool_name": "load_gee_dataset",
+        "code": "asset_id = 'NASA/NASADEM_HGT/001'\nimage = ee.Image(asset_id)",
+    }
+
+
+def test_latest_executable_snippet_builds_gee_loader_script_from_args() -> None:
+    """Verify Copy Script enables when Strands records only GEE tool inputs."""
+    snippet = _latest_executable_snippet(
+        [
+            {
+                "name": "load_gee_dataset",
+                "args": {
+                    "asset_id": "NASA/NASADEM_HGT/001",
+                    "asset_type": "Image",
+                    "bands": "elevation",
+                    "layer_name": "Global NASADEM elevation",
+                    "min_value": 0,
+                    "max_value": 3000,
+                    "palette": "0000ff,00ffff,ffff00,ff0000",
+                },
+            }
+        ]
+    )
+
+    assert snippet["kind"] == "Earth Engine"
+    assert snippet["tool_name"] == "load_gee_dataset"
+    assert "asset_id = 'NASA/NASADEM_HGT/001'" in snippet["code"]
+    assert "image = ee.Image(asset_id)" in snippet["code"]
+    assert "'bands': 'elevation'" in snippet["code"]
+    assert "Global NASADEM elevation" in snippet["code"]
 
 
 def test_console_ready_pyqgis_script_defines_geoagent_context_names() -> None:
@@ -257,5 +339,21 @@ def test_permission_profiles_filter_sensitive_tools() -> None:
         long_running = False
 
     assert not _permission_allows_tool("Inspect only", "run_pyqgis_script", _Meta())
+    assert _permission_allows_tool("Execute Scripts", "run_pyqgis_script", _Meta())
     assert _permission_allows_tool("Execute PyQGIS", "run_pyqgis_script", _Meta())
     assert _permission_allows_tool("Trusted auto-approve", "run_pyqgis_script", _Meta())
+
+
+def test_execute_scripts_profile_allows_gee_snippet_tool() -> None:
+    """Verify script execution profile covers GEE snippets, not only PyQGIS."""
+
+    class _Meta:
+        category = "gee_data_catalogs"
+        requires_confirmation = True
+        destructive = False
+        long_running = True
+
+    assert not _permission_allows_tool(
+        "Inspect only", "run_gee_python_snippet", _Meta()
+    )
+    assert _permission_allows_tool("Execute Scripts", "run_gee_python_snippet", _Meta())

--- a/qgis_geoagent/tests/test_pyqt6_imports.py
+++ b/qgis_geoagent/tests/test_pyqt6_imports.py
@@ -52,3 +52,15 @@ def _module_names():
 def test_module_imports_under_pyqt6(module_name):
     """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
     importlib.import_module(module_name)
+
+
+def test_plugin_uses_scoped_qgis_message_levels():
+    """Avoid legacy Qgis.Warning style enum access."""
+    offenders = []
+    for path in PLUGIN_ROOT.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for legacy in ("Qgis.Warning", "Qgis.Info", "Qgis.Critical"):
+            if legacy in text:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{legacy}")
+
+    assert offenders == []

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -163,9 +163,7 @@ def test_openai_new_models_use_max_completion_tokens(monkeypatch) -> None:
     )
     monkeypatch.setitem(sys.modules, "strands.models.openai", openai_module)
 
-    module_path = (
-        Path(__file__).resolve().parents[2] / "geoagent" / "core" / "model.py"
-    )
+    module_path = Path(__file__).resolve().parents[2] / "geoagent" / "core" / "model.py"
     spec = util.spec_from_file_location("_geoagent_model_under_test", module_path)
     module = util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -261,9 +259,7 @@ def test_litellm_openai_gpt5_omits_temperature(monkeypatch) -> None:
     )
     monkeypatch.setitem(sys.modules, "strands.models.litellm", litellm_module)
 
-    module_path = (
-        Path(__file__).resolve().parents[2] / "geoagent" / "core" / "model.py"
-    )
+    module_path = Path(__file__).resolve().parents[2] / "geoagent" / "core" / "model.py"
     spec = util.spec_from_file_location(
         "_geoagent_model_under_test_litellm", module_path
     )

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 import types
+from importlib import util
+from pathlib import Path
 
-from open_geoagent.dialogs.settings_dock import SETTINGS_PREFIX, collect_diagnostics
+from open_geoagent.dialogs.settings_dock import (
+    ProviderTestWorker,
+    SETTINGS_PREFIX,
+    collect_diagnostics,
+    _model_requires_default_temperature,
+)
 
 
 class _FakeSettings:
@@ -71,3 +78,199 @@ def test_uv_usable_requires_successful_verification(monkeypatch) -> None:
     monkeypatch.setattr(uv_manager, "verify_uv", lambda: (False, "bad"))
 
     assert deps_manager._uv_usable() is False
+
+
+def test_provider_test_worker_uses_ollama_safe_smoke_prompt(monkeypatch) -> None:
+    """Ollama smoke tests should avoid GeoAgent's full prompt/token budget."""
+    import sys
+
+    captured = {}
+
+    class _FakeConfig:
+        def __init__(self, **kwargs):
+            captured["config"] = kwargs
+
+    def _resolve_model(config):
+        captured["resolved_config"] = config
+        return "model"
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured["agent_kwargs"] = kwargs
+
+        def __call__(self, prompt):
+            captured["prompt"] = prompt
+            return "ok"
+
+    geoagent_module = types.ModuleType("geoagent")
+    geoagent_module.GeoAgentConfig = _FakeConfig
+    model_module = types.ModuleType("geoagent.core.model")
+    model_module.resolve_model = _resolve_model
+    strands_module = types.ModuleType("strands")
+    strands_module.Agent = _FakeAgent
+    monkeypatch.setitem(sys.modules, "geoagent", geoagent_module)
+    monkeypatch.setitem(sys.modules, "geoagent.core", types.ModuleType("geoagent.core"))
+    monkeypatch.setitem(sys.modules, "geoagent.core.model", model_module)
+    monkeypatch.setitem(sys.modules, "strands", strands_module)
+
+    worker = ProviderTestWorker("ollama", "qwen3.5:4b", 256, _FakeSettings({}))
+    emitted = {}
+    worker.finished.connect(lambda result: emitted.setdefault("result", result))
+
+    worker.run()
+
+    assert emitted["result"]["success"] is True
+    assert captured["config"]["max_tokens"] == 4096
+    assert captured["agent_kwargs"]["tools"] == []
+    assert "provider connectivity test" in captured["agent_kwargs"]["system_prompt"]
+    assert captured["prompt"].startswith("/no_think")
+
+
+def test_openai_new_models_use_max_completion_tokens(monkeypatch) -> None:
+    """OpenAI gpt-5 style model ids should not send legacy max_tokens."""
+    import sys
+
+    captured = {}
+
+    class _FakeConfig:
+        provider = "openai"
+        model = "gpt-5.5"
+        temperature = 0
+        max_tokens = 2048
+        client_args = {}
+
+        def model_copy(self, update=None):
+            return self
+
+    class _FakeOpenAIModel:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+    config_module = types.ModuleType("geoagent.core.config")
+    config_module.GeoAgentConfig = lambda **kwargs: _FakeConfig()
+    config_module.ProviderName = str
+    openai_module = types.ModuleType("strands.models.openai")
+    openai_module.OpenAIModel = _FakeOpenAIModel
+
+    monkeypatch.setitem(sys.modules, "geoagent", types.ModuleType("geoagent"))
+    monkeypatch.setitem(sys.modules, "geoagent.core", types.ModuleType("geoagent.core"))
+    monkeypatch.setitem(sys.modules, "geoagent.core.config", config_module)
+    monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models",
+        types.ModuleType("strands.models"),
+    )
+    monkeypatch.setitem(sys.modules, "strands.models.openai", openai_module)
+
+    module_path = (
+        Path(__file__).resolve().parents[2] / "geoagent" / "core" / "model.py"
+    )
+    spec = util.spec_from_file_location("_geoagent_model_under_test", module_path)
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module.resolve_model(_FakeConfig())
+
+    params = captured["kwargs"]["params"]
+    assert params["max_completion_tokens"] == 2048
+    assert "max_tokens" not in params
+    assert "temperature" not in params
+
+
+def test_provider_test_worker_uses_default_temperature_for_openai_gpt5(
+    monkeypatch,
+) -> None:
+    """Provider smoke tests should not send temperature=0 to GPT-5 models."""
+    import sys
+
+    captured = {}
+
+    class _FakeConfig:
+        def __init__(self, **kwargs):
+            captured["config"] = kwargs
+
+    def _resolve_model(config):
+        return "model"
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured["agent_kwargs"] = kwargs
+
+        def __call__(self, prompt):
+            captured["prompt"] = prompt
+            return "ok"
+
+    geoagent_module = types.ModuleType("geoagent")
+    geoagent_module.GeoAgentConfig = _FakeConfig
+    model_module = types.ModuleType("geoagent.core.model")
+    model_module.resolve_model = _resolve_model
+    strands_module = types.ModuleType("strands")
+    strands_module.Agent = _FakeAgent
+    monkeypatch.setitem(sys.modules, "geoagent", geoagent_module)
+    monkeypatch.setitem(sys.modules, "geoagent.core", types.ModuleType("geoagent.core"))
+    monkeypatch.setitem(sys.modules, "geoagent.core.model", model_module)
+    monkeypatch.setitem(sys.modules, "strands", strands_module)
+
+    worker = ProviderTestWorker("openai", "gpt-5.5", 1024, _FakeSettings({}))
+    emitted = {}
+    worker.finished.connect(lambda result: emitted.setdefault("result", result))
+
+    worker.run()
+
+    assert emitted["result"]["success"] is True
+    assert captured["config"]["temperature"] == 1
+    assert _model_requires_default_temperature("openai", "gpt-5.5") is True
+
+
+def test_litellm_openai_gpt5_omits_temperature(monkeypatch) -> None:
+    """LiteLLM OpenAI GPT-5 routes should not send unsupported temperature."""
+    import sys
+
+    captured = {}
+
+    class _FakeConfig:
+        provider = "litellm"
+        model = "openai/gpt-5.5"
+        temperature = 0
+        max_tokens = 2048
+        client_args = {}
+        litellm_base_url = None
+
+        def model_copy(self, update=None):
+            return self
+
+    class _FakeLiteLLMModel:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+    config_module = types.ModuleType("geoagent.core.config")
+    config_module.GeoAgentConfig = lambda **kwargs: _FakeConfig()
+    config_module.ProviderName = str
+    litellm_module = types.ModuleType("strands.models.litellm")
+    litellm_module.LiteLLMModel = _FakeLiteLLMModel
+
+    monkeypatch.setitem(sys.modules, "geoagent", types.ModuleType("geoagent"))
+    monkeypatch.setitem(sys.modules, "geoagent.core", types.ModuleType("geoagent.core"))
+    monkeypatch.setitem(sys.modules, "geoagent.core.config", config_module)
+    monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models",
+        types.ModuleType("strands.models"),
+    )
+    monkeypatch.setitem(sys.modules, "strands.models.litellm", litellm_module)
+
+    module_path = (
+        Path(__file__).resolve().parents[2] / "geoagent" / "core" / "model.py"
+    )
+    spec = util.spec_from_file_location(
+        "_geoagent_model_under_test_litellm", module_path
+    )
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module.resolve_model(_FakeConfig())
+
+    params = captured["kwargs"]["params"]
+    assert params == {"max_tokens": 2048}

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -1,0 +1,73 @@
+"""Tests for settings diagnostics and installer selection helpers."""
+
+from __future__ import annotations
+
+import types
+
+from open_geoagent.dialogs.settings_dock import SETTINGS_PREFIX, collect_diagnostics
+
+
+class _FakeSettings:
+    """Small QSettings stand-in for diagnostics tests."""
+
+    def __init__(self, values):
+        self.values = dict(values)
+
+    def value(self, key, default="", type=str):  # noqa: A002
+        value = self.values.get(key, default)
+        if type is bool:
+            return bool(value)
+        if type is int:
+            return int(value)
+        return value
+
+
+def test_collect_diagnostics_redacts_credentials(monkeypatch, tmp_path) -> None:
+    """Diagnostics expose credential presence only, never secret values."""
+    from open_geoagent import deps_manager, uv_manager
+
+    monkeypatch.setattr(deps_manager, "check_dependencies", lambda: [])
+    monkeypatch.setattr(deps_manager, "venv_exists", lambda: True)
+    monkeypatch.setattr(deps_manager, "get_venv_dir", lambda: "/tmp/venv")
+    monkeypatch.setattr(
+        deps_manager, "get_venv_site_packages", lambda: "/tmp/venv/site-packages"
+    )
+    monkeypatch.setattr(uv_manager, "get_uv_path", lambda: "/tmp/uv")
+    monkeypatch.setattr(uv_manager, "verify_uv", lambda: (True, "uv ok"))
+
+    settings = _FakeSettings(
+        {
+            f"{SETTINGS_PREFIX}provider": "openai",
+            f"{SETTINGS_PREFIX}model": "gpt-test",
+            f"{SETTINGS_PREFIX}openai_api_key": "sk-secret",
+        }
+    )
+    (tmp_path / "metadata.txt").write_text("version=1.2.3\n", encoding="utf-8")
+
+    diagnostics = collect_diagnostics(settings, str(tmp_path))
+    text = str(diagnostics)
+
+    assert diagnostics["credential_presence"]["openai_api_key"]["saved"] is True
+    assert diagnostics["model"]["provider"] == "openai"
+    assert "sk-secret" not in text
+
+
+def test_uv_usable_requires_successful_verification(monkeypatch) -> None:
+    """A stale uv file should not be treated as usable."""
+    from open_geoagent import deps_manager
+
+    monkeypatch.setattr(
+        deps_manager,
+        "uv_manager",
+        types.SimpleNamespace(uv_exists=lambda: True, verify_uv=lambda: (False, "bad")),
+        raising=False,
+    )
+
+    # Patch the relative import target through sys.modules by monkeypatching the
+    # imported module functions directly.
+    import open_geoagent.uv_manager as uv_manager
+
+    monkeypatch.setattr(uv_manager, "uv_exists", lambda: True)
+    monkeypatch.setattr(uv_manager, "verify_uv", lambda: (False, "bad"))
+
+    assert deps_manager._uv_usable() is False

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -43,3 +43,12 @@ def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
 
     assert deps_manager.all_dependencies_met() is True
     assert checked == ["geoagent", "openai"]
+
+
+def test_required_dependencies_include_core_runtime_packages() -> None:
+    """Dependency gate should catch partial GeoAgent installs."""
+    from open_geoagent.deps_manager import REQUIRED_PACKAGES
+
+    assert ("geoagent", "GeoAgent[providers]>=1.2.0") in REQUIRED_PACKAGES
+    assert ("strands", "strands-agents>=1.37") in REQUIRED_PACKAGES
+    assert ("pydantic", "pydantic>=2.0") in REQUIRED_PACKAGES

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -8,6 +8,33 @@ import types
 from typing import Any
 
 
+def _install_fake_geoagent(monkeypatch, captured):
+    """Install a fake geoagent module for plugin worker wiring tests."""
+
+    class _GeoAgentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def _factory(name):
+        def _stub_factory(iface, **kwargs):
+            captured["factory"] = name
+            captured["iface"] = iface
+            captured["kwargs"] = kwargs
+            return captured["agent"]
+
+        return _stub_factory
+
+    module = types.ModuleType("geoagent")
+    module.GeoAgentConfig = _GeoAgentConfig
+    module.for_qgis = _factory("for_qgis")
+    module.for_whitebox = _factory("for_whitebox")
+    module.for_nasa_earthdata = _factory("for_nasa_earthdata")
+    module.for_nasa_opera = _factory("for_nasa_opera")
+    module.for_gee_data_catalogs = _factory("for_gee_data_catalogs")
+    monkeypatch.setitem(sys.modules, "geoagent", module)
+    return module
+
+
 def test_dependencies_include_whitebox() -> None:
     """Verify the plugin dependency installer checks Whitebox."""
     from open_geoagent.deps_manager import REQUIRED_PACKAGES
@@ -22,7 +49,6 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
     and ``ChatWorker.run`` is invoked synchronously so a refactor that
     silently swaps the factory will fail this test.
     """
-    import geoagent
     from open_geoagent.dialogs.chat_dock import ChatWorker, SAMPLE_PROMPTS
 
     captured: dict[str, Any] = {}
@@ -41,12 +67,8 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
             captured["prompt"] = prompt
             return _StubResponse()
 
-    def _stub_factory(iface, **kwargs):
-        captured["iface"] = iface
-        captured["kwargs"] = kwargs
-        return _StubAgent()
-
-    monkeypatch.setattr(geoagent, "for_whitebox", _stub_factory)
+    captured["agent"] = _StubAgent()
+    _install_fake_geoagent(monkeypatch, captured)
 
     # Avoid pulling QgsProject (the qgis stub returns None for instance()).
     monkeypatch.setitem(
@@ -64,6 +86,8 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
         fast=False,
         max_tokens=1024,
         auto_approve_tools=True,
+        agent_mode="WhiteboxTools",
+        permission_profile="Run processing",
     )
 
     emitted: dict[str, Any] = {}
@@ -72,8 +96,10 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
     worker.run()
 
     assert captured.get("iface") is sentinel_iface
+    assert captured["factory"] == "for_whitebox"
     assert captured["prompt"] == "hello"
     assert captured["kwargs"]["fast"] is False
+    assert captured["kwargs"]["permission_profile"] == "Run processing"
     assert "confirm" in captured["kwargs"]
     assert captured["kwargs"]["confirm"](types.SimpleNamespace(args={})) is True
     assert emitted["payload"]["success"] is True
@@ -82,7 +108,6 @@ def test_chat_worker_uses_whitebox_factory(monkeypatch) -> None:
 
 def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
     """ChatWorker.run streams deltas through chunk_received when enabled."""
-    import geoagent
     from open_geoagent.dialogs.chat_dock import ChatWorker
 
     captured: dict[str, Any] = {}
@@ -94,12 +119,8 @@ def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
             await asyncio.sleep(0)
             yield {"data": "llo"}
 
-    def _stub_factory(iface, **kwargs):
-        captured["iface"] = iface
-        captured["kwargs"] = kwargs
-        return _StubAgent()
-
-    monkeypatch.setattr(geoagent, "for_whitebox", _stub_factory)
+    captured["agent"] = _StubAgent()
+    _install_fake_geoagent(monkeypatch, captured)
     monkeypatch.setitem(
         sys.modules,
         "qgis.core",
@@ -116,6 +137,7 @@ def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
         max_tokens=1024,
         auto_approve_tools=True,
         stream=True,
+        agent_mode="WhiteboxTools",
     )
 
     chunks: list[str] = []
@@ -126,9 +148,56 @@ def test_chat_worker_streams_when_enabled(monkeypatch) -> None:
     worker.run()
 
     assert captured.get("iface") is sentinel_iface
+    assert captured["factory"] == "for_whitebox"
     assert captured["prompt"] == "stream please"
     assert captured["kwargs"]["fast"] is True
     assert chunks == ["he", "llo"]
     assert emitted["payload"]["success"] is True
     assert emitted["payload"]["answer"] == "hello"
     assert emitted["payload"]["streamed"] is True
+
+
+def test_chat_worker_routes_agent_modes(monkeypatch) -> None:
+    """ChatWorker selects the requested GeoAgent factory."""
+    from open_geoagent.dialogs.chat_dock import ChatWorker
+
+    captured: dict[str, Any] = {}
+
+    class _StubResponse:
+        success = True
+        answer_text = "ok"
+        error_message = ""
+        executed_tools: list = []
+        tool_calls: list = []
+        cancelled_tools: list = []
+        execution_time = 0.0
+
+    class _StubAgent:
+        def chat(self, prompt: str) -> _StubResponse:
+            captured["prompt"] = prompt
+            return _StubResponse()
+
+    captured["agent"] = _StubAgent()
+    _install_fake_geoagent(monkeypatch, captured)
+    monkeypatch.setitem(
+        sys.modules,
+        "qgis.core",
+        types.SimpleNamespace(QgsProject=types.SimpleNamespace(instance=lambda: None)),
+    )
+
+    worker = ChatWorker(
+        iface=object(),
+        prompt="hello",
+        provider="anthropic",
+        model_id="claude-x",
+        fast=False,
+        max_tokens=1024,
+        auto_approve_tools=True,
+        agent_mode="NASA OPERA",
+        permission_profile="Inspect only",
+    )
+    worker.finished.connect(lambda _payload: None)
+    worker.run()
+
+    assert captured["factory"] == "for_nasa_opera"
+    assert captured["kwargs"]["permission_profile"] == "Inspect only"


### PR DESCRIPTION
## Summary
- Add agent mode selector (General QGIS, WhiteboxTools, NASA Earthdata, NASA OPERA, GEE Data Catalogs, STAC) and route the chat worker to the matching factory.
- Add a permission profile selector that defaults to inspect-only access; thread `permission_profile` through `for_qgis`, `for_whitebox`, `for_nasa_earthdata`, `for_nasa_opera`, and `for_gee_data_catalogs` to filter destructive, long-running, and PyQGIS execution tools.
- Add per-project chat history with Markdown import/export, a compact jobs panel with rerun support, provider smoke tests, and redacted JSON diagnostics in the Settings dock.

## Test plan
- [ ] `pre-commit run --all-files`
- [ ] `pytest qgis_geoagent/tests/test_chat_tool_inputs.py qgis_geoagent/tests/test_pyqt6_imports.py qgis_geoagent/tests/test_startup_performance.py qgis_geoagent/tests/test_whitebox_integration.py qgis_geoagent/tests/test_settings_diagnostics.py -q`
- [ ] Manual: load the plugin in QGIS, switch agent modes and permission profiles, confirm inspect-only blocks `run_pyqgis_script`, and verify Test Provider plus Save/Copy Diagnostics in the Settings dock.