### PR TITLE
chore: release qgis_geoagent 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,4 +482,4 @@ GeoAgent is released under the MIT License. See `LICENSE`.
 - Documentation: <https://geoagent.gishub.org>
 - Repository: <https://github.com/opengeos/GeoAgent>
 - Issues: <https://github.com/opengeos/GeoAgent/issues>
-- Strands Agents: <https://strandsagents.com/>
+- Strands Agents: <https://strandsagents.com>

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.1.0
+version=1.2.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -45,6 +45,12 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.2.0 - Added direct image generation support
+        - Added OpenAI Images API tool integration for direct image generation
+        - Added clickable generated-image thumbnails with full-resolution preview
+        - Added image model selection and optional OpenAI org/project settings
+        - Improved voice/API-key environment fallback handling
+
     1.1.0 - Improved voice input controls
         - Added configurable OpenAI transcription model selection
         - Added microphone button, voice shortcut, and recording/transcription indicators


### PR DESCRIPTION
## Summary
- Bump `OpenGeoAgent` QGIS plugin to 1.2.0 with the new changelog entry covering image generation, clickable thumbnails, image model selection, and voice/API-key environment fallback handling.
- Drop a stray trailing slash from the Strands Agents link in `README.md`.

## Test plan
- [ ] `pre-commit run --all-files` is clean.
- [ ] Verify the QGIS plugin loads with `version=1.2.0` and the changelog renders correctly in the QGIS Plugin Manager.
- [ ] Confirm the README Strands Agents link still resolves.