### PR TITLE
feat: Timelapse tools and for_timelapse factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ CLAUDE.md
 *.zip
 docs/examples/codex_example_map.png
 scripts/
+symbology-style.db

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -37,6 +37,7 @@ from geoagent.core.factory import (
     for_nasa_opera,
     for_qgis,
     for_stac,
+    for_timelapse,
     for_vantor,
     for_whitebox,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "for_nasa_opera",
     "for_qgis",
     "for_stac",
+    "for_timelapse",
     "for_vantor",
     "for_whitebox",
     "geo_tool",

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -21,6 +21,7 @@ from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 from geoagent.tools.stac import stac_tools
+from geoagent.tools.timelapse import timelapse_tools
 from geoagent.tools.vantor import vantor_tools
 from geoagent.tools.whitebox import whitebox_tools
 
@@ -149,6 +150,24 @@ Workflow guidance:
   and require user confirmation.
 - Keep responses concise and include event names, item counts, item ids, phase,
   acquisition date, sensor, and loaded layer names when available.
+"""
+
+TIMELAPSE_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in QGIS for the Timelapse plugin.
+Use the Timelapse tools to inspect available imagery types, get the current
+map extent, initialize Earth Engine, create timelapse GIFs, and open plugin
+panels when the user wants the visual UI.
+
+Workflow guidance:
+- If the user gives no bbox, use the current QGIS map extent.
+- Confirm the imagery type and time window before launching long timelapse
+  generation unless the request already provides them clearly.
+- Prefer Landsat for long historical change, Sentinel-2 for recent optical
+  detail, Sentinel-1 for radar/cloud-tolerant change, NAIP for US aerial
+  detail, MODIS NDVI for vegetation phenology, and GOES for weather animation.
+- Timelapse generation can take a while and requires user confirmation.
+- Keep responses concise and include imagery type, bbox, time window, and
+  output path when available.
 """
 
 QGIS_SYSTEM_PROMPT = """\
@@ -286,6 +305,7 @@ def _permission_allows_tool(permission_profile: str | None, tool: Any) -> bool:
         "nasa_earthdata",
         "nasa_opera",
         "gee_data_catalogs",
+        "timelapse",
         "vantor",
     }:
         return profile in {"Run processing", "Execute Scripts", "Trusted auto-approve"}
@@ -337,12 +357,14 @@ def assemble_tools(
     include_nasa_earthdata: bool = False,
     include_nasa_opera: bool = False,
     include_gee_data_catalogs: bool = False,
+    include_timelapse: bool = False,
     include_vantor: bool = False,
     include_whitebox: bool = False,
     include_stac: bool = False,
     include_image_generation: bool = False,
     nasa_earthdata_plugin: Any | None = None,
     gee_data_catalogs_plugin: Any | None = None,
+    timelapse_plugin: Any | None = None,
     vantor_plugin: Any | None = None,
     fast: bool = False,
     permission_profile: str | None = None,
@@ -388,6 +410,16 @@ def assemble_tools(
         )
         register_all_tools(registry, gee_tools)
         collected.extend(gee_tools)
+    if include_timelapse:
+        timelapse_tool_list = _filter_by_imports(
+            timelapse_tools(
+                context.qgis_iface,
+                context.qgis_project,
+                plugin=timelapse_plugin,
+            )
+        )
+        register_all_tools(registry, timelapse_tool_list)
+        collected.extend(timelapse_tool_list)
     if include_vantor:
         vantor_tool_list = _filter_by_imports(
             vantor_tools(
@@ -807,6 +839,63 @@ def for_vantor(
     )
 
 
+def for_timelapse(
+    iface: Any,
+    project: Any = None,
+    *,
+    plugin: Any | None = None,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+    include_qgis: bool = True,
+    permission_profile: str | None = None,
+) -> GeoAgent:
+    """Bind an agent to the QGIS Timelapse plugin runtime.
+
+    The factory exposes native Timelapse tools and, by default, the general
+    QGIS map/project tools used for inspection and navigation.
+    """
+    ctx = GeoAgentContext(
+        qgis_iface=iface,
+        qgis_project=project,
+        metadata={
+            "integration": "timelapse",
+            "system_prompt": TIMELAPSE_SYSTEM_PROMPT,
+        },
+    )
+    tools, registry = assemble_tools(
+        context=ctx,
+        include_qgis=include_qgis,
+        include_timelapse=True,
+        include_image_generation=True,
+        timelapse_plugin=plugin,
+        extra_tools=extra_tools,
+        fast=fast,
+        permission_profile=permission_profile,
+    )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+        qgis_safe_mode=True,
+    )
+
+
 def for_whitebox(
     iface: Any,
     project: Any = None,
@@ -924,6 +1013,7 @@ __all__ = [
     "for_nasa_opera",
     "for_qgis",
     "for_stac",
+    "for_timelapse",
     "for_vantor",
     "for_whitebox",
     "register_all_tools",

--- a/geoagent/tools/__init__.py
+++ b/geoagent/tools/__init__.py
@@ -8,6 +8,7 @@ from geoagent.tools.nasa_earthdata import earthdata_tools
 from geoagent.tools.nasa_opera import nasa_opera_tools
 from geoagent.tools.qgis import qgis_tools
 from geoagent.tools.stac import stac_tools
+from geoagent.tools.timelapse import timelapse_tools
 from geoagent.tools.vantor import vantor_tools
 from geoagent.tools.whitebox import whitebox_tools
 
@@ -20,6 +21,7 @@ __all__ = [
     "nasa_opera_tools",
     "qgis_tools",
     "stac_tools",
+    "timelapse_tools",
     "vantor_tools",
     "whitebox_tools",
 ]

--- a/geoagent/tools/timelapse.py
+++ b/geoagent/tools/timelapse.py
@@ -1,0 +1,818 @@
+"""Tool adapters for the QGIS Timelapse plugin.
+
+The module is import-safe outside QGIS and outside the Timelapse plugin. Tool
+bodies resolve QGIS, Earth Engine, and ``timelapse`` plugin modules lazily so
+ordinary GeoAgent imports do not depend on a QGIS runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import uuid
+from datetime import datetime
+from typing import Any
+
+from geoagent.core.decorators import geo_tool
+from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+TIMELAPSE_IMAGERY_TYPES: dict[str, dict[str, Any]] = {
+    "Landsat": {
+        "description": "Long-running optical satellite timelapses from 1984 onward.",
+        "default_start_year": 1990,
+        "default_bands": ["NIR", "Red", "Green"],
+        "default_date_window": ["06-10", "09-20"],
+        "supports_frequency": True,
+    },
+    "Sentinel-2": {
+        "description": "Optical Sentinel-2 surface reflectance timelapses.",
+        "default_start_year": 2018,
+        "default_bands": ["NIR", "Red", "Green"],
+        "default_date_window": ["06-10", "09-20"],
+        "supports_frequency": True,
+    },
+    "Sentinel-1": {
+        "description": "Synthetic aperture radar timelapses using Sentinel-1.",
+        "default_start_year": 2018,
+        "default_bands": ["VV"],
+        "default_date_window": ["01-01", "12-31"],
+        "supports_frequency": True,
+    },
+    "NAIP": {
+        "description": "High-resolution aerial imagery timelapses for the US.",
+        "default_start_year": 2010,
+        "default_bands": ["R", "G", "B"],
+        "supports_frequency": False,
+    },
+    "MODIS NDVI": {
+        "description": "Vegetation index phenology timelapses from MODIS.",
+        "default_start_year": 2010,
+        "default_bands": ["NDVI"],
+        "supports_frequency": False,
+    },
+    "GOES": {
+        "description": "Weather satellite timelapses from GOES imagery.",
+        "default_start_date": "2021-10-24T14:00:00",
+        "default_end_date": "2021-10-25T01:00:00",
+        "default_band_combination": "true_color",
+        "supports_frequency": False,
+    },
+}
+
+
+def _on_gui(fn: Any) -> Any:
+    """Run ``fn`` on the Qt GUI thread when QGIS is available."""
+    return run_on_qt_gui_thread(fn)
+
+
+def _resolve_timelapse_plugin(plugin: Any = None) -> Any:
+    """Return the supplied or installed Timelapse plugin instance, if present."""
+    if plugin is not None:
+        return plugin
+    try:
+        from qgis.utils import plugins  # type: ignore[import-not-found]
+
+        return plugins.get("timelapse") or plugins.get("Timelapse")
+    except Exception:
+        return None
+
+
+def _add_plugin_parent_to_path(plugin: Any = None) -> None:
+    """Ensure the plugin package parent is importable when a plugin is loaded."""
+    resolved = _resolve_timelapse_plugin(plugin)
+    plugin_dir = getattr(resolved, "plugin_dir", None)
+    if not plugin_dir:
+        return
+    parent = os.path.dirname(os.path.abspath(str(plugin_dir)))
+    if parent and parent not in sys.path:
+        sys.path.append(parent)
+
+
+def _ensure_plugin_deps(plugin: Any = None) -> bool:
+    """Ask the plugin to prepare dependencies when it exposes that helper."""
+    resolved = _resolve_timelapse_plugin(plugin)
+    ensure = getattr(resolved, "_ensure_deps", None)
+    if callable(ensure):
+        return bool(_on_gui(ensure))
+    return False
+
+
+def _ensure_timelapse_runtime(core: Any) -> tuple[bool, str]:
+    """Return whether Timelapse core dependencies are importable."""
+    try:
+        from timelapse.core import venv_manager
+
+        venv_manager.ensure_venv_packages_available()
+    except Exception:
+        pass
+
+    try:
+        reload_deps = getattr(core, "reload_dependencies", None)
+        if callable(reload_deps):
+            deps = reload_deps()
+        else:
+            deps = core.check_dependencies()
+    except Exception as exc:
+        return False, f"Could not check Timelapse dependencies: {exc}"
+
+    missing = [name for name, available in deps.items() if not available]
+    if missing:
+        return (
+            False,
+            "Timelapse dependencies are not importable: "
+            f"{', '.join(missing)}. Open the Timelapse settings panel and "
+            "install dependencies.",
+        )
+    return True, ""
+
+
+def _load_timelapse_core(plugin: Any = None) -> Any:
+    """Import the Timelapse core module lazily."""
+    _add_plugin_parent_to_path(plugin)
+    _ensure_plugin_deps(plugin)
+    try:
+        from timelapse.core import timelapse_core
+    except Exception as exc:
+        raise RuntimeError(
+            "Could not import timelapse.core.timelapse_core. Make sure the "
+            "QGIS Timelapse plugin is installed and loaded."
+        ) from exc
+
+    runtime_ready, reason = _ensure_timelapse_runtime(timelapse_core)
+    if not runtime_ready:
+        raise RuntimeError(reason)
+    return timelapse_core
+
+
+def _parse_list(value: Any) -> list[str] | None:
+    """Parse list-like or comma-separated tool input."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def _parse_bbox(bbox: Any) -> list[float] | None:
+    """Parse west,south,east,north bbox input."""
+    if bbox is None or bbox == "":
+        return None
+    if isinstance(bbox, dict):
+        if {"xmin", "ymin", "xmax", "ymax"}.issubset(bbox):
+            values = [bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"]]
+        else:
+            values = [
+                bbox.get("west"),
+                bbox.get("south"),
+                bbox.get("east"),
+                bbox.get("north"),
+            ]
+    elif isinstance(bbox, (list, tuple)):
+        values = list(bbox)
+    else:
+        values = str(bbox).split(",")
+    if len(values) != 4:
+        raise ValueError("bbox must contain west,south,east,north")
+    west, south, east, north = [float(value) for value in values]
+    if west >= east or south >= north:
+        raise ValueError("bbox coordinates must satisfy west < east and south < north")
+    return [west, south, east, north]
+
+
+def _extent_to_list(extent: Any) -> list[float] | None:
+    """Return [west, south, east, north] values from a QGIS-like extent."""
+    if extent is None:
+        return None
+    if isinstance(extent, (list, tuple)) and len(extent) == 4:
+        return [float(value) for value in extent]
+    accessors = ("xMinimum", "yMinimum", "xMaximum", "yMaximum")
+    if all(hasattr(extent, name) for name in accessors):
+        return [float(getattr(extent, name)()) for name in accessors]
+    try:
+        values = list(extent)
+        if len(values) == 4:
+            return [float(value) for value in values]
+    except Exception:
+        pass
+    return None
+
+
+def _canvas_extent_to_wgs84_bbox(canvas: Any) -> dict[str, Any]:
+    """Return the current canvas extent as a WGS84 bbox."""
+    extent = canvas.extent() if hasattr(canvas, "extent") else None
+    raw_bbox = _extent_to_list(extent)
+    if raw_bbox is None:
+        return {
+            "success": False,
+            "bbox": None,
+            "crs": None,
+            "reason": "The QGIS map canvas did not expose an extent.",
+        }
+
+    source_crs = ""
+    if hasattr(canvas, "mapSettings"):
+        try:
+            crs = canvas.mapSettings().destinationCrs()
+            source_crs = crs.authid() if hasattr(crs, "authid") else str(crs)
+        except Exception:
+            source_crs = ""
+
+    if not source_crs or source_crs.upper() in {"EPSG:4326", "OGC:CRS84"}:
+        return {
+            "success": True,
+            "bbox": raw_bbox,
+            "crs": source_crs or "unknown",
+            "source_bbox": raw_bbox,
+            "source_crs": source_crs or "unknown",
+        }
+
+    try:
+        from qgis.core import (  # type: ignore[import-not-found]
+            QgsCoordinateReferenceSystem,
+            QgsCoordinateTransform,
+            QgsProject,
+            QgsRectangle,
+        )
+
+        src = QgsCoordinateReferenceSystem(source_crs)
+        dst = QgsCoordinateReferenceSystem("EPSG:4326")
+        rect = QgsRectangle(*raw_bbox)
+        transform = QgsCoordinateTransform(src, dst, QgsProject.instance())
+        transformed = transform.transformBoundingBox(rect)
+        bbox = _extent_to_list(transformed)
+        if bbox is not None:
+            return {
+                "success": True,
+                "bbox": bbox,
+                "crs": "EPSG:4326",
+                "source_bbox": raw_bbox,
+                "source_crs": source_crs,
+            }
+    except Exception as exc:
+        return {
+            "success": False,
+            "bbox": None,
+            "crs": None,
+            "source_bbox": raw_bbox,
+            "source_crs": source_crs,
+            "reason": (
+                "Could not transform the QGIS canvas extent to EPSG:4326: "
+                f"{type(exc).__name__}: {exc}"
+            ),
+        }
+
+    return {
+        "success": False,
+        "bbox": None,
+        "crs": None,
+        "source_bbox": raw_bbox,
+        "source_crs": source_crs,
+        "reason": "Could not transform the QGIS canvas extent to EPSG:4326.",
+    }
+
+
+def _normalise_imagery_type(imagery_type: str) -> str:
+    """Return a canonical Timelapse imagery type."""
+    key = str(imagery_type or "").strip().lower().replace("_", " ")
+    key = " ".join(key.replace("-", " ").split())
+    aliases = {
+        "landsat": "Landsat",
+        "sentinel 2": "Sentinel-2",
+        "sentinel2": "Sentinel-2",
+        "s2": "Sentinel-2",
+        "sentinel 1": "Sentinel-1",
+        "sentinel1": "Sentinel-1",
+        "s1": "Sentinel-1",
+        "naip": "NAIP",
+        "modis": "MODIS NDVI",
+        "modis ndvi": "MODIS NDVI",
+        "ndvi": "MODIS NDVI",
+        "goes": "GOES",
+    }
+    try:
+        return aliases[key]
+    except KeyError as exc:
+        allowed = ", ".join(TIMELAPSE_IMAGERY_TYPES)
+        raise ValueError(f"Unsupported imagery_type. Choose one of: {allowed}") from exc
+
+
+def _default_output_path(imagery_type: str) -> str:
+    """Return a unique default output GIF path in a dedicated temp directory."""
+    output_dir = os.path.join(tempfile.gettempdir(), "open_geoagent_timelapse")
+    os.makedirs(output_dir, exist_ok=True)
+    name = imagery_type.lower().replace("-", "").replace(" ", "_")
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = uuid.uuid4().hex[:8]
+    return os.path.join(output_dir, f"{name}_timelapse_{stamp}_{suffix}.gif")
+
+
+def _mp4_path_for(output_path: str, create_mp4: bool) -> str | None:
+    """Return the expected MP4 path when MP4 output is requested."""
+    if not create_mp4:
+        return None
+    root, ext = os.path.splitext(output_path)
+    return f"{root}.mp4" if ext.lower() == ".gif" else f"{output_path}.mp4"
+
+
+def _image_artifact_for_output(output_path: str, imagery_type: str) -> dict[str, Any]:
+    """Return transcript-renderable image metadata for a generated GIF."""
+    ext = output_path.rsplit(".", 1)[-1].lower() if "." in output_path else "gif"
+    if ext == "jpeg":
+        ext = "jpg"
+    mime_type = "image/jpeg" if ext == "jpg" else f"image/{ext}"
+    return {
+        "path": output_path,
+        "format": ext,
+        "mime_type": mime_type,
+        "alt": f"{imagery_type} timelapse",
+    }
+
+
+class _FallbackBboxLayer:
+    """Small QGIS-layer-like object for tests and non-QGIS fallbacks."""
+
+    def __init__(self, name: str, bbox: list[float]) -> None:
+        self._name = name
+        self._bbox = tuple(bbox)
+
+    def name(self) -> str:
+        """Return layer name."""
+        return self._name
+
+    def source(self) -> str:
+        """Return a compact bbox source marker."""
+        return ",".join(str(value) for value in self._bbox)
+
+    def type(self) -> str:
+        """Return layer type."""
+        return "vector"
+
+    def extent(self) -> tuple[float, float, float, float]:
+        """Return layer extent."""
+        return self._bbox
+
+    def isValid(self) -> bool:
+        """Return layer validity."""
+        return True
+
+
+def _project_for_bbox_layer(iface: Any, project: Any = None) -> Any:
+    """Return a QGIS project-like object for adding bbox layers."""
+    if project is not None:
+        return project
+    try:
+        candidate = iface.project()
+        if candidate is not None:
+            return candidate
+    except Exception:
+        pass
+    try:
+        from qgis.core import QgsProject  # type: ignore[import-not-found]
+
+        return QgsProject.instance()
+    except Exception:
+        return None
+
+
+def _add_timelapse_bbox_layer(
+    iface: Any,
+    project: Any,
+    bbox: list[float],
+    layer_name: str,
+) -> dict[str, Any]:
+    """Add the timelapse bbox as a polygon layer in QGIS."""
+    west, south, east, north = bbox
+
+    def _run() -> dict[str, Any]:
+        proj = _project_for_bbox_layer(iface, project)
+        if proj is None or not hasattr(proj, "addMapLayer"):
+            return {
+                "success": False,
+                "layer_name": layer_name,
+                "reason": "No QGIS project is available for adding the bbox layer.",
+            }
+
+        try:
+            from qgis.core import (  # type: ignore[import-not-found]
+                QgsFeature,
+                QgsFillSymbol,
+                QgsGeometry,
+                QgsPointXY,
+                QgsVectorLayer,
+            )
+
+            layer = QgsVectorLayer("Polygon?crs=EPSG:4326", layer_name, "memory")
+            if not layer.isValid():
+                return {
+                    "success": False,
+                    "layer_name": layer_name,
+                    "reason": "Could not create bbox memory layer.",
+                }
+            feature = QgsFeature()
+            points = [
+                QgsPointXY(west, south),
+                QgsPointXY(east, south),
+                QgsPointXY(east, north),
+                QgsPointXY(west, north),
+                QgsPointXY(west, south),
+            ]
+            feature.setGeometry(QgsGeometry.fromPolygonXY([points]))
+            provider = layer.dataProvider()
+            provider.addFeatures([feature])
+            layer.updateExtents()
+
+            try:
+                symbol = QgsFillSymbol.createSimple(
+                    {
+                        "color": "255,0,0,20",
+                        "outline_color": "255,0,0,255",
+                        "outline_width": "0.8",
+                    }
+                )
+                layer.renderer().setSymbol(symbol)
+            except Exception:
+                pass
+
+            proj.addMapLayer(layer)
+        except Exception:
+            layer = _FallbackBboxLayer(layer_name, bbox)
+            proj.addMapLayer(layer)
+
+        try:
+            iface.mapCanvas().refresh()
+        except Exception:
+            pass
+        try:
+            canvas = iface.mapCanvas()
+            try:
+                from geoagent.tools.qgis import _transform_bbox_to_canvas_crs
+
+                extent = _transform_bbox_to_canvas_crs(
+                    canvas,
+                    west,
+                    south,
+                    east,
+                    north,
+                    "EPSG:4326",
+                )
+            except Exception:
+                extent = layer.extent()
+            if extent is not None:
+                canvas.setExtent(extent)
+                canvas.refresh()
+        except Exception:
+            pass
+        return {"success": True, "layer_name": layer_name, "bbox": bbox}
+
+    return _on_gui(_run)
+
+
+def _open_plugin_panel(plugin: Any, method_name: str, dock_attr: str) -> dict[str, Any]:
+    """Open a Timelapse plugin dock by delegating to its public toggle method."""
+    if plugin is None:
+        return {
+            "success": False,
+            "opened": False,
+            "reason": "The QGIS Timelapse plugin instance is not available.",
+        }
+    method = getattr(plugin, method_name, None)
+    if not callable(method):
+        return {
+            "success": False,
+            "opened": False,
+            "reason": f"The plugin does not expose {method_name}().",
+        }
+
+    def _run() -> dict[str, Any]:
+        method()
+        dock = getattr(plugin, dock_attr, None)
+        if dock is not None:
+            try:
+                dock.show()
+            except Exception:
+                pass
+            try:
+                dock.raise_()
+            except Exception:
+                pass
+        return {"success": True, "opened": True}
+
+    return _on_gui(_run)
+
+
+def timelapse_tools(
+    iface: Any = None,
+    project: Any = None,
+    *,
+    plugin: Any | None = None,
+) -> list[Any]:
+    """Return Timelapse plugin tools bound to a QGIS interface."""
+    if iface is None:
+        return []
+
+    @geo_tool(
+        category="timelapse",
+        name="list_timelapse_imagery_types",
+        available_in=("full", "fast"),
+    )
+    def list_timelapse_imagery_types() -> dict[str, Any]:
+        """List Timelapse imagery types and their default options."""
+        current_year = datetime.now().year
+        types = []
+        for name, info in TIMELAPSE_IMAGERY_TYPES.items():
+            item = {"name": name, **info}
+            item.setdefault("default_end_year", current_year)
+            types.append(item)
+        return {"success": True, "count": len(types), "imagery_types": types}
+
+    @geo_tool(
+        category="timelapse",
+        name="get_current_timelapse_extent",
+        available_in=("full", "fast"),
+    )
+    def get_current_timelapse_extent() -> dict[str, Any]:
+        """Return the current QGIS map extent as a WGS84 Timelapse bbox."""
+        if not hasattr(iface, "mapCanvas"):
+            return {
+                "success": False,
+                "bbox": None,
+                "crs": None,
+                "reason": "No QGIS map canvas is bound to this GeoAgent.",
+            }
+
+        def _read_extent() -> dict[str, Any]:
+            return _canvas_extent_to_wgs84_bbox(iface.mapCanvas())
+
+        return _on_gui(_read_extent)
+
+    @geo_tool(
+        category="timelapse",
+        name="initialize_timelapse_earth_engine",
+        requires_confirmation=True,
+    )
+    def initialize_timelapse_earth_engine(
+        project_id: str | None = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Initialize Earth Engine for Timelapse generation.
+
+        Args:
+            project_id: Optional Google Cloud project id. When omitted, the
+                Timelapse plugin falls back to QSettings or EE_PROJECT_ID.
+            force: Reinitialize even when the plugin reports EE is initialized.
+        """
+        try:
+            core = _load_timelapse_core(plugin)
+            ok = bool(core.initialize_ee(project=project_id, force=bool(force)))
+            return {
+                "success": ok,
+                "initialized": ok,
+                "project_id": project_id
+                or getattr(core, "get_ee_project", lambda: None)(),
+                "reason": None if ok else "Earth Engine initialization failed.",
+            }
+        except Exception as exc:
+            return {
+                "success": False,
+                "initialized": False,
+                "project_id": project_id,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+    @geo_tool(
+        category="timelapse",
+        name="create_timelapse",
+        requires_confirmation=True,
+        long_running=True,
+    )
+    def create_timelapse(
+        imagery_type: str = "Landsat",
+        bbox: Any = None,
+        output_path: str | None = None,
+        start_year: int | None = None,
+        end_year: int | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        frequency: str = "year",
+        step: int = 1,
+        dimensions: int = 768,
+        fps: int = 5,
+        bands: Any = None,
+        cloud_pct: int = 30,
+        apply_fmask: bool = True,
+        orbit: Any = None,
+        title: str | None = None,
+        add_text: bool = True,
+        font_size: int = 20,
+        font_color: str = "white",
+        add_progress_bar: bool = True,
+        progress_bar_color: str = "white",
+        progress_bar_height: int = 5,
+        create_mp4: bool = False,
+        add_bbox_to_map: bool = True,
+        bbox_layer_name: str | None = None,
+        gee_project: str | None = None,
+        modis_satellite: str = "Terra",
+        modis_band: str = "NDVI",
+        goes_satellite: str = "GOES-19",
+        goes_scan: str = "full_disk",
+        goes_band_combination: str = "true_color",
+        goes_custom_bands: Any = None,
+    ) -> dict[str, Any]:
+        """Create a Timelapse GIF from a bbox or the current QGIS extent.
+
+        Args:
+            imagery_type: Landsat, Sentinel-2, Sentinel-1, NAIP, MODIS NDVI, or GOES.
+            bbox: Optional west,south,east,north WGS84 bbox. Uses current map
+                extent when omitted.
+            output_path: Optional output GIF path.
+            start_year: Optional start year for annual imagery types.
+            end_year: Optional end year for annual imagery types.
+            start_date: MM-DD date window, or ISO datetime for GOES/MODIS.
+            end_date: MM-DD date window, or ISO datetime for GOES/MODIS.
+            frequency: year, quarter, month, or day for supported imagery types.
+            step: Temporal step.
+            dimensions: GIF frame dimensions.
+            fps: Frames per second.
+            bands: Optional band list or comma-separated band names.
+            cloud_pct: Sentinel-2 cloud percentage threshold.
+            apply_fmask: Whether to mask clouds for Landsat/Sentinel-2.
+            orbit: Sentinel-1 orbit list or comma-separated values.
+            create_mp4: Also create MP4 when supported by the plugin core.
+            add_bbox_to_map: Add the timelapse bbox as a QGIS polygon layer.
+            bbox_layer_name: Optional QGIS layer name for the bbox layer.
+        """
+        try:
+            imagery = _normalise_imagery_type(imagery_type)
+            parsed_bbox = _parse_bbox(bbox)
+            if parsed_bbox is None:
+                extent_result = get_current_timelapse_extent.__wrapped__()
+                if not extent_result.get("success"):
+                    return extent_result
+                parsed_bbox = list(extent_result["bbox"])
+
+            core = _load_timelapse_core(plugin)
+            if not core.is_ee_initialized():
+                if not core.initialize_ee(project=gee_project):
+                    return {
+                        "success": False,
+                        "error": "Failed to initialize Earth Engine.",
+                        "imagery_type": imagery,
+                        "bbox": parsed_bbox,
+                    }
+
+            west, south, east, north = parsed_bbox
+            roi = core.bbox_to_ee_geometry(west, south, east, north)
+            output = os.path.abspath(output_path or _default_output_path(imagery))
+            os.makedirs(os.path.dirname(output), exist_ok=True)
+            current_year = datetime.now().year
+            parsed_bands = _parse_list(bands)
+            common = {
+                "roi": roi,
+                "out_gif": output,
+                "dimensions": int(dimensions),
+                "frames_per_second": int(fps),
+                "title": title,
+                "add_text": bool(add_text),
+                "font_size": int(font_size),
+                "font_color": font_color,
+                "add_progress_bar": bool(add_progress_bar),
+                "progress_bar_color": progress_bar_color,
+                "progress_bar_height": int(progress_bar_height),
+                "mp4": bool(create_mp4),
+            }
+
+            if imagery == "NAIP":
+                result = core.create_naip_timelapse(
+                    **common,
+                    start_year=start_year or 2010,
+                    end_year=end_year or current_year,
+                    bands=parsed_bands or ["R", "G", "B"],
+                    step=int(step),
+                )
+            elif imagery == "Sentinel-2":
+                result = core.create_sentinel2_timelapse(
+                    **common,
+                    start_year=start_year or 2018,
+                    end_year=end_year or current_year,
+                    start_date=start_date or "06-10",
+                    end_date=end_date or "09-20",
+                    bands=parsed_bands or ["NIR", "Red", "Green"],
+                    apply_fmask=bool(apply_fmask),
+                    cloud_pct=int(cloud_pct),
+                    frequency=frequency,
+                    step=int(step),
+                )
+            elif imagery == "Sentinel-1":
+                result = core.create_sentinel1_timelapse(
+                    **common,
+                    start_year=start_year or 2018,
+                    end_year=end_year or current_year,
+                    start_date=start_date or "01-01",
+                    end_date=end_date or "12-31",
+                    bands=parsed_bands or ["VV"],
+                    orbit=_parse_list(orbit) or ["ascending", "descending"],
+                    frequency=frequency,
+                    step=int(step),
+                )
+            elif imagery == "Landsat":
+                result = core.create_landsat_timelapse(
+                    **common,
+                    start_year=start_year or 1990,
+                    end_year=end_year or current_year,
+                    start_date=start_date or "06-10",
+                    end_date=end_date or "09-20",
+                    bands=parsed_bands or ["NIR", "Red", "Green"],
+                    apply_fmask=bool(apply_fmask),
+                    frequency=frequency,
+                    step=int(step),
+                )
+            elif imagery == "MODIS NDVI":
+                result = core.create_modis_ndvi_timelapse(
+                    **common,
+                    data=modis_satellite,
+                    band=modis_band,
+                    start_date=start_date or f"{start_year or 2010}-01-01",
+                    end_date=end_date or f"{end_year or current_year}-12-31",
+                )
+            else:
+                result = core.create_goes_timelapse(
+                    **common,
+                    start_date=start_date or "2021-10-24T14:00:00",
+                    end_date=end_date or "2021-10-25T01:00:00",
+                    data=goes_satellite,
+                    scan=goes_scan,
+                    band_combination=goes_band_combination,
+                    custom_bands=_parse_list(goes_custom_bands),
+                )
+
+            result_path = os.path.abspath(str(result or output))
+            bbox_layer = None
+            if add_bbox_to_map:
+                layer_name = (
+                    bbox_layer_name
+                    or f"Timelapse BBOX - {imagery} - {datetime.now():%H%M%S}"
+                )
+                bbox_layer = _add_timelapse_bbox_layer(
+                    iface,
+                    project,
+                    parsed_bbox,
+                    layer_name,
+                )
+            return {
+                "success": True,
+                "imagery_type": imagery,
+                "output_path": result_path,
+                "mp4_path": _mp4_path_for(result_path, bool(create_mp4)),
+                "images": [_image_artifact_for_output(result_path, imagery)],
+                "bbox": parsed_bbox,
+                "bbox_layer": bbox_layer,
+                "start_year": start_year,
+                "end_year": end_year,
+                "start_date": start_date,
+                "end_date": end_date,
+            }
+        except Exception as exc:
+            return {
+                "success": False,
+                "imagery_type": imagery_type,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+    @geo_tool(
+        category="timelapse",
+        name="open_timelapse_panel",
+        requires_confirmation=True,
+    )
+    def open_timelapse_panel() -> dict[str, Any]:
+        """Open the QGIS Timelapse plugin creation panel."""
+        resolved = _resolve_timelapse_plugin(plugin)
+        return _open_plugin_panel(
+            resolved,
+            "toggle_timelapse_dock",
+            "_timelapse_dock",
+        )
+
+    @geo_tool(
+        category="timelapse",
+        name="open_timelapse_settings",
+        requires_confirmation=True,
+    )
+    def open_timelapse_settings() -> dict[str, Any]:
+        """Open the QGIS Timelapse plugin settings panel."""
+        resolved = _resolve_timelapse_plugin(plugin)
+        return _open_plugin_panel(
+            resolved,
+            "toggle_settings_dock",
+            "_settings_dock",
+        )
+
+    return [
+        list_timelapse_imagery_types,
+        get_current_timelapse_extent,
+        initialize_timelapse_earth_engine,
+        create_timelapse,
+        open_timelapse_panel,
+        open_timelapse_settings,
+    ]

--- a/geoagent/tools/timelapse.py
+++ b/geoagent/tools/timelapse.py
@@ -85,8 +85,11 @@ def _add_plugin_parent_to_path(plugin: Any = None) -> None:
     if not plugin_dir:
         return
     parent = os.path.dirname(os.path.abspath(str(plugin_dir)))
-    if parent and parent not in sys.path:
-        sys.path.append(parent)
+    if not parent:
+        return
+    while parent in sys.path:
+        sys.path.remove(parent)
+    sys.path.insert(0, parent)
 
 
 def _ensure_plugin_deps(plugin: Any = None) -> bool:
@@ -401,43 +404,50 @@ def _add_timelapse_bbox_layer(
                 QgsPointXY,
                 QgsVectorLayer,
             )
+        except ImportError:
+            layer = _FallbackBboxLayer(layer_name, bbox)
+            proj.addMapLayer(layer)
+        else:
+            try:
+                layer = QgsVectorLayer("Polygon?crs=EPSG:4326", layer_name, "memory")
+                if not layer.isValid():
+                    return {
+                        "success": False,
+                        "layer_name": layer_name,
+                        "reason": "Could not create bbox memory layer.",
+                    }
+                feature = QgsFeature()
+                points = [
+                    QgsPointXY(west, south),
+                    QgsPointXY(east, south),
+                    QgsPointXY(east, north),
+                    QgsPointXY(west, north),
+                    QgsPointXY(west, south),
+                ]
+                feature.setGeometry(QgsGeometry.fromPolygonXY([points]))
+                provider = layer.dataProvider()
+                provider.addFeatures([feature])
+                layer.updateExtents()
 
-            layer = QgsVectorLayer("Polygon?crs=EPSG:4326", layer_name, "memory")
-            if not layer.isValid():
+                try:
+                    symbol = QgsFillSymbol.createSimple(
+                        {
+                            "color": "255,0,0,20",
+                            "outline_color": "255,0,0,255",
+                            "outline_width": "0.8",
+                        }
+                    )
+                    layer.renderer().setSymbol(symbol)
+                except Exception:
+                    pass
+
+                proj.addMapLayer(layer)
+            except Exception as exc:
                 return {
                     "success": False,
                     "layer_name": layer_name,
-                    "reason": "Could not create bbox memory layer.",
+                    "reason": str(exc),
                 }
-            feature = QgsFeature()
-            points = [
-                QgsPointXY(west, south),
-                QgsPointXY(east, south),
-                QgsPointXY(east, north),
-                QgsPointXY(west, north),
-                QgsPointXY(west, south),
-            ]
-            feature.setGeometry(QgsGeometry.fromPolygonXY([points]))
-            provider = layer.dataProvider()
-            provider.addFeatures([feature])
-            layer.updateExtents()
-
-            try:
-                symbol = QgsFillSymbol.createSimple(
-                    {
-                        "color": "255,0,0,20",
-                        "outline_color": "255,0,0,255",
-                        "outline_width": "0.8",
-                    }
-                )
-                layer.renderer().setSymbol(symbol)
-            except Exception:
-                pass
-
-            proj.addMapLayer(layer)
-        except Exception:
-            layer = _FallbackBboxLayer(layer_name, bbox)
-            proj.addMapLayer(layer)
 
         try:
             iface.mapCanvas().refresh()
@@ -664,7 +674,9 @@ def timelapse_tools(
 
             west, south, east, north = parsed_bbox
             roi = core.bbox_to_ee_geometry(west, south, east, north)
-            output = os.path.abspath(output_path or _default_output_path(imagery))
+            output = os.path.abspath(
+                os.path.expanduser(output_path or _default_output_path(imagery))
+            )
             os.makedirs(os.path.dirname(output), exist_ok=True)
             current_year = datetime.now().year
             parsed_bands = _parse_list(bands)
@@ -747,7 +759,7 @@ def timelapse_tools(
                     custom_bands=_parse_list(goes_custom_bands),
                 )
 
-            result_path = os.path.abspath(str(result or output))
+            result_path = os.path.abspath(os.path.expanduser(str(result or output)))
             bbox_layer = None
             if add_bbox_to_map:
                 layer_name = (

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -1170,6 +1170,7 @@ def _allowed_output_image_roots():
     candidates = [
         Path(tempfile.gettempdir()) / "open_geoagent_outputs",
         Path(tempfile.gettempdir()) / "geoagent_images",
+        Path(tempfile.gettempdir()) / "open_geoagent_timelapse",
     ]
     env_dir = os.environ.get("GEOAGENT_IMAGE_OUTPUT_DIR", "").strip()
     if env_dir:
@@ -1323,6 +1324,8 @@ def _local_image_metadata_from_path(path):
     """Return image metadata for an existing local image path."""
     path = str(path or "").strip().rstrip(".,);]")
     if not path:
+        return None
+    if not _path_under_allowed_output_root(path):
         return None
     try:
         resolved = Path(path).expanduser().resolve()

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -37,6 +37,7 @@ from qgis.PyQt.QtGui import (
     QGuiApplication,
     QIcon,
     QKeySequence,
+    QMovie,
     QPixmap,
     QTextCursor,
 )
@@ -143,6 +144,7 @@ AGENT_MODES = [
     "NASA OPERA",
     "GEE Data Catalogs",
     "STAC",
+    "Timelapse",
     "Vantor",
 ]
 DEFAULT_AGENT_MODE = "General QGIS"
@@ -195,6 +197,16 @@ WORKFLOW_PROMPTS = {
             "STAC raster layer in QGIS."
         ),
     ],
+    "Timelapse": [
+        (
+            "Create a Landsat timelapse for the current map extent from 1990 "
+            "to the present."
+        ),
+        (
+            "List the available timelapse imagery types and recommend one for "
+            "vegetation change."
+        ),
+    ],
     "Vantor": [
         "List available Vantor Open Data events and summarize the newest results.",
         (
@@ -236,6 +248,7 @@ def _permission_allows_tool(permission_profile, tool_name, meta=None):
         "nasa_earthdata",
         "nasa_opera",
         "gee_data_catalogs",
+        "timelapse",
         "vantor",
     }:
         return profile in {"Run processing", "Execute Scripts", "Trusted auto-approve"}
@@ -937,6 +950,39 @@ def _stac_load_asset_snippet(args, result=None):
     return "\n".join(lines)
 
 
+def _timelapse_create_snippet_from_args(args):
+    """Build a QGIS Python Console snippet for a Timelapse generation call."""
+    if not isinstance(args, dict):
+        return ""
+    cleaned = {
+        str(key): value for key, value in args.items() if value not in (None, "")
+    }
+    if not cleaned:
+        return ""
+    arg_lines = []
+    for key, value in sorted(cleaned.items()):
+        arg_lines.append(f"    {key}={_python_literal(value)},")
+    args_block = "\n".join(arg_lines)
+    return f"""from qgis.core import QgsProject
+from qgis.utils import iface
+
+from geoagent.tools.timelapse import timelapse_tools
+
+project = QgsProject.instance()
+tools = {{
+    getattr(tool, "tool_name", getattr(tool, "__name__", "")): tool
+    for tool in timelapse_tools(iface, project)
+}}
+create_timelapse = tools["create_timelapse"]
+create_timelapse_fn = getattr(create_timelapse, "__wrapped__", create_timelapse)
+
+result = create_timelapse_fn(
+{args_block}
+)
+print(result)
+"""
+
+
 def _script_from_tool_args(tool_name, args):
     """Return a copyable script derived from tool arguments alone."""
     if tool_name == "load_gee_dataset":
@@ -950,6 +996,12 @@ def _script_from_tool_args(tool_name, args):
             "kind": "PyQGIS",
             "tool_name": tool_name,
             "code": _stac_load_asset_snippet(args),
+        }
+    if tool_name == "create_timelapse":
+        return {
+            "kind": "Python",
+            "tool_name": tool_name,
+            "code": _timelapse_create_snippet_from_args(args),
         }
     return {}
 
@@ -1264,6 +1316,47 @@ def _images_from_output_text(text):
                 "mime_type": "image/jpeg" if ext == "jpg" else f"image/{ext}",
             }
         )
+    return _dedupe_output_images(images)
+
+
+def _local_image_metadata_from_path(path):
+    """Return image metadata for an existing local image path."""
+    path = str(path or "").strip().rstrip(".,);]")
+    if not path:
+        return None
+    try:
+        resolved = Path(path).expanduser().resolve()
+    except Exception:
+        return None
+    if not resolved.is_file():
+        return None
+    ext = resolved.suffix.lower().lstrip(".")
+    if ext not in {"png", "jpg", "jpeg", "webp", "gif"}:
+        return None
+    if ext == "jpeg":
+        ext = "jpg"
+    return {
+        "path": str(resolved),
+        "format": ext,
+        "mime_type": "image/jpeg" if ext == "jpg" else f"image/{ext}",
+    }
+
+
+def _images_from_trusted_tool_output_text(text, tool_calls):
+    """Extract local image paths from text when a trusted image tool ran."""
+    trusted_tools = {"create_timelapse", "generate_image"}
+    ran_trusted_tool = any(
+        isinstance(call, dict) and str(call.get("name") or "") in trusted_tools
+        for call in tool_calls or []
+    )
+    if not ran_trusted_tool:
+        return []
+
+    images = []
+    for match in OUTPUT_IMAGE_PATH_RE.finditer(str(text or "")):
+        image = _local_image_metadata_from_path(match.group("path"))
+        if image is not None:
+            images.append(image)
     return _dedupe_output_images(images)
 
 
@@ -1693,6 +1786,7 @@ class ChatWorker(QThread):
                 "NASA OPERA": "for_nasa_opera",
                 "GEE Data Catalogs": "for_gee_data_catalogs",
                 "STAC": "for_stac",
+                "Timelapse": "for_timelapse",
                 "Vantor": "for_vantor",
             }.get(self.agent_mode, "for_qgis")
             factory = getattr(geoagent, factory_name)
@@ -2624,6 +2718,7 @@ class ChatDockWidget(QDockWidget):
                 "include_nasa_opera": mode == "NASA OPERA",
                 "include_gee_data_catalogs": mode == "GEE Data Catalogs",
                 "include_stac": mode == "STAC",
+                "include_timelapse": mode == "Timelapse",
                 "include_vantor": mode == "Vantor",
                 "permission_profile": profile,
                 "fast": self.fast_check.isChecked(),
@@ -2853,6 +2948,79 @@ class ChatDockWidget(QDockWidget):
                 f"Could not preview this image:\n\n{path}",
             )
             return
