### PR TITLE
feat: configurable image generation model and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ wraps Strands with geospatial context, tool metadata, optional package
 adapters, provider configuration, and confirmation hooks for operations that
 should not run silently.
 
+[![](https://img.youtube.com/vi/5zkXQlHUsu8/maxresdefault.jpg)](https://youtu.be/5zkXQlHUsu8)
+
 ## Why GeoAgent?
 
 Many geospatial libraries need the same agent features:

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ invent a separate agent framework. GeoAgent provides the shared foundation,
 while packages contribute focused tool adapters for their own objects and
 workflows.
 
+[![](https://img.youtube.com/vi/5zkXQlHUsu8/maxresdefault.jpg)](https://youtu.be/5zkXQlHUsu8)
+
 ## What GeoAgent Provides
 
 - A `GeoAgent` facade around a Strands `Agent`.

--- a/docs/qgis-plugin.md
+++ b/docs/qgis-plugin.md
@@ -43,6 +43,10 @@ image inputs.
 
 You can download sample data from Source Coop [here](https://data.source.coop/opengeos/geoai/geoagent-sample-data.zip).
 
+## Video Tutorial
+
+[![](https://img.youtube.com/vi/5zkXQlHUsu8/maxresdefault.jpg)](https://youtu.be/5zkXQlHUsu8)
+
 ## Chat With QGIS
 
 The chat dock is aware of the current QGIS project and active layer. It can

--- a/geoagent/tools/images.py
+++ b/geoagent/tools/images.py
@@ -16,6 +16,7 @@ DEFAULT_IMAGE_MODEL = "gpt-image-2"
 FALLBACK_IMAGE_MODEL = "gpt-image-1"
 DEFAULT_IMAGE_SIZE = "1024x1024"
 DEFAULT_IMAGE_QUALITY = "low"
+DEFAULT_IMAGE_TIMEOUT = 180.0
 SUPPORTED_IMAGE_SIZES = {"1024x1024", "1024x1536", "1536x1024", "auto"}
 SUPPORTED_IMAGE_QUALITIES = {"low", "medium", "high", "auto"}
 
@@ -71,6 +72,18 @@ def _is_image_model_permission_error(exc: Exception) -> bool:
     )
 
 
+def _image_timeout() -> float:
+    """Return the image-generation request timeout in seconds."""
+    raw = os.environ.get("GEOAGENT_IMAGE_TIMEOUT", "").strip()
+    if not raw:
+        return DEFAULT_IMAGE_TIMEOUT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return DEFAULT_IMAGE_TIMEOUT
+    return timeout if timeout > 0 else DEFAULT_IMAGE_TIMEOUT
+
+
 def _generate_openai_image(
     client: Any,
     *,
@@ -106,7 +119,7 @@ def image_generation_tools() -> list[Any]:
         prompt: str,
         size: str = DEFAULT_IMAGE_SIZE,
         quality: str = DEFAULT_IMAGE_QUALITY,
-        model: str = DEFAULT_IMAGE_MODEL,
+        model: str = "",
         output_dir: str = "",
     ) -> dict[str, Any]:
         """Generate an image file from a text prompt.
@@ -115,7 +128,8 @@ def image_generation_tools() -> list[Any]:
             prompt: Visual description of the image to generate.
             size: One of 1024x1024, 1024x1536, 1536x1024, or auto.
             quality: One of low, medium, high, or auto.
-            model: OpenAI image model to use. Defaults to gpt-image-2.
+            model: OpenAI image model to use. Defaults to
+                ``GEOAGENT_IMAGE_MODEL`` when set, otherwise gpt-image-2.
             output_dir: Optional directory for the generated image.
 
         Returns:
@@ -141,14 +155,15 @@ def image_generation_tools() -> list[Any]:
         quality = str(quality or DEFAULT_IMAGE_QUALITY).strip()
         if quality not in SUPPORTED_IMAGE_QUALITIES:
             quality = DEFAULT_IMAGE_QUALITY
-        requested_model = (
-            str(model or DEFAULT_IMAGE_MODEL).strip() or DEFAULT_IMAGE_MODEL
-        )
+        configured_model = os.environ.get("GEOAGENT_IMAGE_MODEL", "").strip()
+        requested_model = str(model or configured_model or DEFAULT_IMAGE_MODEL).strip()
+        requested_model = requested_model or DEFAULT_IMAGE_MODEL
         model = requested_model
 
         from openai import OpenAI
 
-        client = OpenAI()
+        timeout = _image_timeout()
+        client = OpenAI(timeout=timeout)
         fallback_reason = ""
         try:
             response = _generate_openai_image(
@@ -172,8 +187,12 @@ def image_generation_tools() -> list[Any]:
             else:
                 return {
                     "success": False,
-                    "error": f"Image generation failed with {model}: {exc}",
+                    "error": (
+                        f"Image generation failed with {model} "
+                        f"within {timeout:g}s: {exc}"
+                    ),
                     "model": model,
+                    "timeout": timeout,
                 }
 
         out_dir = _output_dir(output_dir or None)
@@ -232,6 +251,7 @@ def image_generation_tools() -> list[Any]:
             "requested_model": requested_model,
             "size": size,
             "quality": quality,
+            "timeout": timeout,
             "images": images,
             "path": images[0].get("path", ""),
             "url": images[0].get("url", ""),

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -25,7 +25,8 @@ def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None
             return types.SimpleNamespace(data=[item])
 
     class _Client:
-        def __init__(self) -> None:
+        def __init__(self, **kwargs) -> None:
+            calls["timeout"] = kwargs.get("timeout")
             self.images = _Images()
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -43,6 +44,7 @@ def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None
     assert result["images"][0]["revised_prompt"] == "revised prompt"
     assert calls["model"] == "gpt-image-2"
     assert calls["prompt"] == "orange tabby cat"
+    assert calls["timeout"] == 180.0
     filename = result["images"][0]["path"].split("/")[-1]
     assert (tmp_path / filename).read_bytes() == b"fake-png"
 
@@ -81,7 +83,7 @@ def test_generate_image_falls_back_on_unverified_gpt_image_2(
             return types.SimpleNamespace(data=[item])
 
     class _Client:
-        def __init__(self) -> None:
+        def __init__(self, **kwargs) -> None:
             self.images = _Images()
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -95,3 +97,40 @@ def test_generate_image_falls_back_on_unverified_gpt_image_2(
     assert result["model"] == "gpt-image-1"
     assert "not verified" in result["fallback_reason"]
     assert models == ["gpt-image-2", "gpt-image-1"]
+
+
+def test_generate_image_uses_configured_model_and_timeout(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify QGIS image settings can steer direct tool defaults."""
+    image_payload = base64.b64encode(b"configured-png").decode("ascii")
+    calls = {}
+
+    class _Images:
+        def generate(self, **kwargs):
+            calls.update(kwargs)
+            item = types.SimpleNamespace(
+                b64_json=image_payload,
+                revised_prompt="configured prompt",
+                url=None,
+            )
+            return types.SimpleNamespace(data=[item])
+
+    class _Client:
+        def __init__(self, **kwargs) -> None:
+            calls["timeout"] = kwargs.get("timeout")
+            self.images = _Images()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("GEOAGENT_IMAGE_MODEL", "gpt-image-1")
+    monkeypatch.setenv("GEOAGENT_IMAGE_TIMEOUT", "5")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))
+
+    tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
+    result = tool.__wrapped__("satellite image of seattle", output_dir=str(tmp_path))
+
+    assert result["success"] is True
+    assert result["model"] == "gpt-image-1"
+    assert result["timeout"] == 5.0
+    assert calls["model"] == "gpt-image-1"
+    assert calls["timeout"] == 5.0


### PR DESCRIPTION
## Summary
- Honor `GEOAGENT_IMAGE_MODEL` and `GEOAGENT_IMAGE_TIMEOUT` so the `generate_image` tool can be steered without code changes, and surface the timeout in error messages and the success payload.
- Add a YouTube walkthrough link to the README, docs landing page, and QGIS plugin guide.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_image_tools.py -q`