### PR TITLE
feat: image generation tool and inline image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,10 @@ Key plugin features:
   that support vision inputs;
 - screenshot capture from the map canvas, selected map regions, the QGIS
   window, and selected screen regions;
-- image preview and save/export actions;
+- image preview and save/export actions, plus inline rendering of image outputs
+  returned by multimodal models;
+- direct image generation with the `generate_image` tool when `OPENAI_API_KEY`
+  is configured;
 - copy Markdown transcript and copy executed PyQGIS script actions;
 - confirmation-gated `run_pyqgis_script` fallback when a task needs QGIS API
   operations that are not covered by a dedicated tool;

--- a/docs/qgis-plugin.md
+++ b/docs/qgis-plugin.md
@@ -68,6 +68,21 @@ Screenshot options include:
 Attached images appear as thumbnails in the chat. Click an image to open a
 larger preview, then use the save action or context menu to export it.
 
+When a multimodal model returns image content blocks, OpenGeoAgent writes those
+image artifacts to a local temporary output directory, renders them inline in
+the chat transcript, and includes Markdown image references when copying or
+exporting the conversation.
+
+OpenGeoAgent also exposes a `generate_image` tool for direct image creation
+requests such as "generate a cat image." This tool uses the OpenAI Images API
+and requires `OPENAI_API_KEY`; ChatGPT/Codex OAuth alone is not enough for this
+API call. The default image model is `gpt-image-2`; choose another image model
+in Settings > Model > Image Generation when needed. Generated files are saved
+locally and rendered inline in the chat.
+If verified image-model access belongs to a specific OpenAI organization or
+project, set the optional OpenAI org/project IDs in the plugin settings so the
+Images API request uses that verified context.
+
 ## PyQGIS Fallback
 
 When a request needs QGIS API functionality that is not covered by a dedicated

--- a/docs/result.md
+++ b/docs/result.md
@@ -1,5 +1,10 @@
 # Response
 
-`GeoAgentResponse` is the dataclass returned by `GeoAgent.chat`. It preserves the v0.x field names (`plan`, `data`, `analysis`, `map`, `code`, `answer_text`, `success`, `error_message`, `execution_time`) and adds `executed_tools`, `cancelled_tools`, and the raw `messages` list for advanced inspection.
+`GeoAgentResponse` is the dataclass returned by `GeoAgent.chat`. It includes
+`answer_text`, `success`, `error_message`, `execution_time`, tool execution
+metadata, raw provider result access, and multimodal response artifacts. Image
+content blocks returned by supported models are exposed through `images`, while
+the original top-level assistant content blocks are available as
+`content_blocks`.
 
 ::: geoagent.core.result

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import queue
+import re
 import threading
 import time
 from typing import Any, AsyncIterator, Optional
@@ -20,16 +23,237 @@ from geoagent.core.result import GeoAgentResponse
 from geoagent.core.safety import ConfirmCallback, auto_approve_safe_only
 from geoagent.tools._qt_marshal import is_qt_gui_thread, process_qt_events
 