+
+        is_gif = (
+            path.lower().endswith(".gif")
+            or str(image.get("format") or "").lower() == "gif"
+        )
+        movie = None
+        if is_gif:
+            movie = QMovie(path)
+            if movie.isValid():
+                movie.jumpToFrame(0)
+                rect = movie.frameRect()
+                width = rect.width()
+                height = rect.height()
+                if width <= 0 or height <= 0:
+                    first_frame = movie.currentPixmap()
+                    width = first_frame.width()
+                    height = first_frame.height()
+                dialog = QDialog(self)
+                dialog.setWindowTitle(f"GIF Preview ({width} x {height})")
+                available = _screen_for_widget(self).availableGeometry()
+                dialog.resize(
+                    max(480, int(available.width() * 0.75)),
+                    max(360, int(available.height() * 0.75)),
+                )
+
+                layout = QVBoxLayout(dialog)
+                scroll = QScrollArea(dialog)
+                scroll.setWidgetResizable(False)
+                image_label = QLabel()
+                image_label.setAlignment(_qt_value("AlignmentFlag", "AlignCenter"))
+                image_label.setMovie(movie)
+                image_label._opengeoagent_movie = movie
+                scroll.setWidget(image_label)
+                layout.addWidget(scroll)
+                movie.start()
+
+                def save_image():
+                    """Save a copy of the generated GIF file."""
+                    default_name = os.path.basename(path) or "opengeoagent-image.gif"
+                    default_path = os.path.join(os.path.expanduser("~"), default_name)
+                    selected, _selected_filter = QFileDialog.getSaveFileName(
+                        dialog,
+                        "Save Image",
+                        default_path,
+                        "Images (*.png *.jpg *.jpeg *.webp *.gif);;All Files (*)",
+                    )
+                    if not selected:
+                        return
+                    try:
+                        with open(path, "rb") as src, open(selected, "wb") as dst:
+                            dst.write(src.read())
+                    except Exception as exc:
+                        QMessageBox.warning(
+                            dialog,
+                            "OpenGeoAgent",
+                            f"Could not save image:\n\n{exc}",
+                        )
+                        return
+                    self.status_label.setText(f"Saved image to {selected}")
+                    self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
+                button_layout = QHBoxLayout()
+                save_btn = QPushButton("Save Image")
+                save_btn.clicked.connect(save_image)
+                button_layout.addWidget(save_btn)
+                button_layout.addStretch(1)
+                close_btn = QPushButton("Close")
+                close_btn.clicked.connect(dialog.accept)
+                button_layout.addWidget(close_btn)
+                layout.addLayout(button_layout)
+                _exec_dialog(dialog)
+                movie.stop()
+                return
 
         dialog = QDialog(self)
         dialog.setWindowTitle(f"Image Preview ({pixmap.width()} x {pixmap.height()})")
