### PR TITLE
feat: for_vantor factory and Vantor Open Data tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,19 @@ Natural-language OPERA chat is intentionally disabled inside QGIS for now.
 Use direct tools or `submit_nasa_opera_search_task(...)` so QGIS task/thread
 ownership remains explicit.
 
+### Vantor Open Data
+
+`for_vantor(iface, project=None, plugin=None)` exposes native tools for the
+QGIS Vantor plugin's public Open Data STAC catalog:
+
+- browse event collections: `list_vantor_events`, `get_vantor_event_info`;
+- search imagery: `get_current_vantor_search_extent`, `search_vantor_items`;
+- display results in QGIS: `display_vantor_footprints`, `load_vantor_cog`;
+- open the plugin UI when a plugin instance is supplied: `open_vantor_panel`.
+
+Footprint display and COG loading are confirmation-gated because they add
+layers to the current QGIS project.
+
 ## Direct Tool Calls
 
 Every GeoAgent exposes the underlying Strands tool caller. This is useful for

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -75,3 +75,17 @@ task = submit_nasa_opera_search_task(
 Natural-language OPERA chat is intentionally disabled inside QGIS for now.
 Use direct tools or `submit_nasa_opera_search_task(...)` so QGIS task/thread
 ownership remains explicit.
+
+## Vantor Open Data
+
+`for_vantor(iface, project=None, plugin=None)` exposes native GeoAgent tools
+for the QGIS Vantor plugin's public Open Data STAC catalog:
+
+- Browse events: `list_vantor_events`, `get_vantor_event_info`.
+- Search imagery: `get_current_vantor_search_extent`, `search_vantor_items`.
+- Display results in QGIS: `display_vantor_footprints`, `load_vantor_cog`.
+- Open the plugin panel when a plugin instance is supplied:
+  `open_vantor_panel`.
+
+Footprint display and COG loading require confirmation because they add layers
+to the current QGIS project.

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -37,6 +37,7 @@ from geoagent.core.factory import (
     for_nasa_opera,
     for_qgis,
     for_stac,
+    for_vantor,
     for_whitebox,
 )
 from geoagent.core.agent import GeoAgent
@@ -58,6 +59,7 @@ __all__ = [
     "for_nasa_opera",
     "for_qgis",
     "for_stac",
+    "for_vantor",
     "for_whitebox",
     "geo_tool",
     "get_geo_meta",

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -21,6 +21,7 @@ from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 from geoagent.tools.stac import stac_tools
+from geoagent.tools.vantor import vantor_tools
 from geoagent.tools.whitebox import whitebox_tools
 
 NASA_EARTHDATA_SYSTEM_PROMPT = """\
@@ -126,6 +127,28 @@ Workflow guidance:
 - Keep responses concise and include asset ids, layer names, and filters used.
 - If load_gee_dataset returns a bbox field, include the bbox coordinates in the
   response in west,south,east,north order.
+"""
+
+VANTOR_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS for the Vantor Open Data plugin.
+Use the Vantor tools to list event collections, inspect event metadata, search
+STAC items, display footprints, and load COG imagery into the current QGIS
+project.
+
+Workflow guidance:
+- List Vantor events first when the user names a disaster, place, or event
+  imprecisely.
+- Search a specific event collection before displaying footprints or loading
+  imagery.
+- If the user asks for the current map area, call
+  get_current_vantor_search_extent and pass the returned bbox to
+  search_vantor_items.
+- Use the phase filter for pre-event or post-event requests.
+- For raster display, use a specific item id from search results or a concrete
+  COG URL. Loading rasters and displaying footprints change the QGIS project
+  and require user confirmation.
+- Keep responses concise and include event names, item counts, item ids, phase,
+  acquisition date, sensor, and loaded layer names when available.
 """
 
 QGIS_SYSTEM_PROMPT = """\
@@ -258,7 +281,13 @@ def _permission_allows_tool(permission_profile: str | None, tool: Any) -> bool:
         return False
     if profile == "Run processing":
         return True
-    if category in {"whitebox", "nasa_earthdata", "nasa_opera", "gee_data_catalogs"}:
+    if category in {
+        "whitebox",
+        "nasa_earthdata",
+        "nasa_opera",
+        "gee_data_catalogs",
+        "vantor",
+    }:
         return profile in {"Run processing", "Execute Scripts", "Trusted auto-approve"}
     if profile == "Edit layers":
         return not destructive and name != "run_processing_algorithm"
@@ -308,11 +337,13 @@ def assemble_tools(
     include_nasa_earthdata: bool = False,
     include_nasa_opera: bool = False,
     include_gee_data_catalogs: bool = False,
+    include_vantor: bool = False,
     include_whitebox: bool = False,
     include_stac: bool = False,
     include_image_generation: bool = False,
     nasa_earthdata_plugin: Any | None = None,
     gee_data_catalogs_plugin: Any | None = None,
+    vantor_plugin: Any | None = None,
     fast: bool = False,
     permission_profile: str | None = None,
     exclude_tool_names: set[str] | None = None,
@@ -357,6 +388,16 @@ def assemble_tools(
         )
         register_all_tools(registry, gee_tools)
         collected.extend(gee_tools)
+    if include_vantor:
+        vantor_tool_list = _filter_by_imports(
+            vantor_tools(
+                context.qgis_iface,
+                context.qgis_project,
+                plugin=vantor_plugin,
+            )
+        )
+        register_all_tools(registry, vantor_tool_list)
+        collected.extend(vantor_tool_list)
     if include_whitebox:
         whitebox_tool_list = _filter_by_imports(
             whitebox_tools(context.qgis_iface, context.qgis_project)
@@ -708,6 +749,64 @@ def for_gee_data_catalogs(
     )
 
 
+def for_vantor(
+    iface: Any,
+    project: Any = None,
+    *,
+    plugin: Any | None = None,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+    include_qgis: bool = True,
+    permission_profile: str | None = None,
+) -> GeoAgent:
+    """Bind an agent to the QGIS Vantor plugin runtime.
+
+    The factory exposes native Vantor Open Data STAC tools and, by default,
+    the general QGIS map/project tools used for navigation and layer
+    management.
+    """
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={
+            "integration": "vantor",
+            "system_prompt": VANTOR_SYSTEM_PROMPT,
+        },
+    )
+    tools, registry = assemble_tools(
+        context=ctx,
+        include_qgis=include_qgis,
+        include_vantor=True,
+        include_image_generation=True,
+        vantor_plugin=plugin,
+        extra_tools=extra_tools,
+        fast=fast,
+        permission_profile=permission_profile,
+    )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+        qgis_safe_mode=True,
+    )
+
+
 def for_whitebox(
     iface: Any,
     project: Any = None,
@@ -825,6 +924,7 @@ __all__ = [
     "for_nasa_opera",
     "for_qgis",
     "for_stac",
+    "for_vantor",
     "for_whitebox",
     "register_all_tools",
 ]

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -8,6 +8,7 @@ from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 from geoagent.tools.stac import stac_tools
+from geoagent.tools.vantor import vantor_tools
 from geoagent.tools.whitebox import whitebox_tools
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "nasa_opera_tools",
     "qgis_tools",
     "stac_tools",
+    "vantor_tools",
     "whitebox_tools",
 ]

--- a/geoagent/tools/vantor.py
+++ b/geoagent/tools/vantor.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import uuid
 from typing import Any, Optional
-from urllib.parse import urljoin
+from urllib.error import URLError
+from urllib.parse import urljoin, urlparse
 from urllib.request import Request, urlopen
 
 from geoagent.core.decorators import geo_tool
@@ -31,16 +33,28 @@ VANTOR_HTTP_TIMEOUT = 30
 
 def _fetch_json(url: str) -> dict[str, Any]:
     """Fetch and parse JSON from the Vantor static STAC catalog."""
+    if not str(url).lower().startswith("https://"):
+        raise ValueError("Vantor catalog URLs must use HTTPS.")
     req = Request(url, headers={"User-Agent": "GeoAgent-Vantor/1.0"})
-    with urlopen(req, timeout=VANTOR_HTTP_TIMEOUT) as response:  # nosec B310
+    with urlopen(
+        req, timeout=VANTOR_HTTP_TIMEOUT
+    ) as response:  # nosec B310 - HTTPS enforced above
         return json.loads(response.read().decode("utf-8"))
 
 
 def _resolve_href(base_url: str, href: str) -> str:
-    """Resolve a STAC href against its parent document URL."""
-    if href.startswith(("http://", "https://")):
-        return href
-    return urljoin(base_url, href)
+    """Resolve a STAC href against its parent document URL.
+
+    Only HTTPS URLs are accepted. Non-HTTPS schemes such as ``http://``,
+    ``file://`` or ``ftp://`` are rejected so a malicious or compromised
+    catalog cannot trigger local file reads or unexpected protocol access.
+    """
+    resolved = (
+        href if href.startswith(("http://", "https://")) else urljoin(base_url, href)
+    )
+    if urlparse(resolved).scheme.lower() != "https":
+        raise ValueError(f"Refusing non-HTTPS Vantor URL: {resolved!r}")
+    return resolved
 
 
 def _event_id_from_href(href: str) -> str:
@@ -74,14 +88,11 @@ def _resolve_event_href(event: str) -> str:
         raise ValueError("event is required.")
 
     normalized = value.lower()
-    for item in _catalog_events():
-        if normalized in {
-            item["id"].lower(),
-            item["title"].lower(),
-            os.path.basename(item["href"]).lower(),
-        }:
+    events = _catalog_events()
+    for item in events:
+        if normalized in {item["id"].lower(), item["title"].lower()}:
             return item["href"]
-    for item in _catalog_events():
+    for item in events:
         if normalized in item["id"].lower() or normalized in item["title"].lower():
             return item["href"]
     raise ValueError(f"No Vantor event matched {event!r}.")
@@ -97,21 +108,31 @@ def _collection_item_urls(collection_url: str) -> list[str]:
     return urls
 
 
-def _fetch_items(collection_url: str) -> list[dict[str, Any]]:
-    """Fetch all STAC items for a collection."""
-    items = []
+def _fetch_items(
+    collection_url: str,
+) -> tuple[list[dict[str, Any]], int, str | None]:
+    """Fetch all STAC items for a collection.
+
+    Returns the items list along with the count of item URLs that failed to
+    fetch and the last error message so callers can surface partial results.
+    """
+    items: list[dict[str, Any]] = []
     seen: set[str] = set()
+    failures = 0
+    last_error: str | None = None
     for item_url in _collection_item_urls(collection_url):
         try:
             item = _fetch_json(item_url)
-        except Exception:
+        except (URLError, json.JSONDecodeError, ValueError) as exc:
+            failures += 1
+            last_error = f"{type(exc).__name__}: {exc}"
             continue
         item_id = str(item.get("id") or item_url)
         if item_id in seen:
             continue
         seen.add(item_id)
         items.append(item)
-    return items
+    return items, failures, last_error
 
 
 def _bbox_intersects(item_bbox: Any, query_bbox: list[float]) -> bool:
@@ -384,7 +405,7 @@ def vantor_tools(
             limit: Maximum number of item summaries to return.
         """
         href = _resolve_event_href(event)
-        items = _fetch_items(href)
+        items, failures, last_error = _fetch_items(href)
         filtered = _filter_items(
             items,
             bbox=bbox,
@@ -404,6 +425,8 @@ def vantor_tools(
             "query_text": query_text or None,
             "count": len(filtered),
             "items": [_item_summary(item) for item in filtered[:max_items]],
+            "fetch_failures": failures,
+            "last_fetch_error": last_error,
         }
 
     @geo_tool(
@@ -422,8 +445,9 @@ def vantor_tools(
         """Display Vantor STAC item footprints in the current QGIS project."""
         if event:
             href = _resolve_event_href(event)
+            fetched, _, _ = _fetch_items(href)
             items = _filter_items(
-                _fetch_items(href),
+                fetched,
                 bbox=bbox,
                 phase=phase,
                 query_text=query_text,
@@ -448,7 +472,8 @@ def vantor_tools(
                             pass
 
             path = os.path.join(
-                tempfile.gettempdir(), "geoagent_vantor_footprints.geojson"
+                tempfile.gettempdir(),
+                f"geoagent_vantor_footprints_{uuid.uuid4().hex}.geojson",
             )
             feature_count = _write_footprints_geojson(items, path)
             if feature_count == 0:
@@ -510,7 +535,7 @@ def vantor_tools(
         if not href:
             items = list(state.get("last_search_items") or [])
             if event:
-                items = _fetch_items(_resolve_event_href(event))
+                items, _, _ = _fetch_items(_resolve_event_href(event))
             item = _find_item_by_id(items, item_id)
             if item is None:
                 return {
@@ -529,7 +554,8 @@ def vantor_tools(
             }
         name = (
             layer_name
-            or (str(item.get("id")) if item else os.path.basename(href))
+            or (item.get("id") if item else None)
+            or os.path.basename(href)
             or "Vantor COG"
         )
         qgis_uri = _qgis_raster_uri(href)

--- a/geoagent/tools/vantor.py
+++ b/geoagent/tools/vantor.py
@@ -1,0 +1,610 @@
+"""Tool adapters for the QGIS Vantor plugin.
+
+The tools read the public Vantor Open Data static STAC catalog directly and
+avoid importing QGIS or the Vantor plugin at module import time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any, Optional
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+from geoagent.tools.stac import (
+    _bounded_limit,
+    _canvas_extent_to_wgs84_bbox,
+    _coerce_bbox,
+    _configure_gdal_for_remote_cog,
+    _qgis_raster_uri,
+    _queue_qgis_raster_load,
+    _zoom_to_qgis_layer,
+)
+
+VANTOR_CATALOG_URL = "https://vantor-opendata.s3.amazonaws.com/events/catalog.json"
+VANTOR_HTTP_TIMEOUT = 30
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    """Fetch and parse JSON from the Vantor static STAC catalog."""
+    req = Request(url, headers={"User-Agent": "GeoAgent-Vantor/1.0"})
+    with urlopen(req, timeout=VANTOR_HTTP_TIMEOUT) as response:  # nosec B310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _resolve_href(base_url: str, href: str) -> str:
+    """Resolve a STAC href against its parent document URL."""
+    if href.startswith(("http://", "https://")):
+        return href
+    return urljoin(base_url, href)
+
+
+def _event_id_from_href(href: str) -> str:
+    """Return a readable event identifier from a collection URL."""
+    parts = [part for part in href.rstrip("/").split("/") if part]
+    if len(parts) >= 2 and parts[-1].lower() == "collection.json":
+        return parts[-2]
+    return parts[-1] if parts else href
+
+
+def _catalog_events() -> list[dict[str, str]]:
+    """Return event collection links from the Vantor root catalog."""
+    catalog = _fetch_json(VANTOR_CATALOG_URL)
+    events: list[dict[str, str]] = []
+    for link in catalog.get("links", []):
+        if link.get("rel") != "child" or not link.get("href"):
+            continue
+        href = _resolve_href(VANTOR_CATALOG_URL, str(link["href"]))
+        fallback = _event_id_from_href(href)
+        title = str(link.get("title") or fallback)
+        events.append({"id": fallback, "title": title, "href": href})
+    return events
+
+
+def _resolve_event_href(event: str) -> str:
+    """Resolve an event id, title, or collection URL to a collection href."""
+    value = str(event or "").strip()
+    if value.startswith(("http://", "https://")):
+        return value
+    if not value:
+        raise ValueError("event is required.")
+
+    normalized = value.lower()
+    for item in _catalog_events():
+        if normalized in {
+            item["id"].lower(),
+            item["title"].lower(),
+            os.path.basename(item["href"]).lower(),
+        }:
+            return item["href"]
+    for item in _catalog_events():
+        if normalized in item["id"].lower() or normalized in item["title"].lower():
+            return item["href"]
+    raise ValueError(f"No Vantor event matched {event!r}.")
+
+
+def _collection_item_urls(collection_url: str) -> list[str]:
+    """Return absolute item URLs linked from a Vantor collection."""
+    collection = _fetch_json(collection_url)
+    urls = []
+    for link in collection.get("links", []):
+        if link.get("rel") == "item" and link.get("href"):
+            urls.append(_resolve_href(collection_url, str(link["href"])))
+    return urls
+
+
+def _fetch_items(collection_url: str) -> list[dict[str, Any]]:
+    """Fetch all STAC items for a collection."""
+    items = []
+    seen: set[str] = set()
+    for item_url in _collection_item_urls(collection_url):
+        try:
+            item = _fetch_json(item_url)
+        except Exception:
+            continue
+        item_id = str(item.get("id") or item_url)
+        if item_id in seen:
+            continue
+        seen.add(item_id)
+        items.append(item)
+    return items
+
+
+def _bbox_intersects(item_bbox: Any, query_bbox: list[float]) -> bool:
+    """Return whether a STAC item bbox intersects a query bbox."""
+    if not item_bbox or len(item_bbox) < 4:
+        return True
+    west, south, east, north = query_bbox
+    item_west, item_south, item_east, item_north = [float(v) for v in item_bbox[:4]]
+    return (
+        item_west <= east
+        and item_east >= west
+        and item_south <= north
+        and item_north >= south
+    )
+
+
+def _phase_matches(item: dict[str, Any], phase: str) -> bool:
+    """Return whether an item matches the requested pre/post event phase."""
+    key = str(phase or "all").strip().lower().replace("-event", "")
+    if key in {"", "all", "any"}:
+        return True
+    item_phase = (
+        str((item.get("properties") or {}).get("phase") or "")
+        .strip()
+        .lower()
+        .replace("-event", "")
+    )
+    return item_phase == key
+
+
+def _asset_keys(item: dict[str, Any]) -> list[str]:
+    """Return sorted asset keys from a STAC item."""
+    assets = item.get("assets") or {}
+    return sorted(str(key) for key in assets.keys())
+
+
+def _asset_url(item: dict[str, Any], asset_key: str | None = None) -> str | None:
+    """Return a preferred raster asset URL from a Vantor STAC item."""
+    assets = item.get("assets") or {}
+    if asset_key and asset_key in assets:
+        href = (assets.get(asset_key) or {}).get("href")
+        return str(href) if href else None
+    if "visual" in assets and (assets["visual"] or {}).get("href"):
+        return str(assets["visual"]["href"])
+    for asset in assets.values():
+        asset_type = str((asset or {}).get("type") or "").lower()
+        href = (asset or {}).get("href")
+        if href and any(token in asset_type for token in ("geotiff", "tiff", "cog")):
+            return str(href)
+    return None
+
+
+def _thumbnail_url(item: dict[str, Any]) -> str | None:
+    """Return an item thumbnail URL when available."""
+    assets = item.get("assets") or {}
+    href = (assets.get("thumbnail") or {}).get("href")
+    return str(href) if href else None
+
+
+def _item_summary(item: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact JSON-friendly Vantor STAC item summary."""
+    props = item.get("properties") or {}
+    return {
+        "id": item.get("id"),
+        "collection": item.get("collection"),
+        "bbox": item.get("bbox"),
+        "datetime": props.get("datetime"),
+        "phase": props.get("phase"),
+        "sensor": props.get("vehicle_name") or props.get("constellation"),
+        "cloud_cover": props.get("eo:cloud_cover") or props.get("cloud_cover"),
+        "pan_gsd": props.get("pan_gsd") or props.get("panchromatic_gsd"),
+        "ms_gsd": props.get("multispectral_gsd"),
+        "off_nadir": props.get("view:off_nadir"),
+        "geometry_type": (item.get("geometry") or {}).get("type"),
+        "asset_keys": _asset_keys(item),
+        "cog_url": _asset_url(item),
+        "thumbnail_url": _thumbnail_url(item),
+    }
+
+
+def _filter_items(
+    items: list[dict[str, Any]],
+    *,
+    bbox: Any = None,
+    phase: str = "all",
+    query_text: str = "",
+) -> list[dict[str, Any]]:
+    """Apply bbox, phase, and text filters to Vantor STAC items."""
+    parsed_bbox = _coerce_bbox(bbox)
+    query = str(query_text or "").strip().lower()
+    out = []
+    for item in items:
+        if parsed_bbox and not _bbox_intersects(item.get("bbox"), parsed_bbox):
+            continue
+        if not _phase_matches(item, phase):
+            continue
+        if query:
+            haystack = " ".join(
+                [
+                    str(item.get("id") or ""),
+                    str(item.get("collection") or ""),
+                    str((item.get("properties") or {}).get("phase") or ""),
+                    str((item.get("properties") or {}).get("vehicle_name") or ""),
+                    " ".join(_asset_keys(item)),
+                ]
+            ).lower()
+            if query not in haystack:
+                continue
+        out.append(item)
+    return out
+
+
+def _project_from_runtime(iface: Any, project: Any | None) -> Any | None:
+    """Return the bound project, iface project, or QGIS singleton project."""
+    if project is not None:
+        return project
+    try:
+        return iface.project()
+    except Exception:
+        pass
+    try:
+        from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+        return QgsProject.instance()
+    except Exception:
+        return None
+
+
+def _write_footprints_geojson(
+    items: list[dict[str, Any]],
+    path: str,
+) -> int:
+    """Write item footprint geometries to GeoJSON and return feature count."""
+    features = []
+    for item in items:
+        geometry = item.get("geometry")
+        if not geometry:
+            continue
+        summary = _item_summary(item)
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": geometry,
+                "properties": {
+                    "item_id": summary.get("id"),
+                    "phase": summary.get("phase"),
+                    "datetime": summary.get("datetime"),
+                    "sensor": summary.get("sensor"),
+                    "cloud_cover": summary.get("cloud_cover"),
+                    "cog_url": summary.get("cog_url"),
+                },
+            }
+        )
+    payload = {
+        "type": "FeatureCollection",
+        "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
+        "features": features,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return len(features)
+
+
+def _find_item_by_id(
+    items: list[dict[str, Any]],
+    item_id: str,
+) -> dict[str, Any] | None:
+    """Return a STAC item by exact or substring id match."""
+    value = str(item_id or "").strip().lower()
+    if not value:
+        return None
+    for item in items:
+        if str(item.get("id") or "").lower() == value:
+            return item
+    for item in items:
+        if value in str(item.get("id") or "").lower():
+            return item
+    return None
+
+
+def vantor_tools(
+    iface: Any,
+    project: Optional[Any] = None,
+    plugin: Optional[Any] = None,
+) -> list[Any]:
+    """Return GeoAgent tools for Vantor Open Data workflows in QGIS."""
+    if iface is None:
+        return []
+
+    state: dict[str, Any] = {}
+
+    @geo_tool(
+        category="vantor",
+        name="list_vantor_events",
+        available_in=("full", "fast"),
+    )
+    def list_vantor_events(limit: int = 50) -> dict[str, Any]:
+        """List available Vantor Open Data event collections."""
+        max_events = max(1, int(limit or 50))
+        events = _catalog_events()
+        state["events"] = events
+        return {
+            "success": True,
+            "catalog_url": VANTOR_CATALOG_URL,
+            "count": len(events),
+            "events": events[:max_events],
+        }
+
+    @geo_tool(
+        category="vantor",
+        name="get_vantor_event_info",
+        available_in=("full", "fast"),
+    )
+    def get_vantor_event_info(event: str) -> dict[str, Any]:
+        """Return compact metadata for one Vantor event collection."""
+        href = _resolve_event_href(event)
+        collection = _fetch_json(href)
+        item_count = sum(
+            1 for link in collection.get("links", []) if link.get("rel") == "item"
+        )
+        extent = collection.get("extent") or {}
+        return {
+            "success": True,
+            "event": event,
+            "href": href,
+            "id": collection.get("id") or _event_id_from_href(href),
+            "title": collection.get("title"),
+            "description": collection.get("description"),
+            "item_count": item_count,
+            "extent": extent,
+            "license": collection.get("license"),
+            "keywords": collection.get("keywords") or [],
+        }
+
+    @geo_tool(
+        category="vantor",
+        name="get_current_vantor_search_extent",
+        available_in=("full", "fast"),
+    )
+    def get_current_vantor_search_extent() -> dict[str, Any]:
+        """Return the current QGIS map extent as a Vantor/STAC WGS84 bbox."""
+        if iface is None or not hasattr(iface, "mapCanvas"):
+            return {
+                "success": False,
+                "bbox": None,
+                "crs": None,
+                "reason": "No QGIS interface is bound to this GeoAgent.",
+            }
+
+        def _read_extent() -> dict[str, Any]:
+            return _canvas_extent_to_wgs84_bbox(iface.mapCanvas())
+
+        return run_on_qt_gui_thread(_read_extent)
+
+    @geo_tool(category="vantor", name="search_vantor_items")
+    def search_vantor_items(
+        event: str,
+        bbox: Any = None,
+        phase: str = "all",
+        query_text: str = "",
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        """Search a Vantor event collection by bbox, phase, and text.
+
+        Args:
+            event: Event id, title, or collection URL.
+            bbox: Optional west,south,east,north WGS84 bounding box.
+            phase: One of all, pre-event, post-event, pre, or post.
+            query_text: Optional text filter for item ids, sensors, and assets.
+            limit: Maximum number of item summaries to return.
+        """
+        href = _resolve_event_href(event)
+        items = _fetch_items(href)
+        filtered = _filter_items(
+            items,
+            bbox=bbox,
+            phase=phase,
+            query_text=query_text,
+        )
+        max_items = _bounded_limit(limit, default=10)
+        state["last_event"] = event
+        state["last_event_href"] = href
+        state["last_search_items"] = filtered
+        return {
+            "success": True,
+            "event": event,
+            "event_href": href,
+            "bbox": _coerce_bbox(bbox),
+            "phase": phase,
+            "query_text": query_text or None,
+            "count": len(filtered),
+            "items": [_item_summary(item) for item in filtered[:max_items]],
+        }
+
+    @geo_tool(
+        category="vantor",
+        name="display_vantor_footprints",
+        requires_confirmation=True,
+    )
+    def display_vantor_footprints(
+        event: str = "",
+        bbox: Any = None,
+        phase: str = "all",
+        query_text: str = "",
+        layer_name: str = "Vantor Footprints",
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """Display Vantor STAC item footprints in the current QGIS project."""
+        if event:
+            href = _resolve_event_href(event)
+            items = _filter_items(
+                _fetch_items(href),
+                bbox=bbox,
+                phase=phase,
+                query_text=query_text,
+            )
+        else:
+            href = state.get("last_event_href")
+            items = list(state.get("last_search_items") or [])
+        if not items:
+            return {"success": False, "error": "No Vantor search results available."}
+        items = items[: max(1, int(limit or 100))]
+
+        def _display() -> dict[str, Any]:
+            proj = _project_from_runtime(iface, project)
+            if proj is not None and hasattr(proj, "mapLayersByName"):
+                for existing in proj.mapLayersByName(layer_name):
+                    try:
+                        proj.removeMapLayer(existing.id())
+                    except Exception:
+                        try:
+                            proj.removeMapLayer(existing)
+                        except Exception:
+                            pass
+
+            path = os.path.join(
+                tempfile.gettempdir(), "geoagent_vantor_footprints.geojson"
+            )
+            feature_count = _write_footprints_geojson(items, path)
+            if feature_count == 0:
+                return {"success": False, "error": "No footprint geometries found."}
+
+            layer = None
+            if hasattr(iface, "addVectorLayer"):
+                layer = iface.addVectorLayer(path, layer_name, "ogr")
+            if layer is None and proj is not None:
+                from qgis.core import QgsVectorLayer  # type: ignore[import-not-found]
+
+                layer = QgsVectorLayer(path, layer_name, "ogr")
+                if layer is not None and layer.isValid():
+                    proj.addMapLayer(layer)
+            valid = layer is not None and not (
+                hasattr(layer, "isValid") and not layer.isValid()
+            )
+            if not valid:
+                return {
+                    "success": False,
+                    "error": "Failed to create Vantor footprint layer.",
+                }
+            _zoom_to_qgis_layer(iface, layer)
+            return {
+                "success": True,
+                "event_href": href,
+                "layer_name": layer_name,
+                "feature_count": feature_count,
+                "path": path,
+            }
+
+        return run_on_qt_gui_thread(_display)
+
+    @geo_tool(
+        category="vantor",
+        name="load_vantor_cog",
+        requires_confirmation=True,
+    )
+    def load_vantor_cog(
+        cog_url: str = "",
+        item_id: str = "",
+        event: str = "",
+        asset_key: str = "visual",
+        layer_name: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Load a Vantor COG asset into QGIS.
+
+        Args:
+            cog_url: Direct COG URL. When omitted, ``item_id`` is resolved from
+                the most recent search or the supplied event collection.
+            item_id: Vantor STAC item id to load.
+            event: Optional event id, title, or collection URL used to resolve
+                ``item_id`` when it is not in the most recent search.
+            asset_key: Preferred STAC asset key. Defaults to visual.
+            layer_name: Optional QGIS layer name.
+        """
+        href = str(cog_url or "").strip()
+        item = None
+        if not href:
+            items = list(state.get("last_search_items") or [])
+            if event:
+                items = _fetch_items(_resolve_event_href(event))
+            item = _find_item_by_id(items, item_id)
+            if item is None:
+                return {
+                    "success": False,
+                    "loaded": False,
+                    "error": "No matching Vantor item found. Search first or provide cog_url.",
+                    "item_id": item_id,
+                }
+            href = _asset_url(item, asset_key=asset_key)
+        if not href:
+            return {
+                "success": False,
+                "loaded": False,
+                "error": "No COG or GeoTIFF asset URL found for the requested item.",
+                "item_id": item_id,
+            }
+        name = (
+            layer_name
+            or (str(item.get("id")) if item else os.path.basename(href))
+            or "Vantor COG"
+        )
+        qgis_uri = _qgis_raster_uri(href)
+
+        queued = _queue_qgis_raster_load(iface, qgis_uri, name)
+        if queued is not None:
+            queued["asset_href"] = href
+            queued["item_id"] = item.get("id") if item else item_id or None
+            return queued
+
+        def _load() -> dict[str, Any]:
+            _configure_gdal_for_remote_cog()
+            try:
+                layer = iface.addRasterLayer(qgis_uri, name, "gdal")
+            except TypeError:
+                layer = iface.addRasterLayer(qgis_uri, name)
+            valid = layer is not None and not (
+                hasattr(layer, "isValid") and not layer.isValid()
+            )
+            if valid:
+                zoomed = _zoom_to_qgis_layer(iface, layer)
+                return {
+                    "success": True,
+                    "loaded": True,
+                    "zoomed": zoomed,
+                    "asset_href": href,
+                    "qgis_uri": qgis_uri,
+                    "layer_name": name,
+                    "item_id": item.get("id") if item else item_id or None,
+                }
+            return {
+                "success": False,
+                "loaded": False,
+                "asset_href": href,
+                "qgis_uri": qgis_uri,
+                "layer_name": name,
+                "reason": "QGIS did not accept this Vantor COG as a raster layer.",
+            }
+
+        return run_on_qt_gui_thread(_load)
+
+    @geo_tool(
+        category="vantor",
+        name="open_vantor_panel",
+        available_in=("full", "fast"),
+    )
+    def open_vantor_panel() -> dict[str, Any]:
+        """Open the Vantor plugin panel when a plugin instance is available."""
+        if plugin is None:
+            return {"success": False, "error": "Plugin instance is not available."}
+
+        def _open() -> dict[str, Any]:
+            dock = getattr(plugin, "_main_dock", None)
+            if dock is None and hasattr(plugin, "toggle_main_dock"):
+                plugin.toggle_main_dock()
+                dock = getattr(plugin, "_main_dock", None)
+            if dock is not None:
+                if hasattr(dock, "show"):
+                    dock.show()
+                if hasattr(dock, "raise_"):
+                    dock.raise_()
+                return {"success": True, "opened": True}
+            return {"success": False, "error": "Vantor panel could not be opened."}
+
+        return run_on_qt_gui_thread(_open)
+
+    return [
+        list_vantor_events,
+        get_vantor_event_info,
+        get_current_vantor_search_extent,
+        search_vantor_items,
+        display_vantor_footprints,
+        load_vantor_cog,
+        open_vantor_panel,
+    ]
+
+
+__all__ = ["VANTOR_CATALOG_URL", "vantor_tools"]

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -143,6 +143,7 @@ AGENT_MODES = [
     "NASA OPERA",
     "GEE Data Catalogs",
     "STAC",
+    "Vantor",
 ]
 DEFAULT_AGENT_MODE = "General QGIS"
 PERMISSION_PROFILES = [
@@ -194,6 +195,13 @@ WORKFLOW_PROMPTS = {
             "STAC raster layer in QGIS."
         ),
     ],
+    "Vantor": [
+        "List available Vantor Open Data events and summarize the newest results.",
+        (
+            "Search Vantor imagery for the current map extent and display "
+            "matching footprints."
+        ),
+    ],
 }
 
 
@@ -223,7 +231,13 @@ def _permission_allows_tool(permission_profile, tool_name, meta=None):
         return False
     if profile == "Run processing":
         return True
-    if category in {"whitebox", "nasa_earthdata", "nasa_opera", "gee_data_catalogs"}:
+    if category in {
+        "whitebox",
+        "nasa_earthdata",
+        "nasa_opera",
+        "gee_data_catalogs",
+        "vantor",
+    }:
         return profile in {"Run processing", "Execute Scripts", "Trusted auto-approve"}
     if profile == "Edit layers":
         return not destructive and name != "run_processing_algorithm"
@@ -1679,6 +1693,7 @@ class ChatWorker(QThread):
                 "NASA OPERA": "for_nasa_opera",
                 "GEE Data Catalogs": "for_gee_data_catalogs",
                 "STAC": "for_stac",
+                "Vantor": "for_vantor",
             }.get(self.agent_mode, "for_qgis")
             factory = getattr(geoagent, factory_name)
             kwargs = {
@@ -2609,6 +2624,7 @@ class ChatDockWidget(QDockWidget):
                 "include_nasa_opera": mode == "NASA OPERA",
                 "include_gee_data_catalogs": mode == "GEE Data Catalogs",
                 "include_stac": mode == "STAC",
+                "include_vantor": mode == "Vantor",
                 "permission_profile": profile,
                 "fast": self.fast_check.isChecked(),
             }

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -552,6 +552,14 @@ def test_agent_mode_load_guard_does_not_seed_prompt() -> None:
     assert dock.prompt_input.toPlainText() == ""
 
 
+def test_vantor_mode_is_available() -> None:
+    """Verify Vantor appears in the OpenGeoAgent agent-mode list."""
+    from open_geoagent.dialogs.chat_dock import AGENT_MODES, WORKFLOW_PROMPTS
+
+    assert "Vantor" in AGENT_MODES
+    assert WORKFLOW_PROMPTS["Vantor"]
+
+
 def test_transcribed_prompt_moves_cursor_to_end() -> None:
     """Transcribed text should leave the prompt cursor at the end."""
     from open_geoagent.dialogs.chat_dock import ChatDockWidget
@@ -617,3 +625,16 @@ def test_execute_scripts_profile_allows_gee_snippet_tool() -> None:
         "Inspect only", "run_gee_python_snippet", _Meta()
     )
     assert _permission_allows_tool("Execute Scripts", "run_gee_python_snippet", _Meta())
+
+
+def test_run_processing_profile_allows_vantor_tools() -> None:
+    """Verify Vantor mode can expose confirmation-gated project tools."""
+
+    class _Meta:
+        category = "vantor"
+        requires_confirmation = True
+        destructive = False
+        long_running = False
+
+    assert not _permission_allows_tool("Inspect only", "load_vantor_cog", _Meta())
+    assert _permission_allows_tool("Run processing", "load_vantor_cog", _Meta())

--- a/qgis_geoagent/tests/test_whitebox_integration.py
+++ b/qgis_geoagent/tests/test_whitebox_integration.py
@@ -32,6 +32,7 @@ def _install_fake_geoagent(monkeypatch, captured):
     module.for_nasa_opera = _factory("for_nasa_opera")
     module.for_gee_data_catalogs = _factory("for_gee_data_catalogs")
     module.for_stac = _factory("for_stac")
+    module.for_vantor = _factory("for_vantor")
     monkeypatch.setitem(sys.modules, "geoagent", module)
     return module
 
@@ -250,3 +251,50 @@ def test_chat_worker_uses_stac_factory(monkeypatch) -> None:
     assert captured["kwargs"]["permission_profile"] == "Trusted auto-approve"
     assert worker.auto_approve_tools is True
     assert "STAC mode" in captured["prompt"]
+
+
+def test_chat_worker_uses_vantor_factory(monkeypatch) -> None:
+    """Vantor mode should use the dedicated GeoAgent Vantor factory."""
+    from open_geoagent.dialogs.chat_dock import ChatWorker
+
+    captured: dict[str, Any] = {}
+
+    class _StubResponse:
+        success = True
+        answer_text = "ok"
+        error_message = ""
+        executed_tools: list = []
+        tool_calls: list = []
+        cancelled_tools: list = []
+        execution_time = 0.0
+
+    class _StubAgent:
+        def chat(self, prompt: str) -> _StubResponse:
+            captured["prompt"] = prompt
+            return _StubResponse()
+
+    captured["agent"] = _StubAgent()
+    _install_fake_geoagent(monkeypatch, captured)
+    monkeypatch.setitem(
+        sys.modules,
+        "qgis.core",
+        types.SimpleNamespace(QgsProject=types.SimpleNamespace(instance=lambda: None)),
+    )
+
+    worker = ChatWorker(
+        iface=object(),
+        prompt="search vantor",
+        provider="anthropic",
+        model_id="claude-x",
+        fast=False,
+        max_tokens=1024,
+        auto_approve_tools=True,
+        agent_mode="Vantor",
+        permission_profile="Run processing",
+    )
+    worker.finished.connect(lambda _payload: None)
+    worker.run()
+
+    assert captured["factory"] == "for_vantor"
+    assert captured["kwargs"]["permission_profile"] == "Run processing"
+    assert captured["prompt"] == "search vantor"

--- a/tests/test_vantor_tools.py
+++ b/tests/test_vantor_tools.py
@@ -1,0 +1,280 @@
+"""Tests for the Vantor GeoAgent tool factory."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from geoagent import for_vantor
+from geoagent.testing import MockQGISIface, MockQGISProject
+from geoagent.tools import vantor_tools
+import geoagent.tools.vantor as vantor
+
+
+class _MockModel:
+    """Tiny model stand-in for GeoAgent factory tests."""
+
+    stateful = False
+
+
+EVENT_URL = "https://example.com/events/flood-2026/collection.json"
+ITEM_1_URL = "https://example.com/events/flood-2026/pre.json"
+ITEM_2_URL = "https://example.com/events/flood-2026/post.json"
+
+
+ROOT_CATALOG = {
+    "links": [
+        {
+            "rel": "child",
+            "href": "https://example.com/events/flood-2026/collection.json",
+            "title": "Flood 2026",
+        }
+    ]
+}
+
+
+COLLECTION = {
+    "id": "flood-2026",
+    "title": "Flood 2026",
+    "description": "Example event",
+    "license": "public-domain",
+    "extent": {
+        "spatial": {"bbox": [[-85.0, 34.0, -83.0, 36.0]]},
+        "temporal": {"interval": [["2026-01-01T00:00:00Z", None]]},
+    },
+    "links": [
+        {"rel": "item", "href": "pre.json"},
+        {"rel": "item", "href": "post.json"},
+    ],
+}
+
+
+ITEM_PRE = {
+    "type": "Feature",
+    "id": "flood-pre",
+    "collection": "flood-2026",
+    "bbox": [-84.9, 34.1, -84.0, 35.0],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-84.9, 34.1],
+                [-84.0, 34.1],
+                [-84.0, 35.0],
+                [-84.9, 35.0],
+                [-84.9, 34.1],
+            ]
+        ],
+    },
+    "properties": {
+        "datetime": "2026-01-01T00:00:00Z",
+        "phase": "pre",
+        "vehicle_name": "WorldView",
+        "eo:cloud_cover": 2.5,
+        "pan_gsd": 0.31,
+    },
+    "assets": {
+        "visual": {
+            "href": "https://example.com/pre.tif",
+            "type": "image/tiff; application=geotiff",
+        },
+        "thumbnail": {"href": "https://example.com/pre.png", "type": "image/png"},
+    },
+}
+
+
+ITEM_POST = {
+    "type": "Feature",
+    "id": "flood-post",
+    "collection": "flood-2026",
+    "bbox": [-83.9, 34.2, -83.1, 35.1],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-83.9, 34.2],
+                [-83.1, 34.2],
+                [-83.1, 35.1],
+                [-83.9, 35.1],
+                [-83.9, 34.2],
+            ]
+        ],
+    },
+    "properties": {
+        "datetime": "2026-01-02T00:00:00Z",
+        "phase": "post",
+        "vehicle_name": "WorldView",
+        "eo:cloud_cover": 8.0,
+    },
+    "assets": {
+        "visual": {
+            "href": "https://example.com/post.tif",
+            "type": "image/tiff; application=geotiff",
+        }
+    },
+}
+
+
+def _install_fake_vantor_fetch(monkeypatch) -> None:
+    """Mock Vantor STAC JSON responses."""
+    payloads = {
+        vantor.VANTOR_CATALOG_URL: ROOT_CATALOG,
+        EVENT_URL: COLLECTION,
+        ITEM_1_URL: ITEM_PRE,
+        ITEM_2_URL: ITEM_POST,
+    }
+
+    def _fake_fetch(url: str):
+        return payloads[url]
+
+    monkeypatch.setattr(vantor, "_fetch_json", _fake_fetch)
+
+
+def test_vantor_module_imports_without_qgis_or_plugin() -> None:
+    """Verify Vantor tools are import-safe outside QGIS."""
+    assert "geoagent.tools.vantor" in sys.modules
+    if "qgis" in sys.modules:
+        pytest.skip("qgis is already imported in this environment.")
+    assert "qgis" not in sys.modules
+    assert "vantor" not in sys.modules
+
+
+def test_vantor_tools_returns_empty_for_none_iface() -> None:
+    """Verify the Vantor factory returns no tools without iface."""
+    assert vantor_tools(None) == []
+
+
+def test_vantor_tools_expose_expected_surface() -> None:
+    """Verify Vantor tool names and confirmation metadata."""
+    tools = {tool.tool_name: tool for tool in vantor_tools(object())}
+
+    assert set(tools) == {
+        "list_vantor_events",
+        "get_vantor_event_info",
+        "get_current_vantor_search_extent",
+        "search_vantor_items",
+        "display_vantor_footprints",
+        "load_vantor_cog",
+        "open_vantor_panel",
+    }
+    assert tools["display_vantor_footprints"]._geoagent_meta.requires_confirmation
+    assert tools["load_vantor_cog"]._geoagent_meta.requires_confirmation
+
+
+def test_vantor_event_listing_and_info(monkeypatch) -> None:
+    """Verify event listing and metadata inspection use static STAC JSON."""
+    _install_fake_vantor_fetch(monkeypatch)
+    tools = {tool.tool_name: tool for tool in vantor_tools(object())}
+
+    events = tools["list_vantor_events"].__wrapped__()
+    info = tools["get_vantor_event_info"].__wrapped__("Flood 2026")
+
+    assert events["success"] is True
+    assert events["count"] == 1
+    assert events["events"][0]["id"] == "flood-2026"
+    assert info["success"] is True
+    assert info["id"] == "flood-2026"
+    assert info["item_count"] == 2
+
+
+def test_search_vantor_items_filters_bbox_phase_and_returns_cog(monkeypatch) -> None:
+    """Verify item search filters bbox/phase and returns compact COG metadata."""
+    _install_fake_vantor_fetch(monkeypatch)
+    tools = {tool.tool_name: tool for tool in vantor_tools(object())}
+
+    result = tools["search_vantor_items"].__wrapped__(
+        "flood-2026",
+        bbox="-85,34,-84,35.5",
+        phase="pre-event",
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["items"][0]["id"] == "flood-pre"
+    assert result["items"][0]["cog_url"] == "https://example.com/pre.tif"
+    assert result["items"][0]["thumbnail_url"] == "https://example.com/pre.png"
+
+
+def test_load_vantor_cog_uses_vsicurl_uri(monkeypatch) -> None:
+    """Verify Vantor COG loading forms a QGIS /vsicurl raster URI."""
+    _install_fake_vantor_fetch(monkeypatch)
+    project = MockQGISProject()
+    iface = MockQGISIface(project)
+    tools = {tool.tool_name: tool for tool in vantor_tools(iface, project)}
+
+    tools["search_vantor_items"].__wrapped__("flood-2026", phase="post")
+    result = tools["load_vantor_cog"].__wrapped__(item_id="flood-post")
+
+    assert result["success"] is True
+    assert result["loaded"] is True
+    assert result["qgis_uri"] == "/vsicurl/https://example.com/post.tif"
+    assert project.mapLayers()["flood-post"].source() == result["qgis_uri"]
+
+
+def test_display_vantor_footprints_adds_geojson_layer(monkeypatch) -> None:
+    """Verify footprint display writes GeoJSON and adds a vector layer."""
+    _install_fake_vantor_fetch(monkeypatch)
+    project = MockQGISProject()
+    iface = MockQGISIface(project)
+    tools = {tool.tool_name: tool for tool in vantor_tools(iface, project)}
+
+    result = tools["display_vantor_footprints"].__wrapped__(
+        event="flood-2026",
+        phase="all",
+        layer_name="Vantor Test Footprints",
+    )
+
+    assert result["success"] is True
+    assert result["feature_count"] == 2
+    assert "Vantor Test Footprints" in project.mapLayers()
+
+
+def test_open_vantor_panel_uses_plugin_instance() -> None:
+    """Verify panel opening delegates to the supplied plugin instance."""
+
+    class _Dock:
+        def __init__(self) -> None:
+            self.shown = False
+            self.raised = False
+
+        def show(self) -> None:
+            self.shown = True
+
+        def raise_(self) -> None:
+            self.raised = True
+
+    class _Plugin:
+        def __init__(self) -> None:
+            self._main_dock = None
+            self.toggled = False
+
+        def toggle_main_dock(self) -> None:
+            self.toggled = True
+            self._main_dock = _Dock()
+
+    plugin = _Plugin()
+    tools = {tool.tool_name: tool for tool in vantor_tools(object(), plugin=plugin)}
+
+    result = tools["open_vantor_panel"].__wrapped__()
+
+    assert result == {"success": True, "opened": True}
+    assert plugin.toggled is True
+    assert plugin._main_dock.shown is True
+    assert plugin._main_dock.raised is True
+
+
+def test_for_vantor_registers_vantor_and_qgis_tools() -> None:
+    """Verify the Vantor factory combines Vantor and QGIS tools."""
+    agent = for_vantor(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    names = set(agent.strands_agent.tool_names)
+
+    assert "list_vantor_events" in names
+    assert "search_vantor_items" in names
+    assert "load_vantor_cog" in names
+    assert "list_project_layers" in names
+    assert agent.context.metadata["integration"] == "vantor"


### PR DESCRIPTION
## Summary
- Add `for_vantor(iface, project=None, plugin=None)` factory and a Vantor tools module exposing the QGIS Vantor plugin's public Open Data STAC catalog (event listing, item search, footprint display, COG loading, panel open).
- Wire the new tool category into `assemble_tools` and `_permission_allows_tool`, gating layer mutations behind user confirmation.
- Update README and `docs/tools.md` with usage notes and add tests in `tests/test_vantor_tools.py` plus QGIS chat dock and integration test updates.

## Test plan
- [ ] `pytest tests/ -q`
- [ ] `pre-commit run --all-files`
- [ ] Manual smoke test: load `for_vantor` in a QGIS session, list events, search items, and confirm footprint and COG layers appear after confirmation.