+_IMAGE_MIME_BY_FORMAT = {
+    "gif": "image/gif",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+}
+_IMAGE_FORMAT_BY_MIME = {value: key for key, value in _IMAGE_MIME_BY_FORMAT.items()}
+_IMAGE_FORMAT_BY_MIME["image/jpeg"] = "jpg"
+_IMAGE_PATH_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif")
+
+
+def _result_content_blocks(result: Any) -> list[dict[str, Any]]:
+    """Return top-level assistant content blocks from a Strands result."""
+    msg = getattr(result, "message", None)
+    if not isinstance(msg, dict):
+        return []
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return []
+    return [block for block in content if isinstance(block, dict)]
+
+
+def _image_format_from_mime(mime_type: str | None) -> str:
+    """Return a compact image format name for a MIME type."""
+    return _IMAGE_FORMAT_BY_MIME.get(str(mime_type or "").lower(), "png")
+
+
+def _image_mime_from_format(format_name: str | None) -> str:
+    """Return a MIME type for a compact image format name."""
+    cleaned = str(format_name or "").lower().lstrip(".")
+    if "/" in cleaned:
+        return cleaned
+    return _IMAGE_MIME_BY_FORMAT.get(cleaned, "image/png")
+
+
+def _data_uri_parts(value: str) -> tuple[str, str] | None:
+    """Return MIME type and base64 payload for an image data URI."""
+    match = re.match(r"^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", value, re.S)
+    if not match:
+        return None
+    return match.group(1).lower(), match.group(2)
+
+
+def _decode_image_bytes(value: Any) -> tuple[bytes | None, str | None]:
+    """Decode bytes or base64 image payloads into raw image bytes."""
+    if isinstance(value, bytes):
+        return value, None
+    if isinstance(value, bytearray):
+        return bytes(value), None
+    if not isinstance(value, str):
+        return None, None
+    text = value.strip()
+    if not text:
+        return None, None
+    data_uri = _data_uri_parts(text)
+    if data_uri is not None:
+        mime_type, payload = data_uri
+    else:
+        mime_type, payload = None, re.sub(r"\s+", "", text)
+    try:
+        return base64.b64decode(payload, validate=True), mime_type
+    except (binascii.Error, ValueError):
+        return None, mime_type
+
+
+def _image_artifact_from_block(block: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract one image artifact from a common provider content block."""
+    image = block.get("image")
+    if not isinstance(image, dict) and block.get("type") in {
+        "image",
+        "output_image",
+        "input_image",
+    }:
+        image = block
+
+    if isinstance(image, dict):
+        source = image.get("source") if isinstance(image.get("source"), dict) else {}
+        mime_type = (
+            image.get("mime_type")
+            or image.get("media_type")
+            or source.get("mime_type")
+            or source.get("media_type")
+        )
+        format_name = image.get("format") or source.get("format")
+        raw = (
+            source.get("bytes")
+            or source.get("data")
+            or source.get("base64")
+            or image.get("bytes")
+            or image.get("data")
+            or image.get("base64")
+        )
+        image_bytes, data_mime_type = _decode_image_bytes(raw)
+        mime_type = data_mime_type or mime_type or _image_mime_from_format(format_name)
+        artifact = {
+            "format": str(format_name or _image_format_from_mime(mime_type)),
+            "mime_type": str(mime_type),
+        }
+        path = source.get("path") or image.get("path")
+        if isinstance(path, str) and path.strip():
+            artifact["path"] = path.strip()
+        if image_bytes:
+            artifact["bytes"] = image_bytes
+        url = source.get("url") or image.get("url") or image.get("image_url")
+        if isinstance(url, dict):
+            url = url.get("url")
+        if isinstance(url, str) and url.strip():
+            artifact["url"] = url.strip()
+        return (
+            artifact
+            if artifact.get("bytes") or artifact.get("url") or artifact.get("path")
+            else None
+        )
+
+    raw_url = block.get("image_url")
+    if isinstance(raw_url, dict):
+        raw_url = raw_url.get("url")
+    if isinstance(raw_url, str) and raw_url.strip():
+        text = raw_url.strip()
+        data_uri = _data_uri_parts(text)
+        if data_uri is not None:
+            image_bytes, mime_type = _decode_image_bytes(text)
+            if image_bytes:
+                return {
+                    "format": _image_format_from_mime(mime_type),
+                    "mime_type": mime_type or "image/png",
+                    "bytes": image_bytes,
+                }
+        return {"format": "url", "mime_type": "", "url": text}
+
+    if block.get("type") == "image_generation_call":
+        image_bytes, mime_type = _decode_image_bytes(block.get("result"))
+        if image_bytes:
+            return {
+                "format": _image_format_from_mime(mime_type),
+                "mime_type": mime_type or "image/png",
+                "bytes": image_bytes,
+            }
+
+    return None
+
+
+def _images_from_mapping(value: Any) -> list[dict[str, Any]]:
+    """Extract image artifacts from nested JSON-like tool results."""
+    if not isinstance(value, dict):
+        return []
+
+    images: list[dict[str, Any]] = []
+    nested = value.get("images")
+    if isinstance(nested, list):
+        for item in nested:
+            if isinstance(item, dict):
+                artifact = _image_artifact_from_block({"image": item})
+                if artifact is not None:
+                    images.append(artifact)
+    if images:
+        return images
+
+    artifact = _image_artifact_from_block({"image": value})
+    if artifact is not None:
+        images.append(artifact)
+
+    return images
+
+
+def _dedupe_images(images: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return images with duplicate path/url/bytes references removed."""
+    deduped: list[dict[str, Any]] = []
+    seen: set[Any] = set()
+    for image in images:
+        key = image.get("path") or image.get("url") or image.get("bytes")
+        if key is None:
+            key = tuple(sorted((k, str(v)) for k, v in image.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(image)
+    return deduped
+
+
+def _image_artifacts_from_value(value: Any) -> list[dict[str, Any]]:
+    """Recursively extract image artifacts from JSON-like values."""
+    if isinstance(value, dict):
+        images = _images_from_mapping(value)
+        for key, nested in value.items():
+            if key in {"bytes", "data", "base64", "b64_json"}:
+                continue
+            images.extend(_image_artifacts_from_value(nested))
+        return _dedupe_images(images)
+    if isinstance(value, (list, tuple)):
+        images: list[dict[str, Any]] = []
+        for item in value:
+            images.extend(_image_artifacts_from_value(item))
+        return _dedupe_images(images)
+    if isinstance(value, str):
+        text = value.strip()
+        if text.lower().endswith(_IMAGE_PATH_SUFFIXES):
+            return [{"format": text.rsplit(".", 1)[-1].lower(), "path": text}]
+    return []
+
+
+def _tool_calls_to_images(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract image artifacts returned by tool calls."""
+    images: list[dict[str, Any]] = []
+    for call in tool_calls or []:
+        if not isinstance(call, dict):
+            continue
+        images.extend(_image_artifacts_from_value(call.get("result")))
+    return _dedupe_images(images)
+
+
+def _result_to_images(result: Any) -> list[dict[str, Any]]:
+    """Extract image artifacts from a Strands result object."""
+    images: list[dict[str, Any]] = []
+    for block in _result_content_blocks(result):
+        artifact = _image_artifact_from_block(block)
+        if artifact is not None:
+            images.append(artifact)
+    return images
+
 
 def _result_to_text(result: Any) -> str:
     """Extract response text from a Strands result object."""
     if result is None:
         return ""
-    msg = getattr(result, "message", None)
-    if msg and isinstance(msg, dict):
+    blocks = _result_content_blocks(result)
+    if blocks:
         parts: list[str] = []
-        for block in msg.get("content", []):
-            if isinstance(block, dict) and "text" in block:
+        for block in blocks:
+            if "text" in block:
                 parts.append(str(block["text"]))
         extracted = "\n".join(parts).strip()
         if extracted:
@@ -236,6 +460,8 @@ class GeoAgent:
             elapsed = time.time() - t0
             exec_names = list(getattr(result.metrics, "tool_metrics", {}).keys())
             answer = _result_to_text(result)
+            content_blocks = _result_content_blocks(result)
+            images = _result_to_images(result) + _tool_calls_to_images(self._tool_calls)
             stop = str(getattr(result, "stop_reason", "end_turn"))
             success = stop not in ("cancelled", "guardrail_intervened")
             err = None if success else f"stop_reason={stop}"
@@ -244,6 +470,8 @@ class GeoAgent:
                 success=success,
                 error_message=err,
                 execution_time=elapsed,
+                content_blocks=content_blocks,
+                images=images,
                 executed_tools=exec_names,
                 tool_calls=list(self._tool_calls),
                 cancelled_tools=list(self._cancelled),

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -15,6 +15,7 @@ from geoagent.core.safety import ConfirmCallback
 from geoagent.core.agent import GeoAgent
 from geoagent.tools.anymap import anymap_tools
 from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
+from geoagent.tools.images import image_generation_tools
 from geoagent.tools.leafmap import leafmap_tools
 from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
@@ -138,6 +139,11 @@ Workflow guidance:
   project/canvas changes, write a short PyQGIS script and run it with
   run_pyqgis_script. Do not merely provide a script for the user to paste when
   run_pyqgis_script can safely perform the requested QGIS change.
+- When the user asks to create, draw, render, or generate an image or picture,
+  or provides a standalone visual description after discussing image
+  generation, call generate_image if it is available. Do not reply with only a
+  prompt for another image generator unless the tool reports that image
+  generation is not configured.
 - Keep responses concise and include the tool name, output path, and loaded
   layer names when available.
 """
@@ -253,6 +259,7 @@ def assemble_tools(
     include_nasa_opera: bool = False,
     include_gee_data_catalogs: bool = False,
     include_whitebox: bool = False,
+    include_image_generation: bool = False,
     nasa_earthdata_plugin: Any | None = None,
     gee_data_catalogs_plugin: Any | None = None,
     fast: bool = False,
@@ -304,6 +311,10 @@ def assemble_tools(
         )
         register_all_tools(registry, whitebox_tool_list)
         collected.extend(whitebox_tool_list)
+    if include_image_generation:
+        image_tools = _filter_by_imports(image_generation_tools())
+        register_all_tools(registry, image_tools)
+        collected.extend(image_tools)
     if extra_tools:
         register_all_tools(registry, extra_tools)
         collected.extend(extra_tools)
@@ -363,6 +374,7 @@ def for_leafmap(
     tools, registry = assemble_tools(
         context=ctx,
         include_leafmap=True,
+        include_image_generation=True,
         extra_tools=extra_tools,
         fast=fast,
     )
@@ -400,6 +412,7 @@ def for_anymap(
     tools, registry = assemble_tools(
         context=ctx,
         include_anymap=True,
+        include_image_generation=True,
         extra_tools=extra_tools,
         fast=fast,
     )
@@ -443,6 +456,7 @@ def for_qgis(
     tools, registry = assemble_tools(
         context=ctx,
         include_qgis=True,
+        include_image_generation=True,
         extra_tools=extra_tools,
         fast=fast,
         permission_profile=permission_profile,
@@ -497,6 +511,7 @@ def for_nasa_opera(
         context=ctx,
         include_qgis=include_qgis,
         include_nasa_opera=True,
+        include_image_generation=True,
         extra_tools=extra_tools,
         fast=fast,
         permission_profile=permission_profile,
@@ -552,6 +567,7 @@ def for_nasa_earthdata(
         context=ctx,
         include_qgis=include_qgis,
         include_nasa_earthdata=True,
+        include_image_generation=True,
         nasa_earthdata_plugin=plugin,
         extra_tools=extra_tools,
         fast=fast,
@@ -608,6 +624,7 @@ def for_gee_data_catalogs(
         context=ctx,
         include_qgis=include_qgis,
         include_gee_data_catalogs=True,
+        include_image_generation=True,
         gee_data_catalogs_plugin=plugin,
         extra_tools=extra_tools,
         fast=fast,
@@ -663,6 +680,7 @@ def for_whitebox(
         context=ctx,
         include_qgis=include_qgis,
         include_whitebox=True,
+        include_image_generation=True,
         extra_tools=extra_tools,
         fast=fast,
         permission_profile=permission_profile,

--- a/geoagent/core/prompts.py
+++ b/geoagent/core/prompts.py
@@ -1,6 +1,6 @@
 """Short system prompts for low-latency tool use."""
 
 DEFAULT_SYSTEM_PROMPT = """You are GeoAgent, a geospatial assistant. Use tools for map and GIS actions.
-Prefer calling the right tool immediately when the user's intent is clear. Use set_layer_symbology for QGIS layer color, fill, outline, opacity, and line-width changes. Keep replies concise."""
+Prefer calling the right tool immediately when the user's intent is clear. Use set_layer_symbology for QGIS layer color, fill, outline, opacity, and line-width changes. If the user asks to create, draw, render, or generate an image or picture, or provides a standalone visual description after discussing image generation, call generate_image when that tool is available; do not say you cannot generate images before trying the tool. Keep replies concise."""
 
-FAST_SYSTEM_PROMPT = """You are GeoAgent (fast mode). Call the best tool immediately for map commands, including set_layer_symbology for layer styling. After tool use, reply in one short sentence. Do not summarize, explain, or plan unless the user asks."""
+FAST_SYSTEM_PROMPT = """You are GeoAgent (fast mode). Call the best tool immediately for map commands, including set_layer_symbology for layer styling and generate_image for image creation requests when available. After tool use, reply in one short sentence. Do not summarize, explain, or plan unless the user asks."""

--- a/geoagent/core/result.py
+++ b/geoagent/core/result.py
@@ -17,6 +17,8 @@ class GeoAgentResponse:
     success: bool = True
     error_message: Optional[str] = None
     execution_time: float = 0.0
+    content_blocks: list[dict[str, Any]] = field(default_factory=list)
+    images: list[dict[str, Any]] = field(default_factory=list)
     executed_tools: list[str] = field(default_factory=list)
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     cancelled_tools: list[str] = field(default_factory=list)

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from geoagent.tools.anymap import anymap_tools
 from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
+from geoagent.tools.images import image_generation_tools
 from geoagent.tools.leafmap import leafmap_tools
 from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
@@ -12,6 +13,7 @@ __all__ = [
     "anymap_tools",
     "earthdata_tools",
     "gee_data_catalogs_tools",
+    "image_generation_tools",
     "leafmap_tools",
     "nasa_opera_tools",
     "qgis_tools",

--- a/geoagent/tools/images.py
+++ b/geoagent/tools/images.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import os
 import tempfile
 import time
@@ -177,12 +178,17 @@ def image_generation_tools() -> list[Any]:
 
         out_dir = _output_dir(output_dir or None)
         images: list[dict[str, Any]] = []
+        decode_errors: list[str] = []
         for index, item in enumerate(_response_data_items(response), start=1):
             b64_json = _item_value(item, "b64_json")
             url = _item_value(item, "url")
             revised_prompt = _item_value(item, "revised_prompt")
             if b64_json:
-                image_bytes = base64.b64decode(str(b64_json))
+                try:
+                    image_bytes = base64.b64decode(str(b64_json), validate=True)
+                except (binascii.Error, ValueError) as exc:
+                    decode_errors.append(f"item {index}: {exc}")
+                    continue
                 stem = _safe_image_stem(prompt)
                 suffix = time.strftime("%Y%m%d-%H%M%S")
                 path = out_dir / f"{stem}-{suffix}-{index}.png"
@@ -207,9 +213,16 @@ def image_generation_tools() -> list[Any]:
                 )
 
         if not images:
+            error_message = "The image API response did not include an image."
+            if decode_errors:
+                error_message = (
+                    "The image API returned invalid base64 payload(s): "
+                    + "; ".join(decode_errors)
+                )
             return {
                 "success": False,
-                "error": "The image API response did not include an image.",
+                "error": error_message,
+                "model": model,
             }
 
         return {

--- a/geoagent/tools/images.py
+++ b/geoagent/tools/images.py
@@ -1,0 +1,232 @@
+"""Image generation tools for GeoAgent."""
+
+from __future__ import annotations
+
+import base64
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from geoagent.core.decorators import geo_tool
+
+DEFAULT_IMAGE_MODEL = "gpt-image-2"
+FALLBACK_IMAGE_MODEL = "gpt-image-1"
+DEFAULT_IMAGE_SIZE = "1024x1024"
+DEFAULT_IMAGE_QUALITY = "low"
+SUPPORTED_IMAGE_SIZES = {"1024x1024", "1024x1536", "1536x1024", "auto"}
+SUPPORTED_IMAGE_QUALITIES = {"low", "medium", "high", "auto"}
+
+
+def _output_dir(output_dir: str | None = None) -> Path:
+    """Return the directory used for generated image files."""
+    path = Path(
+        output_dir or os.environ.get("GEOAGENT_IMAGE_OUTPUT_DIR", "")
+    ).expanduser()
+    if not str(path).strip() or str(path) == ".":
+        path = Path(tempfile.gettempdir()) / "geoagent_images"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _safe_image_stem(value: str | None = None) -> str:
+    """Return a compact filesystem-safe image filename stem."""
+    text = "".join(ch if ch.isalnum() else "_" for ch in str(value or "").lower())
+    text = "_".join(part for part in text.split("_") if part)
+    if not text:
+        text = "geoagent_image"
+    return text[:60]
+
+
+def _response_data_items(response: Any) -> list[Any]:
+    """Return image data items from an OpenAI response object or dict."""
+    if isinstance(response, dict):
+        data = response.get("data", [])
+    else:
+        data = getattr(response, "data", [])
+    return list(data or [])
+
+
+def _item_value(item: Any, key: str) -> Any:
+    """Read a field from a response item object or dict."""
+    if isinstance(item, dict):
+        return item.get(key)
+    return getattr(item, key, None)
+
+
+def _is_image_model_permission_error(exc: Exception) -> bool:
+    """Return True when an OpenAI image model is unavailable for the org."""
+    text = f"{type(exc).__name__}: {exc}".lower()
+    return any(
+        marker in text
+        for marker in (
+            "permissiondenied",
+            "permission denied",
+            "not verified",
+            "organization is not verified",
+            "403",
+        )
+    )
+
+
+def _generate_openai_image(
+    client: Any,
+    *,
+    model: str,
+    prompt: str,
+    size: str,
+    quality: str,
+) -> Any:
+    """Call the OpenAI image generation endpoint."""
+    return client.images.generate(
+        model=model,
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        n=1,
+    )
+
+
+def image_generation_tools() -> list[Any]:
+    """Return tools for generating standalone image files."""
+
+    @geo_tool(
+        category="image_generation",
+        description=(
+            "Generate an image from a text prompt using the OpenAI Images API. "
+            "Use this when the user asks to create, draw, render, or generate "
+            "a picture."
+        ),
+        available_in=("full", "fast"),
+        requires_packages=("openai",),
+    )
+    def generate_image(
+        prompt: str,
+        size: str = DEFAULT_IMAGE_SIZE,
+        quality: str = DEFAULT_IMAGE_QUALITY,
+        model: str = DEFAULT_IMAGE_MODEL,
+        output_dir: str = "",
+    ) -> dict[str, Any]:
+        """Generate an image file from a text prompt.
+
+        Args:
+            prompt: Visual description of the image to generate.
+            size: One of 1024x1024, 1024x1536, 1536x1024, or auto.
+            quality: One of low, medium, high, or auto.
+            model: OpenAI image model to use. Defaults to gpt-image-2.
+            output_dir: Optional directory for the generated image.
+
+        Returns:
+            A JSON-friendly result containing local image file paths and image
+            metadata. The host UI can render the returned ``images`` list.
+        """
+        prompt = str(prompt or "").strip()
+        if not prompt:
+            return {"success": False, "error": "Image prompt is empty."}
+        if not os.environ.get("OPENAI_API_KEY"):
+            return {
+                "success": False,
+                "error": (
+                    "OPENAI_API_KEY is required for image generation. Add an "
+                    "OpenAI API key in OpenGeoAgent Settings > Model or set "
+                    "OPENAI_API_KEY."
+                ),
+            }
+
+        size = str(size or DEFAULT_IMAGE_SIZE).strip()
+        if size not in SUPPORTED_IMAGE_SIZES:
+            size = DEFAULT_IMAGE_SIZE
+        quality = str(quality or DEFAULT_IMAGE_QUALITY).strip()
+        if quality not in SUPPORTED_IMAGE_QUALITIES:
+            quality = DEFAULT_IMAGE_QUALITY
+        requested_model = (
+            str(model or DEFAULT_IMAGE_MODEL).strip() or DEFAULT_IMAGE_MODEL
+        )
+        model = requested_model
+
+        from openai import OpenAI
+
+        client = OpenAI()
+        fallback_reason = ""
+        try:
+            response = _generate_openai_image(
+                client,
+                model=model,
+                prompt=prompt,
+                size=size,
+                quality=quality,
+            )
+        except Exception as exc:
+            if model != FALLBACK_IMAGE_MODEL and _is_image_model_permission_error(exc):
+                fallback_reason = str(exc)
+                model = FALLBACK_IMAGE_MODEL
+                response = _generate_openai_image(
+                    client,
+                    model=model,
+                    prompt=prompt,
+                    size=size,
+                    quality=quality,
+                )
+            else:
+                return {
+                    "success": False,
+                    "error": f"Image generation failed with {model}: {exc}",
+                    "model": model,
+                }
+
+        out_dir = _output_dir(output_dir or None)
+        images: list[dict[str, Any]] = []
+        for index, item in enumerate(_response_data_items(response), start=1):
+            b64_json = _item_value(item, "b64_json")
+            url = _item_value(item, "url")
+            revised_prompt = _item_value(item, "revised_prompt")
+            if b64_json:
+                image_bytes = base64.b64decode(str(b64_json))
+                stem = _safe_image_stem(prompt)
+                suffix = time.strftime("%Y%m%d-%H%M%S")
+                path = out_dir / f"{stem}-{suffix}-{index}.png"
+                with open(path, "wb") as f:
+                    f.write(image_bytes)
+                images.append(
+                    {
+                        "path": str(path),
+                        "format": "png",
+                        "mime_type": "image/png",
+                        "revised_prompt": revised_prompt or "",
+                    }
+                )
+            elif url:
+                images.append(
+                    {
+                        "url": str(url),
+                        "format": "url",
+                        "mime_type": "",
+                        "revised_prompt": revised_prompt or "",
+                    }
+                )
+
+        if not images:
+            return {
+                "success": False,
+                "error": "The image API response did not include an image.",
+            }
+
+        return {
+            "success": True,
+            "prompt": prompt,
+            "model": model,
+            "requested_model": requested_model,
+            "size": size,
+            "quality": quality,
+            "images": images,
+            "path": images[0].get("path", ""),
+            "url": images[0].get("url", ""),
+            "message": f"Generated {len(images)} image(s).",
+            "fallback_reason": fallback_reason,
+        }
+
+    return [generate_image]
+
+
+__all__ = ["image_generation_tools"]

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -88,6 +88,8 @@ provider and model. API keys and host settings are stored in QGIS settings and
 applied to the current QGIS process before each chat request:
 
 - OpenAI: `OPENAI_API_KEY`
+- OpenAI organization/project targeting: optional `OPENAI_ORG_ID` and
+  `OPENAI_PROJECT_ID`
 - Voice transcription: `OPENAI_API_KEY` is required even when the chat provider
   is set to ChatGPT/Codex OAuth. Voice input sends recorded audio to the OpenAI
   transcription API and may incur API costs. If no key is configured, recording
@@ -95,6 +97,11 @@ applied to the current QGIS process before each chat request:
   model in **Settings > Model > Voice Transcription**. The default is
   `gpt-4o-mini-transcribe`; `OPENAI_TRANSCRIPTION_MODEL` is used as a fallback
   when no QGIS setting has been saved.
+- Image generation: `OPENAI_API_KEY` is required for direct requests such as
+  "generate a cat image." ChatGPT/Codex OAuth can still power chat, but the
+  `generate_image` tool calls the OpenAI Images API. The default image model
+  is `gpt-image-2`; choose `gpt-image-1` in Settings > Model > Image
+  Generation when you want the lower-cost fallback model.
 - ChatGPT/Codex OAuth: choose `openai-codex` and click **Login with ChatGPT**
   in the Model tab. Headless use can set `OPENAI_CODEX_ACCESS_TOKEN`.
 - Anthropic: `ANTHROPIC_API_KEY`

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -1,6 +1,7 @@
 """Dockable OpenGeoAgent chat interface."""
 
 import asyncio
+import base64
 import hashlib
 import os
 import html
@@ -12,6 +13,7 @@ import tempfile
 import time
 import traceback
 import wave
+from pathlib import Path
 
 from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtCore import (
@@ -60,7 +62,7 @@ from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QTableWidget,
     QTableWidgetItem,
-    QTextEdit,
+    QTextBrowser,
     QVBoxLayout,
     QWidget,
 )
@@ -90,9 +92,20 @@ MAX_CONTEXT_CHARS = 12000
 MAX_IMAGE_ATTACHMENTS = 4
 MAX_IMAGE_EDGE = 1568
 IMAGE_THUMBNAIL_SIZE = 72
+MAX_OUTPUT_IMAGE_DISPLAY_EDGE = 480
+OUTPUT_IMAGE_THUMBNAIL_EDGE = 180
+OUTPUT_IMAGE_PATH_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z]:[\\/]|/|~/?)[^\s`'\"<>]+\.(?:png|jpe?g|webp|gif))",
+    re.IGNORECASE,
+)
 DEFAULT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe"
 DEFAULT_VOICE_SHORTCUT = "Ctrl+Alt+Space"
 VOICE_SHORTCUT_SETTING = "voice_shortcut_v2"
+DEFAULT_IMAGE_MODEL = "gpt-image-2"
+IMAGE_MODELS = [
+    "gpt-image-2",
+    "gpt-image-1",
+]
 TRANSCRIPTION_MODELS = [
     "gpt-4o-mini-transcribe",
     "gpt-4o-transcribe",
@@ -334,6 +347,9 @@ def _apply_environment_from_settings(settings):
     # heuristics on lines that contain "api_key" / "API_KEY".
     env_map = {
         "openai_api_key": "OPENAI_API_KEY",  # pragma: allowlist secret
+        "openai_org_id": "OPENAI_ORG_ID",
+        "openai_project_id": "OPENAI_PROJECT_ID",
+        "image_model": "GEOAGENT_IMAGE_MODEL",
         "anthropic_api_key": "ANTHROPIC_API_KEY",  # pragma: allowlist secret
         "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
         "aws_region": "AWS_REGION",
@@ -357,6 +373,15 @@ def _transcription_model_from_settings(settings):
         return saved
     env_model = os.environ.get("OPENAI_TRANSCRIPTION_MODEL", "").strip()
     return env_model or DEFAULT_TRANSCRIPTION_MODEL
+
+
+def _image_model_from_settings(settings):
+    """Return the configured OpenAI image-generation model."""
+    saved = _setting(settings, "image_model", "", str).strip()
+    if saved:
+        return saved
+    env_model = os.environ.get("GEOAGENT_IMAGE_MODEL", "").strip()
+    return env_model or DEFAULT_IMAGE_MODEL
 
 
 def _qt_value(enum_name, member_name):
@@ -425,6 +450,42 @@ def _plain_text_to_html(text):
     return html.escape(text).replace("\n", "<br>")
 
 
+def _markdown_image_target_to_html_src(target):
+    """Return a safe HTML image source for a Markdown image target."""
+    target = str(target or "").strip()
+    if not target:
+        return ""
+    if target.startswith(("http://", "https://", "data:image/", "file://")):
+        return target
+    try:
+        path = Path(target).expanduser()
+        if path.exists():
+            return path.resolve().as_uri()
+    except Exception:
+        pass
+    return target
+
+
+def _image_html(src, alt="image", width=None, height=None):
+    """Return a constrained HTML image tag."""
+    src = _markdown_image_target_to_html_src(src)
+    if not src:
+        return ""
+    attrs = [f"src='{html.escape(src, quote=True)}'"]
+    attrs.append(f"alt='{html.escape(str(alt or 'image'), quote=True)}'")
+    if width and height:
+        attrs.append(f"width='{int(width)}'")
+        attrs.append(f"height='{int(height)}'")
+    elif width:
+        attrs.append(f"width='{int(width)}'")
+    elif height:
+        attrs.append(f"height='{int(height)}'")
+    attrs.append(
+        "style='max-width: 100%; border: 1px solid #d0d7de; border-radius: 4px;'"
+    )
+    return f"<img {' '.join(attrs)}>"
+
+
 def _inline_markdown_to_html(text):
     """Convert inline Markdown spans to HTML."""
     text = html.escape(text)
@@ -473,6 +534,16 @@ def _markdown_to_basic_html(markdown):
         if not stripped:
             close_lists()
             html_lines.append("")
+            continue
+
+        image = re.match(r"^!\[([^\]]*)\]\((?:<([^>]+)>|([^)]+))\)$", stripped)
+        if image:
+            close_lists()
+            alt = image.group(1) or "image"
+            target = image.group(2) or image.group(3) or ""
+            img = _image_html(target, alt=alt)
+            if img:
+                html_lines.append(f"<p>{img}</p>")
             continue
 
         heading = re.match(r"^(#{1,3})\s+(.+)$", stripped)
@@ -828,6 +899,9 @@ def _conversation_markdown(messages):
     for msg in messages:
         sender = str(msg.get("sender") or "").strip()
         body = str(msg.get("display_body") or msg.get("body") or "").strip()
+        image_body = _message_images_markdown(msg.get("images"))
+        if image_body:
+            body = f"{body}\n\n{image_body}".strip()
         if not sender or not body:
             continue
         blocks.append(f"## {sender}\n\n{body}")
@@ -862,6 +936,183 @@ def _image_to_png_bytes(image):
     finally:
         buffer.close()
     return bytes(data.data()), image.width(), image.height()
+
+
+def _output_image_dir():
+    """Return the directory used for model-generated image artifacts."""
+    path = Path(tempfile.gettempdir()) / "open_geoagent_outputs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _output_image_extension(image):
+    """Return a safe file extension for a model-generated image."""
+    format_name = str(image.get("format") or "").lower().lstrip(".")
+    mime_type = str(image.get("mime_type") or "").lower()
+    if format_name in {"png", "jpg", "jpeg", "webp", "gif"}:
+        return "jpg" if format_name == "jpeg" else format_name
+    if mime_type == "image/jpeg":
+        return "jpg"
+    if mime_type.startswith("image/"):
+        candidate = mime_type.split("/", 1)[1].split("+", 1)[0]
+        if candidate in {"png", "jpg", "jpeg", "webp", "gif"}:
+            return "jpg" if candidate == "jpeg" else candidate
+    return "png"
+
+
+def _decode_output_image_bytes(value):
+    """Decode model image bytes that may arrive as bytes or base64 text."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, str):
+        text = value.strip()
+        data_uri = re.match(r"^data:image/[a-zA-Z0-9.+-]+;base64,(.+)$", text, re.S)
+        if data_uri:
+            text = data_uri.group(1)
+        try:
+            return base64.b64decode(re.sub(r"\s+", "", text), validate=True)
+        except Exception:
+            return b""
+    return b""
+
+
+def _display_size_for_image(width, height, max_edge=MAX_OUTPUT_IMAGE_DISPLAY_EDGE):
+    """Return a constrained display size preserving aspect ratio."""
+    try:
+        width = int(width or 0)
+        height = int(height or 0)
+    except (TypeError, ValueError):
+        return None, None
+    if width <= 0 or height <= 0:
+        return None, None
+    scale = min(1.0, float(max_edge) / float(max(width, height)))
+    return max(1, int(width * scale)), max(1, int(height * scale))
+
+
+def _prepare_output_images(images):
+    """Persist model-generated image bytes and return transcript-safe metadata."""
+    prepared = []
+    for index, image in enumerate(images or []):
+        if not isinstance(image, dict):
+            continue
+        entry = {
+            key: image.get(key)
+            for key in ("format", "mime_type", "width", "height", "url", "path")
+            if image.get(key) not in (None, "")
+        }
+        image_bytes = _decode_output_image_bytes(image.get("bytes"))
+        if image_bytes:
+            digest = hashlib.sha1(  # noqa: S324 - non-security artifact name
+                image_bytes, usedforsecurity=False
+            ).hexdigest()[:16]
+            ext = _output_image_extension(image)
+            path = _output_image_dir() / f"opengeoagent-image-{digest}.{ext}"
+            if not path.exists():
+                with open(path, "wb") as f:
+                    f.write(image_bytes)
+            entry["path"] = str(path)
+
+            if QGuiApplication.instance() is not None:
+                pixmap = QPixmap()
+                if pixmap.loadFromData(image_bytes):
+                    entry["width"] = pixmap.width()
+                    entry["height"] = pixmap.height()
+        elif not entry.get("url") and not entry.get("path"):
+            continue
+        entry.setdefault("alt", f"OpenGeoAgent image {index + 1}")
+        prepared.append(entry)
+    return prepared
+
+
+def _dedupe_output_images(images):
+    """Return image metadata with duplicate path/url entries removed."""
+    deduped = []
+    seen = set()
+    for image in images or []:
+        if not isinstance(image, dict):
+            continue
+        key = image.get("path") or image.get("url")
+        if not key:
+            key = tuple(sorted((str(k), str(v)) for k, v in image.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(image)
+    return deduped
+
+
+def _images_from_output_text(text):
+    """Extract local image paths mentioned in model/tool output text."""
+    images = []
+    for match in OUTPUT_IMAGE_PATH_RE.finditer(str(text or "")):
+        path = match.group("path").rstrip(".,);]")
+        ext = path.rsplit(".", 1)[-1].lower()
+        if ext == "jpeg":
+            ext = "jpg"
+        images.append(
+            {
+                "path": path,
+                "format": ext,
+                "mime_type": "image/jpeg" if ext == "jpg" else f"image/{ext}",
+            }
+        )
+    return _dedupe_output_images(images)
+
+
+def _image_markdown_target(image):
+    """Return the Markdown target for one transcript image."""
+    target = str(image.get("url") or image.get("path") or "").strip()
+    if not target:
+        return ""
+    if " " in target or target.startswith("/"):
+        return f"<{target}>"
+    return target
+
+
+def _message_images_markdown(images):
+    """Return Markdown image references for a message image list."""
+    lines = []
+    for image in images or []:
+        if not isinstance(image, dict):
+            continue
+        target = _image_markdown_target(image)
+        if not target:
+            continue
+        alt = str(image.get("alt") or "OpenGeoAgent image").replace("]", "")
+        lines.append(f"![{alt}]({target})")
+    return "\n\n".join(lines)
+
+
+def _message_images_html(images):
+    """Return inline HTML for a message image list."""
+    parts = []
+    for image in images or []:
+        if not isinstance(image, dict):
+            continue
+        target = image.get("url") or image.get("path") or ""
+        width, height = _display_size_for_image(
+            image.get("width"),
+            image.get("height"),
+            max_edge=OUTPUT_IMAGE_THUMBNAIL_EDGE,
+        )
+        if width is None:
+            width = OUTPUT_IMAGE_THUMBNAIL_EDGE
+        img = _image_html(
+            target,
+            alt=image.get("alt") or "OpenGeoAgent image",
+            width=width,
+            height=height,
+        )
+        if not img:
+            continue
+        label = html.escape(str(image.get("path") or image.get("url") or "image"))
+        href = image.get("_href")
+        if href:
+            img = f"<a href='{html.escape(str(href), quote=True)}'>{img}</a>"
+        parts.append(f"<p>{img}<br><small>{label}</small></p>")
+    return "\n".join(parts)
 
 
 def _attachment_to_content_block(attachment):
@@ -1274,6 +1525,7 @@ class ChatWorker(QThread):
                         "success": False,
                         "answer": "",
                         "error": "",
+                        "images": getattr(response, "images", []) or [],
                         "tools": ", ".join(response.executed_tools or []),
                         "tool_calls": response.tool_calls or [],
                         "cancelled": ", ".join(response.cancelled_tools or []),
@@ -1288,6 +1540,7 @@ class ChatWorker(QThread):
                     "success": bool(response.success),
                     "answer": response.answer_text or "",
                     "error": response.error_message or "",
+                    "images": getattr(response, "images", []) or [],
                     "tools": ", ".join(response.executed_tools or []),
                     "tool_calls": response.tool_calls or [],
                     "cancelled": ", ".join(response.cancelled_tools or []),
@@ -1301,6 +1554,7 @@ class ChatWorker(QThread):
                     "success": False,
                     "answer": "",
                     "error": f"{exc}\n\n{traceback.format_exc()}",
+                    "images": [],
                     "tools": "",
                     "cancelled": "",
                     "elapsed": "",
@@ -1333,6 +1587,20 @@ class ChatWorker(QThread):
         tool_metrics = getattr(
             getattr(final_result, "metrics", None), "tool_metrics", {}
         )
+        try:
+            from geoagent.core.agent import (
+                _result_to_images,
+                _result_to_text,
+                _tool_calls_to_images,
+            )
+
+            tool_calls = list(getattr(agent, "_tool_calls", []) or [])
+            images = _result_to_images(final_result) + _tool_calls_to_images(tool_calls)
+            final_text = _result_to_text(final_result)
+        except Exception:
+            images = []
+            final_text = ""
+            tool_calls = list(getattr(agent, "_tool_calls", []) or [])
         executed_tools = (
             list(tool_metrics.keys()) if isinstance(tool_metrics, dict) else []
         )
@@ -1344,10 +1612,11 @@ class ChatWorker(QThread):
         self.finished.emit(
             {
                 "success": success,
-                "answer": "".join(chunks),
+                "answer": "".join(chunks) or final_text,
                 "error": "" if success else f"stop_reason={stop_reason}",
+                "images": images,
                 "tools": ", ".join(executed_tools),
-                "tool_calls": list(getattr(agent, "_tool_calls", []) or []),
+                "tool_calls": tool_calls,
                 "cancelled": ", ".join(getattr(agent, "_cancelled", []) or []),
                 "elapsed": f"{time.time() - started_at:.2f}s",
                 "cancelled_by_user": self.isInterruptionRequested(),
@@ -1689,6 +1958,7 @@ class ChatDockWidget(QDockWidget):
         self._messages = []
         self._last_script_snippet = {}
         self._image_attachments = []
+        self._transcript_image_links = {}
         self._streaming_message_index = None
         self._streaming_answer = ""
         self._status_started_at = None
@@ -1854,9 +2124,12 @@ class ChatDockWidget(QDockWidget):
         jobs_layout.addWidget(self.jobs_controls)
         layout.addWidget(self.jobs_group)
 
-        self.transcript = QTextEdit()
+        self.transcript = QTextBrowser()
         self.transcript.setReadOnly(True)
         self.transcript.setAcceptRichText(True)
+        self.transcript.setOpenLinks(False)
+        self.transcript.setOpenExternalLinks(False)
+        self.transcript.anchorClicked.connect(self._on_transcript_anchor_clicked)
         self.transcript.setPlaceholderText("Conversation will appear here.")
         layout.addWidget(self.transcript, 1)
 
@@ -2269,6 +2542,79 @@ class ChatDockWidget(QDockWidget):
         layout.addLayout(button_layout)
         _exec_dialog(dialog)
 
+    def _preview_output_image(self, image):
+        """Show a full-resolution preview for a generated transcript image."""
+        path = str(image.get("path") or "").strip()
+        if not path:
+            QMessageBox.information(
+                self,
+                "OpenGeoAgent",
+                "This image is remote and cannot be previewed locally.",
+            )
+            return
+        path = os.path.expanduser(path)
+        pixmap = QPixmap(path)
+        if pixmap.isNull():
+            QMessageBox.warning(
+                self,
+                "OpenGeoAgent",
+                f"Could not preview this image:\n\n{path}",
+            )
+            return
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle(f"Image Preview ({pixmap.width()} x {pixmap.height()})")
+        available = _screen_for_widget(self).availableGeometry()
+        dialog.resize(
+            max(480, int(available.width() * 0.75)),
+            max(360, int(available.height() * 0.75)),
+        )
+
+        layout = QVBoxLayout(dialog)
+        scroll = QScrollArea(dialog)
+        scroll.setWidgetResizable(False)
+        image_label = QLabel()
+        image_label.setAlignment(_qt_value("AlignmentFlag", "AlignCenter"))
+        image_label.setPixmap(pixmap)
+        scroll.setWidget(image_label)
+        layout.addWidget(scroll)
+
+        def save_image():
+            """Save a copy of the generated image file."""
+            default_name = os.path.basename(path) or "opengeoagent-image.png"
+            default_path = os.path.join(os.path.expanduser("~"), default_name)
+            selected, _selected_filter = QFileDialog.getSaveFileName(
+                dialog,
+                "Save Image",
+                default_path,
+                "Images (*.png *.jpg *.jpeg *.webp *.gif);;All Files (*)",
+            )
+            if not selected:
+                return
+            try:
+                with open(path, "rb") as src, open(selected, "wb") as dst:
+                    dst.write(src.read())
+            except Exception as exc:
+                QMessageBox.warning(
+                    dialog,
+                    "OpenGeoAgent",
+                    f"Could not save image:\n\n{exc}",
+                )
+                return
+            self.status_label.setText(f"Saved image to {selected}")
+            self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
+        button_layout = QHBoxLayout()
+        save_btn = QPushButton("Save Image")
+        save_btn.clicked.connect(save_image)
+        button_layout.addWidget(save_btn)
+        button_layout.addStretch(1)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(dialog.accept)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+        _exec_dialog(dialog)
+
     def _remove_image_attachment(self, index):
         """Remove one pending image attachment."""
         if 0 <= index < len(self._image_attachments):
@@ -2474,10 +2820,18 @@ class ChatDockWidget(QDockWidget):
         if permission_profile == "Trusted auto-approve":
             auto_approve_tools = True
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        image_model = _image_model_from_settings(self.settings)
         if not prompt:
             prompt = "Describe the attached image."
         self._record_prompt(prompt)
         prompt_with_context = self._build_prompt_with_context(prompt)
+        if image_model:
+            prompt_with_context = (
+                f"{prompt_with_context}\n\n"
+                "Image generation setting: when calling generate_image, use "
+                f"model={image_model} unless the user explicitly asks for a "
+                "different image model."
+            )
         attachments = [dict(item) for item in self._image_attachments]
         chat_payload = _build_chat_content(prompt_with_context, attachments)
 
@@ -2506,6 +2860,7 @@ class ChatDockWidget(QDockWidget):
                 "prompt": prompt,
                 "provider": provider,
                 "model": model_id,
+                "image_model": image_model,
                 "mode": agent_mode,
                 "permission_profile": permission_profile,
                 "status": "Running",
@@ -2744,7 +3099,7 @@ class ChatDockWidget(QDockWidget):
             "QProgressBar { border: 1px solid #b0bec5; border-radius: 3px; "
             "background: #eceff1; } "
             f"QProgressBar::chunk {{ background-color: {chunk_color}; "
-            "border-radius: 2px; }}"
+            "border-radius: 2px; }"
         )
 
     def _set_voice_level_recording(self):
@@ -2948,7 +3303,10 @@ class ChatDockWidget(QDockWidget):
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
             self._finish_active_job("Cancelled", result)
         elif result.get("success"):
-            answer = result.get("answer") or "(No text response.)"
+            output_images = _prepare_output_images(result.get("images") or [])
+            answer = result.get("answer") or (
+                "(Image output.)" if output_images else "(No text response.)"
+            )
             details = []
             tool_calls = result.get("tool_calls") or []
             snippet = _latest_executable_snippet(tool_calls)
@@ -2964,14 +3322,23 @@ class ChatDockWidget(QDockWidget):
                 details.append(f"Elapsed: {result['elapsed']}")
             if details:
                 answer = f"{answer}\n\n" + "\n".join(details)
+            output_images = _dedupe_output_images(
+                output_images + _prepare_output_images(_images_from_output_text(answer))
+            )
             if result.get("streamed") and self._streaming_message_index is not None:
                 self._update_message(
                     self._streaming_message_index,
                     answer,
                     markdown=True,
+                    images=output_images,
                 )
             else:
-                self._append_message("OpenGeoAgent", answer, markdown=True)
+                self._append_message(
+                    "OpenGeoAgent",
+                    answer,
+                    markdown=True,
+                    images=output_images,
+                )
             self.status_label.setText("Ready")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
             self._finish_active_job("Succeeded", result)
@@ -3067,7 +3434,9 @@ class ChatDockWidget(QDockWidget):
             f"{spinner} {self._status_base_text}{dots} {elapsed}s - {suffix}"
         )
 
-    def _append_message(self, sender, message, markdown=False, display_body=None):
+    def _append_message(
+        self, sender, message, markdown=False, display_body=None, images=None
+    ):
         """Append a chat message and refresh the transcript.
 
         ``body`` holds the canonical prompt or response text used for context
@@ -3075,21 +3444,28 @@ class ChatDockWidget(QDockWidget):
         UI and copied transcripts so that ephemeral metadata (such as image
         attachment markers) does not bleed into later conversation history.
         """
-        body = message.strip()
+        body = str(message or "").strip()
         entry = {"sender": sender, "body": body, "markdown": markdown}
         if display_body is not None:
             entry["display_body"] = display_body.strip()
+        if images:
+            entry["images"] = images
         self._messages.append(entry)
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
         self._save_project_history()
 
-    def _update_message(self, index, message, markdown=False):
+    def _update_message(self, index, message, markdown=False, images=None):
         """Update an existing chat message and refresh the transcript."""
         if index < 0 or index >= len(self._messages):
             return
-        self._messages[index]["body"] = message
+        self._messages[index]["body"] = str(message or "")
         self._messages[index]["markdown"] = markdown
+        if images is not None:
+            if images:
+                self._messages[index]["images"] = images
+            else:
+                self._messages[index].pop("images", None)
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
         self._save_project_history()
@@ -3097,6 +3473,8 @@ class ChatDockWidget(QDockWidget):
     def _render_transcript(self):
         """Render the stored chat messages as HTML."""
         blocks = []
+        image_links = {}
+        image_index = 0
         for msg in self._messages:
             sender = html.escape(msg["sender"])
             display = msg.get("display_body") or msg["body"]
@@ -3104,16 +3482,38 @@ class ChatDockWidget(QDockWidget):
                 body = _markdown_to_basic_html(display)
             else:
                 body = f"<p>{_plain_text_to_html(display)}</p>"
+            images = []
+            for image in msg.get("images") or []:
+                if not isinstance(image, dict):
+                    continue
+                href = f"opengeoagent-image:{image_index}"
+                linked = dict(image)
+                linked["_href"] = href
+                image_links[href] = linked
+                image_index += 1
+                images.append(linked)
+            image_html = _message_images_html(images)
+            if image_html:
+                body = f"{body}\n{image_html}"
             blocks.append(
                 "<div style='margin-bottom: 12px;'>"
                 f"<p style='font-weight: 600; margin-bottom: 4px;'>{sender}</p>"
                 f"{body}"
                 "</div>"
             )
+        self._transcript_image_links = image_links
         blocks.append("<div style='height: 1em;'>&nbsp;</div>")
         self.transcript.setHtml("\n".join(blocks))
         end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
         self.transcript.moveCursor(end_cursor)
+
+    def _on_transcript_anchor_clicked(self, url):
+        """Open generated image thumbnails in a full-size preview dialog."""
+        href = url.toString() if hasattr(url, "toString") else str(url)
+        image = self._transcript_image_links.get(href)
+        if image is None:
+            return
+        self._preview_output_image(image)
 
     def _copy_transcript_markdown(self):
         """Copy the full chat transcript to the clipboard as Markdown."""
@@ -3205,7 +3605,9 @@ class ChatDockWidget(QDockWidget):
         self._messages = [
             item
             for item in messages
-            if isinstance(item, dict) and item.get("sender") and item.get("body")
+            if isinstance(item, dict)
+            and item.get("sender")
+            and (item.get("body") or item.get("images"))
         ]
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -359,13 +359,11 @@ def _apply_environment_from_settings(settings):
     }
     for key, env_names in env_map.items():
         value = _setting(settings, key, "").strip()
-        if isinstance(env_names, str):
-            env_names = (env_names,)
-        for env_name in env_names:
-            if value:
+        if value:
+            if isinstance(env_names, str):
+                env_names = (env_names,)
+            for env_name in env_names:
                 os.environ[env_name] = value
-            else:
-                os.environ.pop(env_name, None)
 
 
 def _transcription_model_from_settings(settings):

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -359,11 +359,13 @@ def _apply_environment_from_settings(settings):
     }
     for key, env_names in env_map.items():
         value = _setting(settings, key, "").strip()
-        if value:
-            if isinstance(env_names, str):
-                env_names = (env_names,)
-            for env_name in env_names:
+        if isinstance(env_names, str):
+            env_names = (env_names,)
+        for env_name in env_names:
+            if value:
                 os.environ[env_name] = value
+            else:
+                os.environ.pop(env_name, None)
 
 
 def _transcription_model_from_settings(settings):
@@ -455,8 +457,11 @@ def _markdown_image_target_to_html_src(target):
     target = str(target or "").strip()
     if not target:
         return ""
-    if target.startswith(("http://", "https://", "data:image/", "file://")):
+    lower = target.lower()
+    if lower.startswith(("http://", "https://", "data:image/", "file://")):
         return target
+    if re.match(r"^[a-z][a-z0-9+.-]*:", lower):
+        return ""
     try:
         path = Path(target).expanduser()
         if path.exists():
@@ -945,6 +950,39 @@ def _output_image_dir():
     return path
 
 
+def _allowed_output_image_roots():
+    """Return resolved directories where extracted output paths may live."""
+    roots: list[Path] = []
+    candidates = [
+        Path(tempfile.gettempdir()) / "open_geoagent_outputs",
+        Path(tempfile.gettempdir()) / "geoagent_images",
+    ]
+    env_dir = os.environ.get("GEOAGENT_IMAGE_OUTPUT_DIR", "").strip()
+    if env_dir:
+        candidates.append(Path(env_dir).expanduser())
+    for candidate in candidates:
+        try:
+            roots.append(candidate.resolve())
+        except Exception:
+            continue
+    return roots
+
+
+def _path_under_allowed_output_root(path):
+    """Return True when the given path resolves under an allowlisted root."""
+    try:
+        resolved = Path(path).expanduser().resolve()
+    except Exception:
+        return False
+    for root in _allowed_output_image_roots():
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
 def _output_image_extension(image):
     """Return a safe file extension for a model-generated image."""
     format_name = str(image.get("format") or "").lower().lstrip(".")
@@ -1048,6 +1086,8 @@ def _images_from_output_text(text):
     images = []
     for match in OUTPUT_IMAGE_PATH_RE.finditer(str(text or "")):
         path = match.group("path").rstrip(".,);]")
+        if not _path_under_allowed_output_root(path):
+            continue
         ext = path.rsplit(".", 1)[-1].lower()
         if ext == "jpeg":
             ext = "jpg"

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -464,8 +464,12 @@ def _markdown_image_target_to_html_src(target):
         path = Path(target).expanduser()
         if path.exists():
             return path.resolve().as_uri()
-    except Exception:
-        pass
+    except Exception as exc:
+        QgsMessageLog.logMessage(
+            f"Could not resolve image target {target!r}: {exc}",
+            "OpenGeoAgent",
+            Qgis.MessageLevel.Info,
+        )
     return target
 
 
@@ -961,8 +965,12 @@ def _allowed_output_image_roots():
     for candidate in candidates:
         try:
             roots.append(candidate.resolve())
-        except Exception:
-            continue
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not resolve output image root {candidate}: {exc}",
+                "OpenGeoAgent",
+                Qgis.MessageLevel.Info,
+            )
     return roots
 
 

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -30,9 +30,11 @@ from qgis.PyQt.QtWidgets import (
 
 from .chat_dock import (
     DEFAULT_MODELS,
+    DEFAULT_IMAGE_MODEL,
     DEFAULT_PROVIDER,
     DEFAULT_TRANSCRIPTION_MODEL,
     DEFAULT_VOICE_SHORTCUT,
+    IMAGE_MODELS,
     PROVIDERS,
     SETTINGS_PREFIX,
     TRANSCRIPTION_MODELS,
@@ -50,6 +52,8 @@ from ..oauth import (
 
 ENV_FALLBACKS = {
     "openai_api_key": ("OPENAI_API_KEY",),
+    "openai_org_id": ("OPENAI_ORG_ID",),
+    "openai_project_id": ("OPENAI_PROJECT_ID",),
     "anthropic_api_key": ("ANTHROPIC_API_KEY",),
     "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
     "aws_region": ("AWS_REGION", "AWS_DEFAULT_REGION"),
@@ -162,6 +166,11 @@ def collect_diagnostics(
                 os.environ.get(
                     "OPENAI_TRANSCRIPTION_MODEL", DEFAULT_TRANSCRIPTION_MODEL
                 ),
+                type=str,
+            ),
+            "image_model": settings.value(
+                f"{SETTINGS_PREFIX}image_model",
+                os.environ.get("GEOAGENT_IMAGE_MODEL", DEFAULT_IMAGE_MODEL),
                 type=str,
             ),
             "voice_shortcut": settings.value(
@@ -528,6 +537,16 @@ class SettingsDockWidget(QDockWidget):
         self.openai_key_input.setEchoMode(password_mode)
         credentials_form.addRow("OpenAI API key:", self.openai_key_input)
 
+        self.openai_org_input = QLineEdit()
+        self.openai_org_input.setEchoMode(password_mode)
+        self.openai_org_input.setPlaceholderText("Optional OpenAI organization ID")
+        credentials_form.addRow("OpenAI org ID:", self.openai_org_input)
+
+        self.openai_project_input = QLineEdit()
+        self.openai_project_input.setEchoMode(password_mode)
+        self.openai_project_input.setPlaceholderText("Optional OpenAI project ID")
+        credentials_form.addRow("OpenAI project ID:", self.openai_project_input)
+
         self.anthropic_key_input = QLineEdit()
         self.anthropic_key_input.setEchoMode(password_mode)
         credentials_form.addRow("Anthropic API key:", self.anthropic_key_input)
@@ -553,6 +572,32 @@ class SettingsDockWidget(QDockWidget):
         credentials_form.addRow("LiteLLM base URL:", self.litellm_base_url_input)
 
         layout.addWidget(credentials_group)
+
+        image_group = QGroupBox("Image Generation")
+        image_form = QFormLayout(image_group)
+
+        self.image_model_combo = QComboBox()
+        self.image_model_combo.addItems(IMAGE_MODELS)
+        self.image_model_combo.setEditable(True)
+        self.image_model_combo.setMinimumContentsLength(18)
+        self.image_model_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        image_form.addRow("Image model:", self.image_model_combo)
+
+        image_note = QLabel(
+            "Direct image generation uses the OpenAI Images API. "
+            "`gpt-image-2` is the default; choose `gpt-image-1` when you want "
+            "the lower-cost fallback model."
+        )
+        image_note.setWordWrap(True)
+        image_note.setStyleSheet("font-size: 10px; color: gray;")
+        image_form.addRow(image_note)
+        layout.addWidget(image_group)
 
         voice_group = QGroupBox("Voice Transcription")
         voice_form = QFormLayout(voice_group)
@@ -887,6 +932,17 @@ class SettingsDockWidget(QDockWidget):
         if self.transcription_model_combo.findText(transcription_model) < 0:
             self.transcription_model_combo.addItem(transcription_model)
         self.transcription_model_combo.setCurrentText(transcription_model)
+        image_model = (
+            self.settings.value(
+                f"{SETTINGS_PREFIX}image_model",
+                os.environ.get("GEOAGENT_IMAGE_MODEL", DEFAULT_IMAGE_MODEL),
+                type=str,
+            ).strip()
+            or DEFAULT_IMAGE_MODEL
+        )
+        if self.image_model_combo.findText(image_model) < 0:
+            self.image_model_combo.addItem(image_model)
+        self.image_model_combo.setCurrentText(image_model)
         voice_shortcut = (
             self.settings.value(
                 f"{SETTINGS_PREFIX}{VOICE_SHORTCUT_SETTING}",
@@ -899,6 +955,8 @@ class SettingsDockWidget(QDockWidget):
 
         self._credential_inputs = (
             ("openai_api_key", self.openai_key_input),
+            ("openai_org_id", self.openai_org_input),
+            ("openai_project_id", self.openai_project_input),
             ("anthropic_api_key", self.anthropic_key_input),
             ("gemini_api_key", self.gemini_key_input),
             ("aws_region", self.aws_region_input),
@@ -944,6 +1002,10 @@ class SettingsDockWidget(QDockWidget):
             f"{SETTINGS_PREFIX}transcription_model",
             self.transcription_model_combo.currentText().strip()
             or DEFAULT_TRANSCRIPTION_MODEL,
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}image_model",
+            self.image_model_combo.currentText().strip() or DEFAULT_IMAGE_MODEL,
         )
         sequence = _single_chord_sequence(self.voice_shortcut_edit.keySequence())
         if sequence != self.voice_shortcut_edit.keySequence():
@@ -1057,9 +1119,12 @@ class SettingsDockWidget(QDockWidget):
             "fast_mode",
             "max_tokens",
             "transcription_model",
+            "image_model",
             VOICE_SHORTCUT_SETTING,
             "voice_shortcut",
             "openai_api_key",
+            "openai_org_id",
+            "openai_project_id",
             "anthropic_api_key",
             "gemini_api_key",
             "aws_region",

--- a/qgis_geoagent/open_geoagent/oauth.py
+++ b/qgis_geoagent/open_geoagent/oauth.py
@@ -29,8 +29,8 @@ OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 OPENAI_CODEX_CALLBACK_PORT = 1455
 OPENAI_CODEX_CALLBACK_PATH = "/auth/callback"
 # OAuth authorize-request flag values below are protocol parameters, not credentials.
-OPENAI_CODEX_AUTH_EXTRA_PARAMS = {  # nosec B105
-    "id_token_add_organizations": "true",
+OPENAI_CODEX_AUTH_EXTRA_PARAMS = {
+    "id_token_add_organizations": "true",  # nosec B105
     "codex_cli_simplified_flow": "true",
     "originator": "pi",
 }

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -4,6 +4,7 @@ from qgis.PyQt.QtCore import QPoint, QRect, QSize
 from qgis.PyQt.QtGui import QColor, QImage
 
 from open_geoagent.dialogs.chat_dock import (
+    SETTINGS_PREFIX,
     _build_chat_content,
     _console_ready_pyqgis_script,
     _conversation_markdown,
@@ -11,13 +12,29 @@ from open_geoagent.dialogs.chat_dock import (
     _grab_screen_rect,
     _grab_widget_global_rect,
     _image_to_png_bytes,
+    _image_model_from_settings,
+    _images_from_output_text,
     _latest_executable_snippet,
     _latest_pyqgis_script,
+    _markdown_to_basic_html,
+    _message_images_html,
+    _message_images_markdown,
+    _prepare_output_images,
     _normalized_crop_rect,
     _parse_markdown_transcript,
     _permission_allows_tool,
     _project_history_key,
 )
+
+
+class _FakeSettings:
+    """Small QSettings stand-in for chat helper tests."""
+
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def value(self, key, default="", type=str):  # noqa: A002
+        return self.values.get(key, default)
 
 
 def _qimage_format(name):
@@ -46,6 +63,82 @@ def test_conversation_markdown_includes_full_history() -> None:
     assert "## You\n\nrun flow accumulation" in text
     assert "Tool inputs:" in text
     assert text.count("## OpenGeoAgent") == 2
+
+
+def test_conversation_markdown_includes_output_images() -> None:
+    """Verify copied Markdown includes generated image references."""
+    text = _conversation_markdown(
+        [
+            {
+                "sender": "OpenGeoAgent",
+                "body": "Generated map",
+                "markdown": True,
+                "images": [{"path": "/tmp/open geoagent/map.png", "alt": "Map"}],
+            }
+        ]
+    )
+
+    assert "Generated map" in text
+    assert "![Map](</tmp/open geoagent/map.png>)" in text
+
+
+def test_markdown_renderer_supports_image_references() -> None:
+    """Verify Markdown image output is rendered as inline HTML."""
+    html = _markdown_to_basic_html("![Map](https://example.com/map.png)")
+
+    assert "<img " in html
+    assert "https://example.com/map.png" in html
+
+
+def test_message_images_html_uses_clickable_thumbnail() -> None:
+    """Verify generated image chat output renders as a clickable thumbnail."""
+    html = _message_images_html(
+        [
+            {
+                "path": "/tmp/geoagent_images/cat.png",
+                "format": "png",
+                "_href": "opengeoagent-image:0",
+            }
+        ]
+    )
+
+    assert "href='opengeoagent-image:0'" in html
+    assert "width='180'" in html
+    assert "/tmp/geoagent_images/cat.png" in html
+
+
+def test_prepare_output_images_writes_model_image_bytes() -> None:
+    """Verify model image bytes become transcript-safe local artifacts."""
+    prepared = _prepare_output_images(
+        [
+            {
+                "format": "png",
+                "mime_type": "image/png",
+                "bytes": b"\x89PNG\r\n\x1a\nfake",
+            }
+        ]
+    )
+
+    assert len(prepared) == 1
+    assert prepared[0]["path"].endswith(".png")
+    assert "bytes" not in prepared[0]
+    assert _message_images_markdown(prepared).startswith("![OpenGeoAgent image 1](")
+
+
+def test_images_from_output_text_extracts_generated_path() -> None:
+    """Verify generated-image output paths become renderable image metadata."""
+    images = _images_from_output_text(
+        "Output path: /tmp/geoagent_images/cat-20260430-163529-1.png\n"
+        "Elapsed: 18.95s"
+    )
+
+    assert images == [
+        {
+            "path": "/tmp/geoagent_images/cat-20260430-163529-1.png",
+            "format": "png",
+            "mime_type": "image/png",
+        }
+    ]
 
 
 def test_image_to_png_bytes_serializes_qimage() -> None:
@@ -78,6 +171,18 @@ def test_build_chat_content_adds_image_blocks() -> None:
         {"text": "Describe this map screenshot."},
         {"image": {"format": "png", "source": {"bytes": b"png-bytes"}}},
     ]
+
+
+def test_image_model_from_settings_prefers_saved_then_env(monkeypatch) -> None:
+    """Verify image generation model selection has a stable default path."""
+    monkeypatch.setenv("GEOAGENT_IMAGE_MODEL", "gpt-image-1")
+    saved_settings = _FakeSettings({f"{SETTINGS_PREFIX}image_model": "gpt-image-2"})
+
+    assert _image_model_from_settings(saved_settings) == "gpt-image-2"
+    assert _image_model_from_settings(_FakeSettings()) == "gpt-image-1"
+
+    monkeypatch.delenv("GEOAGENT_IMAGE_MODEL")
+    assert _image_model_from_settings(_FakeSettings()) == "gpt-image-2"
 
 
 def test_latest_pyqgis_script_extracts_last_run_script() -> None:

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -48,8 +48,11 @@ def test_collect_diagnostics_redacts_credentials(monkeypatch, tmp_path) -> None:
             f"{SETTINGS_PREFIX}provider": "openai",
             f"{SETTINGS_PREFIX}model": "gpt-test",
             f"{SETTINGS_PREFIX}transcription_model": "gpt-4o-transcribe",
+            f"{SETTINGS_PREFIX}image_model": "gpt-image-2",
             f"{SETTINGS_PREFIX}{VOICE_SHORTCUT_SETTING}": "Alt+M",
             f"{SETTINGS_PREFIX}openai_api_key": "sk-secret",
+            f"{SETTINGS_PREFIX}openai_org_id": "org-secret",
+            f"{SETTINGS_PREFIX}openai_project_id": "proj-secret",
         }
     )
     (tmp_path / "metadata.txt").write_text("version=1.2.3\n", encoding="utf-8")
@@ -58,10 +61,15 @@ def test_collect_diagnostics_redacts_credentials(monkeypatch, tmp_path) -> None:
     text = str(diagnostics)
 
     assert diagnostics["credential_presence"]["openai_api_key"]["saved"] is True
+    assert diagnostics["credential_presence"]["openai_org_id"]["saved"] is True
+    assert diagnostics["credential_presence"]["openai_project_id"]["saved"] is True
     assert diagnostics["model"]["provider"] == "openai"
     assert diagnostics["model"]["transcription_model"] == "gpt-4o-transcribe"
+    assert diagnostics["model"]["image_model"] == "gpt-image-2"
     assert diagnostics["model"]["voice_shortcut"] == "Alt+M"
     assert "sk-secret" not in text
+    assert "org-secret" not in text
+    assert "proj-secret" not in text
 
 
 def test_uv_usable_requires_successful_verification(monkeypatch) -> None:

--- a/qgis_geoagent/tests/test_voice_input.py
+++ b/qgis_geoagent/tests/test_voice_input.py
@@ -1,11 +1,13 @@
 """Tests for OpenGeoAgent voice input helpers."""
 
+import os
 import sys
 import types
 
 from open_geoagent.dialogs.chat_dock import (
     SETTINGS_PREFIX,
     VoiceTranscriptionWorker,
+    _apply_environment_from_settings,
 )
 
 
@@ -37,6 +39,15 @@ def test_voice_transcription_requires_openai_api_key(monkeypatch, tmp_path) -> N
     assert results
     assert results[0]["success"] is False
     assert "Voice transcription requires an OpenAI API key" in results[0]["error"]
+
+
+def test_apply_environment_preserves_openai_api_key_fallback(monkeypatch) -> None:
+    """Empty QSettings should not erase an existing OPENAI_API_KEY fallback."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+
+    _apply_environment_from_settings(_EmptySettings())
+
+    assert os.environ["OPENAI_API_KEY"] == "sk-env"
 
 
 def test_voice_transcription_uses_saved_model(monkeypatch, tmp_path) -> None:

--- a/tests/test_geoagent_chat_mock.py
+++ b/tests/test_geoagent_chat_mock.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import threading
 
 from geoagent import for_leafmap, for_qgis
+from geoagent.core.agent import _tool_calls_to_images
 from geoagent.testing import MockLeafmap, MockQGISIface, MockQGISProject
 
 
@@ -157,6 +158,72 @@ def test_chat_passes_multimodal_content_blocks_to_strands() -> None:
     assert resp.success
     assert resp.answer_text == "image described"
     mock_agent.assert_called_once_with(content)
+
+
+def test_chat_preserves_image_output_blocks() -> None:
+    """Verify image content blocks are exposed on GeoAgentResponse."""
+    m = MockLeafmap()
+    agent = for_leafmap(m, model=_MockModel())
+
+    image_bytes = b"\x89PNG\r\n\x1a\nfake"
+    metrics = SimpleNamespace(tool_metrics={})
+    msg = {
+        "role": "assistant",
+        "content": [
+            {"text": "Here is the map."},
+            {"image": {"format": "png", "source": {"bytes": image_bytes}}},
+        ],
+    }
+    fake_result = SimpleNamespace(
+        stop_reason="end_turn",
+        metrics=metrics,
+        message=msg,
+    )
+    agent._strands = MagicMock(return_value=fake_result)  # noqa: SLF001
+
+    resp = agent.chat("generate a map image")
+
+    assert resp.success
+    assert resp.answer_text == "Here is the map."
+    assert resp.content_blocks == msg["content"]
+    assert resp.images == [
+        {"format": "png", "mime_type": "image/png", "bytes": image_bytes}
+    ]
+
+
+def test_tool_call_image_results_are_extractable() -> None:
+    """Verify generated-image tool results can feed response image artifacts."""
+    images = _tool_calls_to_images(
+        [
+            {
+                "name": "generate_image",
+                "result": {
+                    "success": True,
+                    "content": [
+                        {
+                            "json": {
+                                "images": [
+                                    {
+                                        "path": "/tmp/geoagent_images/cat.png",
+                                        "format": "png",
+                                        "mime_type": "image/png",
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                },
+            }
+        ]
+    )
+
+    assert images == [
+        {
+            "format": "png",
+            "mime_type": "image/png",
+            "path": "/tmp/geoagent_images/cat.png",
+        }
+    ]
 
 
 def test_chat_json_parse_error_returns_actionable_guidance() -> None:

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -1,0 +1,97 @@
+"""Tests for GeoAgent image generation tools."""
+
+from __future__ import annotations
+
+import base64
+import sys
+import types
+
+from geoagent.tools.images import image_generation_tools
+
+
+def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None:
+    """Verify generate_image saves OpenAI b64 image responses as files."""
+    image_payload = base64.b64encode(b"fake-png").decode("ascii")
+    calls = {}
+
+    class _Images:
+        def generate(self, **kwargs):
+            calls.update(kwargs)
+            item = types.SimpleNamespace(
+                b64_json=image_payload,
+                revised_prompt="revised prompt",
+                url=None,
+            )
+            return types.SimpleNamespace(data=[item])
+
+    class _Client:
+        def __init__(self) -> None:
+            self.images = _Images()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))
+
+    tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
+    result = tool.__wrapped__(
+        "orange tabby cat",
+        output_dir=str(tmp_path),
+        quality="low",
+    )
+
+    assert result["success"] is True
+    assert result["images"][0]["path"].endswith(".png")
+    assert result["images"][0]["revised_prompt"] == "revised prompt"
+    assert calls["model"] == "gpt-image-2"
+    assert calls["prompt"] == "orange tabby cat"
+    filename = result["images"][0]["path"].split("/")[-1]
+    assert (tmp_path / filename).read_bytes() == b"fake-png"
+
+
+def test_generate_image_reports_missing_api_key(monkeypatch) -> None:
+    """Verify image generation gives a clear setup error without API key."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
+    result = tool.__wrapped__("orange tabby cat")
+
+    assert result["success"] is False
+    assert "OPENAI_API_KEY" in result["error"]
+
+
+def test_generate_image_falls_back_on_unverified_gpt_image_2(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify gpt-image-2 permission failures retry with gpt-image-1."""
+    image_payload = base64.b64encode(b"fallback-png").decode("ascii")
+    models = []
+
+    class _Images:
+        def generate(self, **kwargs):
+            models.append(kwargs["model"])
+            if kwargs["model"] == "gpt-image-2":
+                raise RuntimeError(
+                    "organization is not verified for gpt-image-2 "
+                    "(403 PermissionDeniedError)"
+                )
+            item = types.SimpleNamespace(
+                b64_json=image_payload,
+                revised_prompt="fallback prompt",
+                url=None,
+            )
+            return types.SimpleNamespace(data=[item])
+
+    class _Client:
+        def __init__(self) -> None:
+            self.images = _Images()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))
+
+    tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
+    result = tool.__wrapped__("digital globe", output_dir=str(tmp_path))
+
+    assert result["success"] is True
+    assert result["requested_model"] == "gpt-image-2"
+    assert result["model"] == "gpt-image-1"
+    assert "not verified" in result["fallback_reason"]
+    assert models == ["gpt-image-2", "gpt-image-1"]


### PR DESCRIPTION
## Summary
- Add `generate_image` tool backed by the OpenAI Images API and register it across the leafmap, anymap, QGIS, NASA, GEE, and Whitebox factories.
- Extract image artifacts from Strands result content blocks and tool outputs, exposing them through new `images` and `content_blocks` fields on `GeoAgentResponse`.
- Render generated and model-returned images inline in the OpenGeoAgent QGIS chat dock, with settings for the image model and optional OpenAI org/project IDs.

## Test plan
- [ ] `pytest tests/ -q`
- [ ] `pytest qgis_geoagent/tests -q` under an environment with QGIS available
- [ ] In the QGIS plugin, ask the agent to "generate a cat image" with `OPENAI_API_KEY` set and confirm the image renders in the chat transcript
- [ ] Send a multimodal model an image-producing prompt and confirm returned image blocks render inline