@@ -3615,7 +3783,11 @@ class ChatDockWidget(QDockWidget):
             if details:
                 answer = f"{answer}\n\n" + "\n".join(details)
             output_images = _dedupe_output_images(
-                output_images + _prepare_output_images(_images_from_output_text(answer))
+                output_images
+                + _prepare_output_images(_images_from_output_text(answer))
+                + _prepare_output_images(
+                    _images_from_trusted_tool_output_text(answer, tool_calls)
+                )
             )
             if result.get("streamed") and self._streaming_message_index is not None:
                 self._update_message(

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -24,6 +24,7 @@ from open_geoagent.dialogs.chat_dock import (
     _parse_markdown_transcript,
     _permission_allows_tool,
     _project_history_key,
+    _images_from_trusted_tool_output_text,
 )
 
 
@@ -107,6 +108,23 @@ def test_message_images_html_uses_clickable_thumbnail() -> None:
     assert "/tmp/geoagent_images/cat.png" in html
 
 
+def test_message_images_html_supports_clickable_gif_thumbnail() -> None:
+    """Verify generated GIF output renders as a clickable thumbnail."""
+    html = _message_images_html(
+        [
+            {
+                "path": "/tmp/landsat_timelapse.gif",
+                "format": "gif",
+                "_href": "opengeoagent-image:0",
+            }
+        ]
+    )
+
+    assert "href='opengeoagent-image:0'" in html
+    assert "width='180'" in html
+    assert "/tmp/landsat_timelapse.gif" in html
+
+
 def test_prepare_output_images_writes_model_image_bytes() -> None:
     """Verify model image bytes become transcript-safe local artifacts."""
     prepared = _prepare_output_images(
@@ -139,6 +157,34 @@ def test_images_from_output_text_extracts_generated_path() -> None:
             "mime_type": "image/png",
         }
     ]
