### PR TITLE
chore: bump GeoAgent to 1.3.0

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.2.0"
+version = "1.3.0"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -76,7 +76,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.2.0"
+current_version = "1.3.0"
 commit = true
 tag = true
 

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -78,7 +78,7 @@ required Python packages. The installer creates an isolated environment under
 Manual fallback:
 
 ```bash
-pip install "GeoAgent[providers]>=1.2.0"
+pip install "GeoAgent[providers]>=1.3.0"
 ```
 
 ## Provider Configuration

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -29,7 +29,7 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 
 # Required packages: (import_name, pip_install_name)
 REQUIRED_PACKAGES = [
-    ("geoagent", "GeoAgent[providers]>=1.2.0"),
+    ("geoagent", "GeoAgent[providers]>=1.3.0"),
     ("strands", "strands-agents>=1.37"),
     ("pydantic", "pydantic>=2.0"),
     ("whitebox", "whitebox>=2.3.6"),
@@ -578,7 +578,7 @@ def create_venv(venv_dir: str) -> str:
         "This can happen when QGIS bundles Python in a way that prevents\n"
         "standard venv creation.\n\n"
         "You can try installing manually with:\n"
-        '  pip install "GeoAgent[providers]>=1.2.0"\n\n'
+        '  pip install "GeoAgent[providers]>=1.3.0"\n\n'
         "Details:\n" + "\n".join(f"  {d}" for d in details)
     )
 
@@ -712,7 +712,7 @@ class DepsInstallWorker(QThread):
                         False,
                         "pip is not available in the virtual environment.\n"
                         "Please install dependencies manually:\n"
-                        'pip install "GeoAgent[providers]>=1.2.0"',
+                        'pip install "GeoAgent[providers]>=1.3.0"',
                     )
                     return
             self.progress.emit(15, "Package installer ready.")

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -766,7 +766,7 @@ class SettingsDockWidget(QDockWidget):
                 self,
                 "Installation Failed",
                 f"Failed to install dependencies:\n\n{message}\n\n"
-                'Manual fallback: pip install "GeoAgent[providers]>=1.2.0"',
+                'Manual fallback: pip install "GeoAgent[providers]>=1.3.0"',
             )
 
         self._deps_worker = None

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -25,7 +25,7 @@ def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
     monkeypatch.setattr(
         deps_manager,
         "REQUIRED_PACKAGES",
-        [("geoagent", "GeoAgent[providers]>=1.2.0"), ("openai", "openai>=1.0")],
+        [("geoagent", "GeoAgent[providers]>=1.3.0"), ("openai", "openai>=1.0")],
     )
     monkeypatch.setattr(deps_manager, "ensure_venv_packages_available", lambda: True)
 
@@ -49,6 +49,6 @@ def test_required_dependencies_include_core_runtime_packages() -> None:
     """Dependency gate should catch partial GeoAgent installs."""
     from open_geoagent.deps_manager import REQUIRED_PACKAGES
 
-    assert ("geoagent", "GeoAgent[providers]>=1.2.0") in REQUIRED_PACKAGES
+    assert ("geoagent", "GeoAgent[providers]>=1.3.0") in REQUIRED_PACKAGES
     assert ("strands", "strands-agents>=1.37") in REQUIRED_PACKAGES
     assert ("pydantic", "pydantic>=2.0") in REQUIRED_PACKAGES


### PR DESCRIPTION
## Summary
- Bump the GeoAgent package version to 1.3.0 in `pyproject.toml`, `geoagent/__init__.py`, and the bumpversion config.
- Update the QGIS plugin's bundled dependency specs and tests to require `GeoAgent[providers]>=1.3.0` so the plugin pulls the matching release.

## Test plan
- [ ] `pre-commit run --all-files` is clean.
- [ ] `pytest qgis_geoagent/tests/test_startup_performance.py` passes against the new pin.
- [ ] Verify the QGIS plugin's dependency installer resolves `GeoAgent[providers]>=1.3.0` once the release is on PyPI.