### PR TITLE
chore: bump GeoAgent to 1.4.1

### DIFF
--- a/docs/qgis-plugin.md
+++ b/docs/qgis-plugin.md
@@ -39,6 +39,10 @@ Use the settings panel to configure API keys, hosts, model defaults, and
 dependency status. Vision features require a provider and model that support
 image inputs.
 
+## Sample Data
+
+You can download sample data from Source Coop [here](https://data.source.coop/opengeos/geoai/geoagent-sample-data.zip).
+
 ## Chat With QGIS
 
 The chat dock is aware of the current QGIS project and active layer. It can

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.4.0"
+version = "1.4.1"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -76,7 +76,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.4.0"
+current_version = "1.4.1"
 commit = true
 tag = true
 

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -80,11 +80,11 @@ adds its site-packages directory when the plugin loads.
 Manual fallback:
 
 ```bash
-pip install "GeoAgent[providers]>=1.4.0"
-pip install "GeoAgent[stac]>=1.4.0"
-pip install "GeoAgent[whitebox]>=1.4.0"
-pip install "GeoAgent[earthdata,nasa-opera]>=1.4.0"
-pip install "GeoAgent[earthengine]>=1.4.0"
+pip install "GeoAgent[providers]>=1.4.1"
+pip install "GeoAgent[stac]>=1.4.1"
+pip install "GeoAgent[whitebox]>=1.4.1"
+pip install "GeoAgent[earthdata,nasa-opera]>=1.4.1"
+pip install "GeoAgent[earthengine]>=1.4.1"
 ```
 
 GEE Data Catalogs mode also expects the `gee_data_catalogs` Python module from

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -30,7 +30,7 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 # Dependency specs: (import_name, pip_install_name)
 MIN_PYTHON_VERSION = (3, 11)
 CORE_RUNTIME_PACKAGES = [
-    ("geoagent", "GeoAgent[providers]>=1.4.0"),
+    ("geoagent", "GeoAgent[providers]>=1.4.1"),
     ("strands", "strands-agents>=1.37"),
     ("pydantic", "pydantic>=2.0"),
 ]
@@ -663,7 +663,7 @@ def create_venv(venv_dir: str) -> str:
         "This can happen when QGIS bundles Python in a way that prevents\n"
         "standard venv creation.\n\n"
         "You can try installing manually with:\n"
-        '  pip install "GeoAgent[providers]>=1.4.0"\n\n'
+        '  pip install "GeoAgent[providers]>=1.4.1"\n\n'
         "Details:\n" + "\n".join(f"  {d}" for d in details)
     )
 
@@ -805,7 +805,7 @@ class DepsInstallWorker(QThread):
                         False,
                         "pip is not available in the virtual environment.\n"
                         "Please install dependencies manually:\n"
-                        'pip install "GeoAgent[providers]>=1.4.0"',
+                        'pip install "GeoAgent[providers]>=1.4.1"',
                     )
                     return
             self.progress.emit(15, "Package installer ready.")

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -822,7 +822,7 @@ class SettingsDockWidget(QDockWidget):
                 self,
                 "Installation Failed",
                 f"Failed to install dependencies:\n\n{message}\n\n"
-                'Manual fallback: pip install "GeoAgent[providers]>=1.4.0"',
+                'Manual fallback: pip install "GeoAgent[providers]>=1.4.1"',
             )
 
         self._deps_worker = None

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.4.0
+version=1.4.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.4.1 - Patch update for GEE Data Catalogs styling
+        - Raised the plugin dependency guidance to GeoAgent 1.4.1
+
     1.4.0 - Updated GeoAgent package dependency
         - Raised the plugin dependency guidance to GeoAgent 1.4.0
 

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -25,7 +25,7 @@ def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
     monkeypatch.setattr(
         deps_manager,
         "CORE_RUNTIME_PACKAGES",
-        [("geoagent", "GeoAgent[providers]>=1.4.0"), ("strands", "strands-agents")],
+        [("geoagent", "GeoAgent[providers]>=1.4.1"), ("strands", "strands-agents")],
     )
     monkeypatch.setattr(deps_manager, "ensure_venv_packages_available", lambda: True)
 
@@ -49,7 +49,7 @@ def test_required_dependencies_include_core_runtime_packages() -> None:
     """Dependency gate should catch partial GeoAgent installs."""
     from open_geoagent.deps_manager import REQUIRED_PACKAGES
 
-    assert ("geoagent", "GeoAgent[providers]>=1.4.0") in REQUIRED_PACKAGES
+    assert ("geoagent", "GeoAgent[providers]>=1.4.1") in REQUIRED_PACKAGES
     assert ("strands", "strands-agents>=1.37") in REQUIRED_PACKAGES
     assert ("pydantic", "pydantic>=2.0") in REQUIRED_PACKAGES
 


### PR DESCRIPTION
## Summary
- Bump version to 1.4.1 across `geoagent`, `pyproject.toml`, the QGIS plugin metadata/README, and dependency specs.
- Add a Sample Data section to the QGIS plugin docs pointing at the Source Coop download.

## Test plan
- [ ] `pre-commit run --all-files`
- [ ] `pytest tests/ -q`
- [ ] Verify the QGIS plugin reports version 1.4.1 and dependency guidance references `GeoAgent[providers]>=1.4.1`.