+
+
+def test_trusted_tool_output_text_extracts_timelapse_gif(tmp_path) -> None:
+    """Verify Timelapse GIF paths in successful answers become thumbnails."""
+    gif = tmp_path / "landsat_timelapse.gif"
+    gif.write_bytes(b"GIF89a")
+
+    images = _images_from_trusted_tool_output_text(
+        f"Output: {gif}\nElapsed: 46.27s",
+        [{"name": "create_timelapse", "args": {}}],
+    )
+
+    assert images == [
+        {
+            "path": str(gif),
+            "format": "gif",
+            "mime_type": "image/gif",
+        }
+    ]
+
+
+def test_untrusted_output_text_ignores_arbitrary_tmp_gif(tmp_path) -> None:
+    """Verify arbitrary local image paths are not trusted without a tool call."""
+    gif = tmp_path / "landsat_timelapse.gif"
+    gif.write_bytes(b"GIF89a")
+
+    assert _images_from_output_text(f"Output: {gif}") == []
+    assert _images_from_trusted_tool_output_text(f"Output: {gif}", []) == []
 
 
 def test_image_to_png_bytes_serializes_qimage() -> None:
@@ -247,6 +293,34 @@ def test_latest_executable_snippet_builds_signed_stac_loader_from_args() -> None
     assert "href = planetary_computer.sign(href)" in snippet["code"]
     assert "uri = f'/vsicurl/{uri}'" in snippet["code"]
     assert href in snippet["code"]
+
+
+def test_latest_executable_snippet_builds_timelapse_script_from_args() -> None:
+    """Verify Copy Script enables for Timelapse generation calls."""
+    snippet = _latest_executable_snippet(
+        [
+            {
+                "name": "create_timelapse",
+                "args": {
+                    "imagery_type": "Landsat",
+                    "bbox": "-115.45,35.95,-114.90,36.40",
+                    "start_year": 1990,
+                    "end_year": 2026,
+                    "frequency": "year",
+                    "add_bbox_to_map": True,
+                    "bbox_layer_name": "Las Vegas Timelapse BBOX",
+                },
+            }
+        ]
+    )
+
+    assert snippet["kind"] == "Python"
+    assert snippet["tool_name"] == "create_timelapse"
+    assert "from geoagent.tools.timelapse import timelapse_tools" in snippet["code"]
+    assert "imagery_type='Landsat'" in snippet["code"]
+    assert "bbox='-115.45,35.95,-114.90,36.40'" in snippet["code"]
+    assert "start_year=1990" in snippet["code"]
+    assert "create_timelapse_fn(" in snippet["code"]
 
 
 def test_image_model_from_settings_prefers_saved_then_env(monkeypatch) -> None:
@@ -560,6 +634,14 @@ def test_vantor_mode_is_available() -> None:
     assert WORKFLOW_PROMPTS["Vantor"]
 
 
+def test_timelapse_mode_is_available() -> None:
+    """Verify Timelapse appears in the OpenGeoAgent agent-mode list."""
+    from open_geoagent.dialogs.chat_dock import AGENT_MODES, WORKFLOW_PROMPTS
+
+    assert "Timelapse" in AGENT_MODES
+    assert WORKFLOW_PROMPTS["Timelapse"]
+
+
 def test_transcribed_prompt_moves_cursor_to_end() -> None:
     """Transcribed text should leave the prompt cursor at the end."""
     from open_geoagent.dialogs.chat_dock import ChatDockWidget
@@ -638,3 +720,16 @@ def test_run_processing_profile_allows_vantor_tools() -> None:
 
     assert not _permission_allows_tool("Inspect only", "load_vantor_cog", _Meta())
     assert _permission_allows_tool("Run processing", "load_vantor_cog", _Meta())
+
+
+def test_run_processing_profile_allows_timelapse_tools() -> None:
+    """Verify Timelapse mode can expose long-running generation tools."""
+
+    class _Meta:
+        category = "timelapse"
+        requires_confirmation = True
+        destructive = False
+        long_running = True
+
+    assert not _permission_allows_tool("Inspect only", "create_timelapse", _Meta())
+    assert _permission_allows_tool("Run processing", "create_timelapse", _Meta())

--- a/tests/test_timelapse_tools.py
+++ b/tests/test_timelapse_tools.py
@@ -1,0 +1,275 @@
+"""Tests for the Timelapse GeoAgent tool factory."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+
+from geoagent import for_timelapse
+from geoagent.testing import MockQGISIface, MockQGISProject
+from geoagent.tools import timelapse_tools
+import geoagent.tools.timelapse as timelapse
+
+
+class _MockModel:
+    """Tiny model stand-in for GeoAgent factory tests."""
+
+    stateful = False
+
+
+class _FakeTimelapseCore:
+    """Small Timelapse core stand-in for dispatch tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.initialized = True
+
+    def is_ee_initialized(self) -> bool:
+        """Return mock Earth Engine state."""
+        return self.initialized
+
+    def initialize_ee(self, project=None, force=False) -> bool:
+        """Record and report successful Earth Engine initialization."""
+        self.calls.append(("initialize_ee", {"project": project, "force": force}))
+        self.initialized = True
+        return True
+
+    def get_ee_project(self):
+        """Return a fake Earth Engine project id."""
+        return "test-project"
+
+    def bbox_to_ee_geometry(self, west, south, east, north):
+        """Return a JSON-friendly ROI marker."""
+        return ("roi", west, south, east, north)
+
+    def create_landsat_timelapse(self, **kwargs):
+        """Record Landsat timelapse creation."""
+        self.calls.append(("create_landsat_timelapse", kwargs))
+        return kwargs["out_gif"]
+
+
+def test_timelapse_module_imports_without_qgis_or_plugin() -> None:
+    """Verify Timelapse tools are import-safe outside QGIS."""
+    assert "geoagent.tools.timelapse" in sys.modules
+    if "qgis" in sys.modules:
+        pytest.skip("qgis is already imported in this environment.")
+    assert "qgis" not in sys.modules
+    assert "timelapse" not in sys.modules
+
+
+def test_timelapse_tools_returns_empty_for_none_iface() -> None:
+    """Verify the Timelapse factory returns no tools without iface."""
+    assert timelapse_tools(None) == []
+
+
+def test_timelapse_tools_expose_expected_surface() -> None:
+    """Verify Timelapse tool names and confirmation metadata."""
+    tools = {tool.tool_name: tool for tool in timelapse_tools(object())}
+
+    assert set(tools) == {
+        "list_timelapse_imagery_types",
+        "get_current_timelapse_extent",
+        "initialize_timelapse_earth_engine",
+        "create_timelapse",
+        "open_timelapse_panel",
+        "open_timelapse_settings",
+    }
+    assert tools[
+        "initialize_timelapse_earth_engine"
+    ]._geoagent_meta.requires_confirmation
+    assert tools["create_timelapse"]._geoagent_meta.requires_confirmation
+    assert tools["create_timelapse"]._geoagent_meta.long_running
+    assert tools["open_timelapse_panel"]._geoagent_meta.requires_confirmation
+    assert tools["open_timelapse_settings"]._geoagent_meta.requires_confirmation
+
+
+def test_get_current_timelapse_extent_uses_canvas_extent() -> None:
+    """Verify current extent returns a WGS84 bbox from the QGIS canvas."""
+    iface = MockQGISIface()
+    iface.mapCanvas().setExtent((-85.0, 34.0, -83.0, 36.0))
+    tools = {tool.tool_name: tool for tool in timelapse_tools(iface)}
+
+    result = tools["get_current_timelapse_extent"].__wrapped__()
+
+    assert result["success"] is True
+    assert result["bbox"] == [-85.0, 34.0, -83.0, 36.0]
+
+
+def test_initialize_timelapse_earth_engine_uses_core(monkeypatch) -> None:
+    """Verify Earth Engine initialization delegates to Timelapse core."""
+    core = _FakeTimelapseCore()
+    core.initialized = False
+    monkeypatch.setattr(timelapse, "_load_timelapse_core", lambda plugin=None: core)
+    tools = {tool.tool_name: tool for tool in timelapse_tools(object())}
+
+    result = tools["initialize_timelapse_earth_engine"].__wrapped__("project-1")
+
+    assert result["success"] is True
+    assert result["initialized"] is True
+    assert core.calls == [("initialize_ee", {"project": "project-1", "force": False})]
+
+
+def test_load_timelapse_core_continues_when_plugin_gate_is_false(monkeypatch) -> None:
+    """Verify runtime dependency checks, not plugin gate state, decide readiness."""
+    fake_core = types.ModuleType("timelapse.core.timelapse_core")
+    fake_core.reload_dependencies = lambda: {"earthengine-api": True, "Pillow": True}
+
+    fake_venv = types.ModuleType("timelapse.core.venv_manager")
+    fake_venv.ensure_venv_packages_available = lambda: True
+
+    fake_core_package = types.ModuleType("timelapse.core")
+    fake_core_package.timelapse_core = fake_core
+    fake_core_package.venv_manager = fake_venv
+
+    fake_package = types.ModuleType("timelapse")
+    fake_package.core = fake_core_package
+
+    monkeypatch.setitem(sys.modules, "timelapse", fake_package)
+    monkeypatch.setitem(sys.modules, "timelapse.core", fake_core_package)
+    monkeypatch.setitem(sys.modules, "timelapse.core.timelapse_core", fake_core)
+    monkeypatch.setitem(sys.modules, "timelapse.core.venv_manager", fake_venv)
+
+    class _Plugin:
+        plugin_dir = "/tmp/qgis-timelapse-plugin/timelapse"
+
+        def __init__(self) -> None:
+            self.checked = False
+
+        def _ensure_deps(self) -> bool:
+            self.checked = True
+            return False
+
+    plugin = _Plugin()
+
+    assert timelapse._load_timelapse_core(plugin) is fake_core
+    assert plugin.checked is True
+
+
+def test_default_output_path_uses_dedicated_unique_temp_dir() -> None:
+    """Verify default Timelapse outputs do not overwrite earlier GIFs."""
+    first = timelapse._default_output_path("Landsat")
+    second = timelapse._default_output_path("Landsat")
+
+    assert first != second
+    assert Path(first).parent == Path(tempfile.gettempdir()) / "open_geoagent_timelapse"
+    assert Path(second).parent == Path(first).parent
+    assert Path(first).name.startswith("landsat_timelapse_")
+    assert Path(first).suffix == ".gif"
+
+
+def test_create_timelapse_dispatches_to_landsat_core(monkeypatch, tmp_path) -> None:
+    """Verify create_timelapse builds ROI and calls the selected core function."""
+    core = _FakeTimelapseCore()
+    monkeypatch.setattr(timelapse, "_load_timelapse_core", lambda plugin=None: core)
+    output = tmp_path / "landsat.gif"
+    project = MockQGISProject()
+    iface = MockQGISIface(project)
+    tools = {tool.tool_name: tool for tool in timelapse_tools(iface, project)}
+
+    result = tools["create_timelapse"].__wrapped__(
+        imagery_type="Landsat",
+        bbox="-85,34,-83,36",
+        output_path=str(output),
+        start_year=2001,
+        end_year=2003,
+        bands="NIR, Red, Green",
+        create_mp4=True,
+        bbox_layer_name="Test Timelapse BBOX",
+    )
+
+    assert result["success"] is True
+    assert result["output_path"] == str(output)
+    assert result["mp4_path"] == str(Path(tmp_path / "landsat.mp4"))
+    assert result["images"] == [
+        {
+            "path": str(output),
+            "format": "gif",
+            "mime_type": "image/gif",
+            "alt": "Landsat timelapse",
+        }
+    ]
+    assert result["bbox"] == [-85.0, 34.0, -83.0, 36.0]
+    assert result["bbox_layer"] == {
+        "success": True,
+        "layer_name": "Test Timelapse BBOX",
+        "bbox": [-85.0, 34.0, -83.0, 36.0],
+    }
+    assert "Test Timelapse BBOX" in project.mapLayers()
+    assert project.mapLayers()["Test Timelapse BBOX"].extent() == (
+        -85.0,
+        34.0,
+        -83.0,
+        36.0,
+    )
+    assert iface.mapCanvas().extent() == (-85.0, 34.0, -83.0, 36.0)
+    name, kwargs = core.calls[-1]
+    assert name == "create_landsat_timelapse"
+    assert kwargs["roi"] == ("roi", -85.0, 34.0, -83.0, 36.0)
+    assert kwargs["start_year"] == 2001
+    assert kwargs["end_year"] == 2003
+    assert kwargs["bands"] == ["NIR", "Red", "Green"]
+
+
+def test_open_timelapse_panels_use_plugin_instance() -> None:
+    """Verify panel opening delegates to the supplied Timelapse plugin."""
+
+    class _Dock:
+        def __init__(self) -> None:
+            self.shown = False
+            self.raised = False
+
+        def show(self) -> None:
+            self.shown = True
+
+        def raise_(self) -> None:
+            self.raised = True
+
+    class _Plugin:
+        def __init__(self) -> None:
+            self._timelapse_dock = None
+            self._settings_dock = None
+            self.timelapse_toggled = False
+            self.settings_toggled = False
+
+        def toggle_timelapse_dock(self) -> None:
+            self.timelapse_toggled = True
+            self._timelapse_dock = _Dock()
+
+        def toggle_settings_dock(self) -> None:
+            self.settings_toggled = True
+            self._settings_dock = _Dock()
+
+    plugin = _Plugin()
+    tools = {tool.tool_name: tool for tool in timelapse_tools(object(), plugin=plugin)}
+
+    panel_result = tools["open_timelapse_panel"].__wrapped__()
+    settings_result = tools["open_timelapse_settings"].__wrapped__()
+
+    assert panel_result == {"success": True, "opened": True}
+    assert settings_result == {"success": True, "opened": True}
+    assert plugin.timelapse_toggled is True
+    assert plugin.settings_toggled is True
+    assert plugin._timelapse_dock.shown is True
+    assert plugin._timelapse_dock.raised is True
+    assert plugin._settings_dock.shown is True
+    assert plugin._settings_dock.raised is True
+
+
+def test_for_timelapse_registers_timelapse_and_qgis_tools() -> None:
+    """Verify the Timelapse factory combines Timelapse and QGIS tools."""
+    agent = for_timelapse(
+        MockQGISIface(),
+        MockQGISProject(),
+        model=_MockModel(),
+    )
+    names = set(agent.strands_agent.tool_names)
+
+    assert "list_timelapse_imagery_types" in names
+    assert "get_current_timelapse_extent" in names
+    assert "create_timelapse" in names
+    assert "list_project_layers" in names
+    assert agent.context.metadata["integration"] == "timelapse"


### PR DESCRIPTION
## Summary
- Add `geoagent/tools/timelapse.py` with tools to list imagery types, read the current QGIS extent, initialize Earth Engine, create timelapse GIFs, and open Timelapse plugin panels.
- Add `for_timelapse` factory that bundles Timelapse and QGIS map tools, plus a Timelapse agent mode in the OpenGeoAgent chat dock with GIF preview, copyable Python snippet, and a bbox polygon layer.
- Cover the new factory, tool dispatch, snippet builder, and trusted-image extraction with unit tests.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_timelapse_tools.py qgis_geoagent/tests/test_chat_tool_inputs.py -q` (only failures are pre-existing on `main` and unrelated to this change)