### PR TITLE
feat: Solara map workspace UI with provider controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,18 @@ agent = for_anymap(m)
 agent.chat("Change the basemap and list the current layers.")
 ```
 
+Launch the browser workspace:
+
+```bash
+pip install "GeoAgent[ui,anymap,openai]"
+geoagent ui
+```
+
+The Solara UI opens directly to a map chat workspace with provider/model
+controls, fast mode, session chat history, compact tool-call results, and a
+conservative confirmation policy. Confirmation-required tools are denied by
+default unless you enable auto-approve in the UI.
+
 Use GeoAgent inside QGIS:
 
 ```python

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,30 +1,63 @@
 # Web UI
 
-GeoAgent includes a Solara-based chat interface for interactive geospatial analysis with a persistent, interactive map.
+GeoAgent includes a Solara-based browser workspace for map-bound chat. The UI
+creates a persistent live map for the current browser session, binds it to a
+GeoAgent, and lets you control the provider, model, fast mode, and confirmation
+policy from the page.
 
 ## Quick Start
 
-```bash
-# Install UI dependencies
-pip install "geoagent[ui]"
+Install the UI dependency plus at least one web map backend:
 
-# Launch the UI
+```bash
+pip install "GeoAgent[ui,anymap,openai]"
+```
+
+`anymap` is preferred. If it is not installed, the UI tries `leafmap`:
+
+```bash
+pip install "GeoAgent[ui,leafmap,openai]"
+```
+
+Launch the UI:
+
+```bash
 geoagent ui
 ```
 
-Or run directly:
+Or run Solara directly:
 
 ```bash
 solara run geoagent/ui/pages
 ```
 
-## Features
+## Workspace
 
-- **Persistent map** — layers accumulate across queries on the same interactive MapLibre map
-- **Native widget rendering** — full bidirectional map interaction (zoom, pan, click)
-- **Chat interface** — type natural language queries with real-time status updates
-- **Provider selection** — switch between OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, or LiteLLM
-- **Generated code** — toggle code display for transparency
+The first screen is the chat-and-map workspace. It includes:
+
+- a persistent interactive map where layers accumulate across prompts;
+- provider and model controls for OpenAI, ChatGPT/Codex OAuth, Anthropic,
+  Google Gemini, Bedrock, LiteLLM, and Ollama;
+- a fast-mode toggle for lower-latency map-control prompts;
+- an auto-approve toggle for confirmation-required tools;
+- chat history for the current browser session;
+- executed tool names, cancelled tool names, and compact tool-call results.
+
+The MVP uses non-streaming `agent.chat(...)` calls. Provider credentials are
+still configured through the same environment variables used by the Python API,
+such as `OPENAI_API_KEY`, `OPENAI_CODEX_ACCESS_TOKEN`, `ANTHROPIC_API_KEY`,
+`GEMINI_API_KEY`, `LITELLM_API_KEY`, `OLLAMA_HOST`, or AWS credentials for
+Bedrock.
+
+## Safety
+
+The web UI denies confirmation-required tools by default. This means requests
+that remove layers, clear layers, save maps, or run other gated actions will be
+cancelled unless you enable **Auto-approve confirmation tools**.
+
+Use auto-approve only for trusted sessions. It applies to the current UI
+session and allows GeoAgent to execute tools marked as confirmation-required,
+destructive, or long-running.
 
 ## Python API
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -25,11 +25,16 @@ Launch the UI:
 geoagent ui
 ```
 
-Or run Solara directly:
+Or run Solara directly. The UI's pages directory is shipped inside the
+installed `geoagent` package, so resolve it dynamically rather than relying on
+a relative path that only exists in a source checkout:
 
 ```bash
-solara run geoagent/ui/pages
+solara run "$(python -c 'from geoagent.ui import PAGES_DIR; print(PAGES_DIR)')"
 ```
+
+If you are working from a source checkout you can also run
+`solara run geoagent/ui/pages` directly from the repository root.
 
 ## Workspace
 

--- a/geoagent/ui/app.py
+++ b/geoagent/ui/app.py
@@ -1,0 +1,153 @@
+"""Runtime helpers for the Solara GeoAgent web UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from geoagent import (
+    GeoAgent,
+    GeoAgentConfig,
+    auto_approve_all,
+    auto_approve_safe_only,
+)
+from geoagent.core.safety import ConfirmCallback, ConfirmRequest
+
+PROVIDER_NAMES: tuple[str, ...] = (
+    "openai-codex",
+    "openai",
+    "anthropic",
+    "gemini",
+    "bedrock",
+    "litellm",
+    "ollama",
+)
+
+DEFAULT_MODEL_BY_PROVIDER: dict[str, str] = {
+    "openai-codex": "gpt-5.5",
+    "openai": "gpt-5.5",
+    "anthropic": "claude-sonnet-4-6",
+    "gemini": "gemini-3.1-pro-preview",
+    "bedrock": "us.anthropic.claude-sonnet-4-6",
+    "litellm": "openai/gpt-5.5",
+    "ollama": "qwen3.5:4b",
+}
+
+
+@dataclass
+class UiMapBinding:
+    """A map object and the GeoAgent factory needed to bind it."""
+
+    map_obj: Any
+    map_library: str
+    factory: Callable[..., GeoAgent]
+
+
+def default_model_for_provider(provider: str | None) -> str:
+    """Return the UI's default model id for a provider."""
+    return DEFAULT_MODEL_BY_PROVIDER.get(str(provider or ""), "")
+
+
+def confirmation_callback(auto_approve: bool) -> ConfirmCallback:
+    """Return the confirmation policy selected in the UI."""
+    return auto_approve_all if auto_approve else auto_approve_safe_only
+
+
+def confirmation_preview(auto_approve: bool, tool_name: str = "preview") -> bool:
+    """Return whether the current confirmation setting would approve a tool."""
+    callback = confirmation_callback(auto_approve)
+    return callback(ConfirmRequest(tool_name=tool_name, args={}))
+
+
+def _map_from_anymap() -> UiMapBinding:
+    """Create an anymap-backed UI binding."""
+    import anymap
+    from geoagent import for_anymap
+
+    return UiMapBinding(
+        map_obj=anymap.Map(),
+        map_library="anymap",
+        factory=for_anymap,
+    )
+
+
+def _map_from_leafmap() -> UiMapBinding:
+    """Create a leafmap-backed UI binding."""
+    import leafmap
+    from geoagent import for_leafmap
+
+    return UiMapBinding(
+        map_obj=leafmap.Map(),
+        map_library="leafmap",
+        factory=for_leafmap,
+    )
+
+
+def create_ui_map_binding() -> UiMapBinding:
+    """Create the first available web map binding, preferring anymap."""
+    errors: list[str] = []
+    for create in (_map_from_anymap, _map_from_leafmap):
+        try:
+            return create()
+        except Exception as exc:
+            errors.append(f"{create.__name__}: {exc}")
+    details = "; ".join(errors) if errors else "no map libraries were tried"
+    raise RuntimeError(
+        "GeoAgent UI needs a web map package. Install `GeoAgent[anymap,ui]` "
+        "or `GeoAgent[leafmap,ui]` and restart the UI. "
+        f"Details: {details}"
+    )
+
+
+def create_bound_agent(
+    binding: UiMapBinding,
+    *,
+    provider: str,
+    model_id: str | None = None,
+    fast: bool = False,
+    auto_approve: bool = False,
+) -> GeoAgent:
+    """Create a map-bound GeoAgent from current UI controls."""
+    model = (model_id or "").strip() or None
+    config = GeoAgentConfig(
+        provider=provider,  # type: ignore[arg-type]
+        model=model,
+    )
+    return binding.factory(
+        binding.map_obj,
+        config=config,
+        fast=bool(fast),
+        confirm=confirmation_callback(bool(auto_approve)),
+    )
+
+
+def compact_tool_call(call: dict[str, Any], *, max_chars: int = 1200) -> str:
+    """Return a compact human-readable tool-call summary."""
+    name = str(call.get("name") or "tool")
+    args = call.get("args")
+    result = call.get("result")
+    exception = call.get("exception")
+    parts = [name]
+    if args:
+        parts.append(f"args={args}")
+    if exception:
+        parts.append(f"error={exception}")
+    elif result is not None:
+        parts.append(f"result={result}")
+    text = " | ".join(parts)
+    if len(text) > max_chars:
+        return text[: max_chars - 16].rstrip() + " ... [truncated]"
+    return text
+
+
+__all__ = [
+    "DEFAULT_MODEL_BY_PROVIDER",
+    "PROVIDER_NAMES",
+    "UiMapBinding",
+    "compact_tool_call",
+    "confirmation_callback",
+    "confirmation_preview",
+    "create_bound_agent",
+    "create_ui_map_binding",
+    "default_model_for_provider",
+]

--- a/geoagent/ui/app.py
+++ b/geoagent/ui/app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from geoagent import (
     GeoAgent,
@@ -11,6 +11,7 @@ from geoagent import (
     auto_approve_all,
     auto_approve_safe_only,
 )
+from geoagent.core.config import _default_provider_from_env
 from geoagent.core.safety import ConfirmCallback, ConfirmRequest
 
 PROVIDER_NAMES: tuple[str, ...] = (
@@ -32,6 +33,20 @@ DEFAULT_MODEL_BY_PROVIDER: dict[str, str] = {
     "litellm": "openai/gpt-5.5",
     "ollama": "qwen3.5:4b",
 }
+
+MAX_CONTEXT_MESSAGES = 12
+MAX_CONTEXT_CHARS = 12000
+
+
+def default_provider() -> str:
+    """Return the provider id derived from environment for UI initialization.
+
+    Mirrors :func:`geoagent.core.config._default_provider_from_env` so the UI
+    starts on a provider whose credentials are already configured instead of
+    forcing the user onto the package-wide default.
+    """
+    candidate = _default_provider_from_env()
+    return candidate if candidate in PROVIDER_NAMES else PROVIDER_NAMES[0]
 
 
 @dataclass
@@ -121,33 +136,194 @@ def create_bound_agent(
     )
 
 
+def _compact_value(
+    value: Any,
+    *,
+    per_string: int = 200,
+    list_limit: int = 10,
+    dict_limit: int = 20,
+) -> Any:
+    """Shrink a value structurally so its repr stays small.
+
+    Truncates long strings, caps list and dict sizes, and recurses into nested
+    containers so the final stringification cannot accidentally serialize a
+    multi-megabyte tool-call payload.
+    """
+    if isinstance(value, str):
+        if len(value) <= per_string:
+            return value
+        return value[:per_string] + "...[truncated]"
+    if isinstance(value, dict):
+        items = list(value.items())[:dict_limit]
+        compact = {
+            k: _compact_value(
+                v,
+                per_string=per_string,
+                list_limit=list_limit,
+                dict_limit=dict_limit,
+            )
+            for k, v in items
+        }
+        if len(value) > dict_limit:
+            compact["..."] = f"+{len(value) - dict_limit} more keys"
+        return compact
+    if isinstance(value, (list, tuple)):
+        head = [
+            _compact_value(
+                v,
+                per_string=per_string,
+                list_limit=list_limit,
+                dict_limit=dict_limit,
+            )
+            for v in list(value)[:list_limit]
+        ]
+        if len(value) > list_limit:
+            head.append(f"...[+{len(value) - list_limit} more]")
+        return head
+    return value
+
+
 def compact_tool_call(call: dict[str, Any], *, max_chars: int = 1200) -> str:
-    """Return a compact human-readable tool-call summary."""
+    """Return a compact human-readable tool-call summary.
+
+    Args and results are first compacted structurally so a single oversized
+    payload cannot allocate a multi-megabyte intermediate string before the
+    final character cap kicks in.
+    """
     name = str(call.get("name") or "tool")
     args = call.get("args")
     result = call.get("result")
     exception = call.get("exception")
     parts = [name]
     if args:
-        parts.append(f"args={args}")
+        parts.append(f"args={_compact_value(args)}")
     if exception:
-        parts.append(f"error={exception}")
+        parts.append(f"error={_compact_value(exception)}")
     elif result is not None:
-        parts.append(f"result={result}")
+        parts.append(f"result={_compact_value(result)}")
     text = " | ".join(parts)
     if len(text) > max_chars:
         return text[: max_chars - 16].rstrip() + " ... [truncated]"
     return text
 
 
+def build_prompt_with_context(
+    history: Sequence[dict[str, Any]],
+    prompt: str,
+    *,
+    max_messages: int = MAX_CONTEXT_MESSAGES,
+    max_chars: int = MAX_CONTEXT_CHARS,
+) -> str:
+    """Prepend recent transcript so multi-turn requests retain context.
+
+    Mirrors the QGIS chat dock so follow-up turns like "remove the layer you
+    just added" can resolve against earlier messages even though each send
+    creates a fresh agent in the web UI.
+    """
+    history_lines: list[str] = []
+    for msg in list(history)[-max_messages:]:
+        body = str(msg.get("text") or "").strip()
+        if not body:
+            continue
+        role = "User" if msg.get("role") == "user" else "Assistant"
+        history_lines.append(f"{role}: {body}")
+    if not history_lines:
+        return prompt
+    transcript = "\n\n".join(history_lines)
+    if len(transcript) > max_chars:
+        transcript = "[Earlier history truncated]\n" + transcript[-max_chars:]
+    return (
+        "Use the recent conversation history for context. The current user "
+        "request is the authoritative request to answer now.\n\n"
+        f"Recent conversation:\n{transcript}\n\n"
+        f"Current user request:\n{prompt}"
+    )
+
+
+def format_response_message(response: Any) -> dict[str, Any]:
+    """Build the assistant chat-history entry from a GeoAgentResponse."""
+    details: list[str] = []
+    executed = list(getattr(response, "executed_tools", None) or [])
+    if executed:
+        details.append("Executed tools: " + ", ".join(executed))
+    cancelled = list(getattr(response, "cancelled_tools", None) or [])
+    if cancelled:
+        details.append("Cancelled tools: " + ", ".join(cancelled))
+    error_message = getattr(response, "error_message", None)
+    if error_message:
+        details.append(str(error_message))
+    answer_text = getattr(response, "answer_text", "") or ""
+    if answer_text and details:
+        text = answer_text + "\n\n" + "\n".join(details)
+    else:
+        text = answer_text or "\n".join(details) or "No text response."
+    success = bool(getattr(response, "success", True))
+    return {
+        "role": "assistant",
+        "text": text,
+        "status": "ok" if success else "error",
+    }
+
+
+def dispatch_prompt(
+    text: str,
+    *,
+    history: Sequence[dict[str, Any]],
+    binding: "UiMapBinding | None",
+    binding_error: str = "",
+    provider: str,
+    model_id: str | None,
+    fast: bool,
+    auto_approve: bool,
+    create_agent: Callable[..., GeoAgent] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run one UI send and return ``(next_history, tool_calls)``.
+
+    Pure helper extracted from ``WorkspacePage`` so the send pipeline is
+    unit-testable without a Solara render.
+    """
+    factory = create_agent or create_bound_agent
+    next_history: list[dict[str, Any]] = [
+        *history,
+        {"role": "user", "text": text},
+    ]
+    try:
+        if binding is None:
+            raise RuntimeError(binding_error or "Map binding unavailable.")
+        prompt = build_prompt_with_context(history, text)
+        agent = factory(
+            binding,
+            provider=provider,
+            model_id=model_id,
+            fast=fast,
+            auto_approve=auto_approve,
+        )
+        response = agent.chat(prompt)
+        message = format_response_message(response)
+        return [*next_history, message], list(
+            getattr(response, "tool_calls", None) or []
+        )
+    except Exception as exc:
+        return (
+            [*next_history, {"role": "assistant", "text": str(exc), "status": "error"}],
+            [],
+        )
+
+
 __all__ = [
     "DEFAULT_MODEL_BY_PROVIDER",
+    "MAX_CONTEXT_CHARS",
+    "MAX_CONTEXT_MESSAGES",
     "PROVIDER_NAMES",
     "UiMapBinding",
+    "build_prompt_with_context",
     "compact_tool_call",
     "confirmation_callback",
     "confirmation_preview",
     "create_bound_agent",
     "create_ui_map_binding",
     "default_model_for_provider",
+    "default_provider",
+    "dispatch_prompt",
+    "format_response_message",
 ]

--- a/geoagent/ui/pages/00_home.py
+++ b/geoagent/ui/pages/00_home.py
@@ -1,24 +1,5 @@
-"""Solara home page."""
+"""Solara home page for the GeoAgent web workspace."""
 
-import solara
+from geoagent.ui.workspace import WorkspacePage
 
-
-@solara.component
-def Page():
-    """Render the Solara page."""
-    with solara.Column(align="center"):
-        markdown = """
-        ## 🌍 GeoAgent
-
-        An AI agent for geospatial data analysis and visualization.
-
-        **Features:**
-        - Natural language interface for geospatial data workflows
-        - Multi-LLM support (OpenAI, Anthropic, Google Gemini, Ollama, LiteLLM)
-        - Interactive MapLibre maps with layer accumulation
-        - Dynamic catalog discovery across 134+ Planetary Computer collections
-        - Code transparency showing generated Python at each step
-
-        Click **Chat** above to start querying geospatial data.
-        """
-        solara.Markdown(markdown)
+Page = WorkspacePage

--- a/geoagent/ui/pages/01_chat.py
+++ b/geoagent/ui/pages/01_chat.py
@@ -1,30 +1,5 @@
-"""Solara chat page (minimal) — use the Python API for full control.
+"""Solara chat page for the GeoAgent web workspace."""
 
-GeoAgent 1.0 uses Strands Agents. Install ``GeoAgent[ui,leafmap,openai]`` (or
-other provider extra), set API keys, then use :class:`geoagent.GeoAgent` in
-this page or in a notebook.
-"""
+from geoagent.ui.workspace import WorkspacePage
 
-from __future__ import annotations
-
-import solara
-import solara.alias as rv
-
-from geoagent import __version__
-
-
-@solara.component
-def Page():
-    """Render the Solara page."""
-    with solara.AppBarTitle("GeoAgent chat"):
-        pass
-    with solara.Column(align="center"):
-        rv.Markdown(f"# GeoAgent {__version__}")
-        rv.Markdown(
-            "Configure a model provider via environment variables, then "
-            "use `from geoagent import for_leafmap` and `agent.chat(...)` "
-            "from the Python console or a notebook."
-        )
-
-
-__routes__ = ["/", Page]
+Page = WorkspacePage

--- a/geoagent/ui/workspace.py
+++ b/geoagent/ui/workspace.py
@@ -1,0 +1,191 @@
+"""Solara components for the GeoAgent web workspace."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import solara
+
+from geoagent import __version__
+from geoagent.ui.app import (
+    PROVIDER_NAMES,
+    compact_tool_call,
+    create_bound_agent,
+    create_ui_map_binding,
+    default_model_for_provider,
+)
+
+
+def _message_markdown(message: dict[str, Any]) -> str:
+    """Render one chat-history message as Markdown."""
+    role = str(message.get("role") or "assistant").title()
+    status = str(message.get("status") or "")
+    text = str(message.get("text") or "")
+    if status == "error":
+        return f"**{role} error**\n\n{text}"
+    return f"**{role}**\n\n{text}"
+
+
+def _safe_create_binding() -> tuple[Any | None, str]:
+    """Create a map binding without letting render-time import errors escape."""
+    try:
+        return create_ui_map_binding(), ""
+    except Exception as exc:
+        return None, str(exc)
+
+
+@solara.component
+def WorkspacePage() -> None:
+    """Render the map chat workspace."""
+    provider = solara.use_reactive("openai-codex")
+    model_id = solara.use_reactive(default_model_for_provider(provider.value))
+    prompt = solara.use_reactive("")
+    fast = solara.use_reactive(False)
+    auto_approve = solara.use_reactive(False)
+    busy = solara.use_reactive(False)
+    history = solara.use_reactive([])
+    last_tool_calls = solara.use_reactive([])
+    binding_state = solara.use_memo(_safe_create_binding, dependencies=[])
+
+    def _provider_changed(value: str) -> None:
+        provider.set(value)
+        model_id.set(default_model_for_provider(value))
+
+    def _send() -> None:
+        text = prompt.value.strip()
+        if not text or busy.value:
+            return
+        prompt.set("")
+        busy.set(True)
+        last_tool_calls.set([])
+        next_history = [*history.value, {"role": "user", "text": text}]
+        history.set(next_history)
+        try:
+            if not isinstance(binding_state, tuple):
+                raise RuntimeError("Map binding did not initialize correctly.")
+            binding, binding_error = binding_state
+            if binding_error:
+                raise RuntimeError(binding_error)
+            agent = create_bound_agent(
+                binding,
+                provider=provider.value,
+                model_id=model_id.value,
+                fast=fast.value,
+                auto_approve=auto_approve.value,
+            )
+            response = agent.chat(text)
+            last_tool_calls.set(list(response.tool_calls))
+            details: list[str] = []
+            if response.executed_tools:
+                details.append("Executed tools: " + ", ".join(response.executed_tools))
+            if response.cancelled_tools:
+                details.append(
+                    "Cancelled tools: " + ", ".join(response.cancelled_tools)
+                )
+            if response.error_message:
+                details.append(response.error_message)
+            answer = response.answer_text or "\n".join(details) or "No text response."
+            if details and response.answer_text:
+                answer = answer + "\n\n" + "\n".join(details)
+            history.set(
+                [
+                    *next_history,
+                    {
+                        "role": "assistant",
+                        "text": answer,
+                        "status": "error" if not response.success else "ok",
+                    },
+                ]
+            )
+        except Exception as exc:
+            history.set(
+                [
+                    *next_history,
+                    {
+                        "role": "assistant",
+                        "text": str(exc),
+                        "status": "error",
+                    },
+                ]
+            )
+        finally:
+            busy.set(False)
+
+    binding, binding_error = binding_state
+    try:
+        map_obj = binding.map_obj if binding is not None else None
+        map_label = binding.map_library if binding is not None else "unavailable"
+    except Exception as exc:  # pragma: no cover - defensive Solara path
+        map_obj = None
+        map_label = "unavailable"
+        binding_error = str(exc)
+
+    with solara.Column(gap="12px"):
+        solara.Markdown(f"## GeoAgent {__version__}")
+        with solara.Row(gap="12px"):
+            with solara.Column(
+                gap="8px", style={"minWidth": "280px", "maxWidth": "360px"}
+            ):
+                solara.Select(
+                    label="Provider",
+                    values=list(PROVIDER_NAMES),
+                    value=provider.value,
+                    on_value=_provider_changed,
+                )
+                solara.InputText(
+                    label="Model",
+                    value=model_id.value,
+                    on_value=model_id.set,
+                )
+                solara.Checkbox(
+                    label="Fast mode",
+                    value=fast.value,
+                    on_value=fast.set,
+                )
+                solara.Checkbox(
+                    label="Auto-approve confirmation tools",
+                    value=auto_approve.value,
+                    on_value=auto_approve.set,
+                )
+                solara.InputTextArea(
+                    label="Prompt",
+                    value=prompt.value,
+                    on_value=prompt.set,
+                    rows=5,
+                )
+                solara.Button(
+                    "Send",
+                    on_click=_send,
+                    disabled=busy.value or not prompt.value.strip(),
+                    color="primary",
+                )
+                if busy.value:
+                    solara.ProgressLinear()
+                solara.Markdown(
+                    f"Map backend: `{map_label}`. "
+                    "Confirmation-required tools are denied unless auto-approve is enabled."
+                )
+
+            with solara.Column(gap="8px", style={"minWidth": "360px", "flex": "1"}):
+                if binding_error:
+                    solara.Markdown(f"**Map unavailable**\n\n{binding_error}")
+                elif map_obj is not None:
+                    solara.display(map_obj)
+
+                solara.Markdown("### Chat")
+                if not history.value:
+                    solara.Markdown(
+                        "Ask GeoAgent to inspect the map, add layers, change the "
+                        "view, or summarize geospatial data."
+                    )
+                for item in history.value:
+                    with solara.Card():
+                        solara.Markdown(_message_markdown(item))
+
+                if last_tool_calls.value:
+                    solara.Markdown("### Tool Calls")
+                    for call in last_tool_calls.value:
+                        solara.Markdown(f"`{compact_tool_call(call)}`")
+
+
+__all__ = ["WorkspacePage"]

--- a/geoagent/ui/workspace.py
+++ b/geoagent/ui/workspace.py
@@ -10,17 +10,45 @@ from geoagent import __version__
 from geoagent.ui.app import (
     PROVIDER_NAMES,
     compact_tool_call,
-    create_bound_agent,
     create_ui_map_binding,
     default_model_for_provider,
+    default_provider,
+    dispatch_prompt,
 )
 
 
+def _fenced_block(text: str) -> str:
+    """Wrap arbitrary text in a Markdown code fence that survives backticks.
+
+    Uses the smallest run of backticks longer than any backtick run in the
+    text, so user prompts containing ````` characters still render
+    verbatim instead of being interpreted as Markdown.
+    """
+    longest = 0
+    current = 0
+    for ch in text:
+        if ch == "`":
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    fence = "`" * max(3, longest + 1)
+    return f"{fence}\n{text}\n{fence}"
+
+
 def _message_markdown(message: dict[str, Any]) -> str:
-    """Render one chat-history message as Markdown."""
+    """Render one chat-history message as Markdown.
+
+    User text is rendered inside a fenced code block so prompts containing
+    Markdown syntax, links, or raw HTML do not change meaning in the
+    transcript. Assistant messages are rendered as Markdown so tool results
+    keep their formatting.
+    """
     role = str(message.get("role") or "assistant").title()
     status = str(message.get("status") or "")
     text = str(message.get("text") or "")
+    if message.get("role") == "user":
+        return f"**{role}**\n\n{_fenced_block(text)}"
     if status == "error":
         return f"**{role} error**\n\n{text}"
     return f"**{role}**\n\n{text}"
@@ -37,7 +65,7 @@ def _safe_create_binding() -> tuple[Any | None, str]:
 @solara.component
 def WorkspacePage() -> None:
     """Render the map chat workspace."""
-    provider = solara.use_reactive("openai-codex")
+    provider = solara.use_reactive(default_provider())
     model_id = solara.use_reactive(default_model_for_provider(provider.value))
     prompt = solara.use_reactive("")
     fast = solara.use_reactive(False)
@@ -57,57 +85,22 @@ def WorkspacePage() -> None:
             return
         prompt.set("")
         busy.set(True)
-        last_tool_calls.set([])
-        next_history = [*history.value, {"role": "user", "text": text}]
-        history.set(next_history)
         try:
-            if not isinstance(binding_state, tuple):
-                raise RuntimeError("Map binding did not initialize correctly.")
-            binding, binding_error = binding_state
-            if binding_error:
-                raise RuntimeError(binding_error)
-            agent = create_bound_agent(
-                binding,
+            binding_obj, binding_error = (
+                binding_state if isinstance(binding_state, tuple) else (None, "")
+            )
+            new_history, tool_calls = dispatch_prompt(
+                text,
+                history=history.value,
+                binding=binding_obj,
+                binding_error=binding_error,
                 provider=provider.value,
                 model_id=model_id.value,
                 fast=fast.value,
                 auto_approve=auto_approve.value,
             )
-            response = agent.chat(text)
-            last_tool_calls.set(list(response.tool_calls))
-            details: list[str] = []
-            if response.executed_tools:
-                details.append("Executed tools: " + ", ".join(response.executed_tools))
-            if response.cancelled_tools:
-                details.append(
-                    "Cancelled tools: " + ", ".join(response.cancelled_tools)
-                )
-            if response.error_message:
-                details.append(response.error_message)
-            answer = response.answer_text or "\n".join(details) or "No text response."
-            if details and response.answer_text:
-                answer = answer + "\n\n" + "\n".join(details)
-            history.set(
-                [
-                    *next_history,
-                    {
-                        "role": "assistant",
-                        "text": answer,
-                        "status": "error" if not response.success else "ok",
-                    },
-                ]
-            )
-        except Exception as exc:
-            history.set(
-                [
-                    *next_history,
-                    {
-                        "role": "assistant",
-                        "text": str(exc),
-                        "status": "error",
-                    },
-                ]
-            )
+            history.set(new_history)
+            last_tool_calls.set(tool_calls)
         finally:
             busy.set(False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ stac = ["pystac-client>=0.8", "planetary-computer>=1.0"]
 earthdata = ["earthaccess>=0.10"]
 nasa-opera = ["earthaccess>=0.10"]
 whitebox = ["whitebox>=2.3.6"]
-ui = ["solara>=1.35"]
+ui = ["solara>=1.35", "starlette<1.0"]
 qgis = []
 providers = ["GeoAgent[openai,anthropic,gemini,ollama,litellm]"]
 all = [

--- a/tests/test_ui_app.py
+++ b/tests/test_ui_app.py
@@ -119,3 +119,199 @@ def test_solara_pages_import_with_stubbed_solara(monkeypatch) -> None:
 
     assert callable(home.Page)
     assert callable(chat.Page)
+
+
+def test_default_provider_uses_environment(monkeypatch) -> None:
+    """Verify default_provider() reflects the available env credential."""
+    for var in (
+        "OPENAI_API_KEY",
+        "OPENAI_CODEX_ACCESS_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "LITELLM_API_KEY",
+        "LITELLM_MODEL",
+        "LITELLM_BASE_URL",
+        "OLLAMA_HOST",
+        "USE_OLLAMA",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert app.default_provider() == "openai"
+
+    monkeypatch.delenv("OPENAI_API_KEY")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-test")
+    assert app.default_provider() == "anthropic"
+
+
+def test_compact_tool_call_truncates_structurally() -> None:
+    """Verify oversized arg payloads are compacted before stringification."""
+    huge_value = "x" * 100_000
+    call = {
+        "name": "run_pyqgis_script",
+        "args": {"code": huge_value, "extra": list(range(50))},
+        "result": "ok",
+    }
+    out = app.compact_tool_call(call, max_chars=1200)
+    assert "run_pyqgis_script" in out
+    assert "result=ok" in out
+    assert "...[truncated]" in out
+    assert "+40 more" in out
+    assert len(out) <= 1200
+
+
+def test_build_prompt_with_context_includes_history() -> None:
+    """Verify recent user/assistant turns are folded into the next prompt."""
+    history = [
+        {"role": "user", "text": "Add a basemap of Tokyo."},
+        {"role": "assistant", "text": "Added OpenStreetMap centred on Tokyo."},
+    ]
+    prompt = app.build_prompt_with_context(history, "Now zoom to Shibuya.")
+    assert "Add a basemap of Tokyo." in prompt
+    assert "Added OpenStreetMap centred on Tokyo." in prompt
+    assert "Now zoom to Shibuya." in prompt
+    assert "User:" in prompt and "Assistant:" in prompt
+
+
+def test_build_prompt_with_context_returns_prompt_when_empty() -> None:
+    """Verify the helper is a no-op when there is no usable history."""
+    assert app.build_prompt_with_context([], "Hello") == "Hello"
+
+
+def test_format_response_message_success_and_error() -> None:
+    """Verify GeoAgentResponse-like inputs produce the expected message dicts."""
+
+    class FakeResp:
+        def __init__(self, **kw):
+            for k, v in kw.items():
+                setattr(self, k, v)
+
+    success = FakeResp(
+        success=True,
+        answer_text="Done.",
+        executed_tools=["add_basemap"],
+        cancelled_tools=[],
+        error_message=None,
+        tool_calls=[],
+    )
+    msg = app.format_response_message(success)
+    assert msg["status"] == "ok"
+    assert "Done." in msg["text"]
+    assert "Executed tools: add_basemap" in msg["text"]
+
+    failure = FakeResp(
+        success=False,
+        answer_text="",
+        executed_tools=[],
+        cancelled_tools=["remove_layer"],
+        error_message="Confirmation denied",
+        tool_calls=[],
+    )
+    err_msg = app.format_response_message(failure)
+    assert err_msg["status"] == "error"
+    assert "Cancelled tools: remove_layer" in err_msg["text"]
+    assert "Confirmation denied" in err_msg["text"]
+
+
+def test_dispatch_prompt_success_flow(monkeypatch) -> None:
+    """Verify a successful send appends the assistant reply and tool calls."""
+
+    class FakeResp:
+        success = True
+        answer_text = "Centred on Knoxville."
+        executed_tools = ["set_center"]
+        cancelled_tools = []
+        error_message = None
+        tool_calls = [{"name": "set_center", "args": {"lat": 35.96, "lon": -83.92}}]
+
+    class FakeAgent:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        def chat(self, prompt: str):
+            self.calls.append(prompt)
+            return FakeResp()
+
+    fake_agent = FakeAgent()
+
+    def factory(binding, **kwargs):
+        factory.kwargs = kwargs
+        factory.binding = binding
+        return fake_agent
+
+    binding = app.UiMapBinding(map_obj=object(), map_library="anymap", factory=factory)
+    history = [
+        {"role": "user", "text": "Earlier turn"},
+        {"role": "assistant", "text": "Earlier reply"},
+    ]
+
+    new_history, tool_calls = app.dispatch_prompt(
+        "Centre on Knoxville",
+        history=history,
+        binding=binding,
+        provider="openai",
+        model_id="gpt-test",
+        fast=False,
+        auto_approve=True,
+        create_agent=factory,
+    )
+
+    assert new_history[: len(history)] == history
+    assert new_history[-2] == {"role": "user", "text": "Centre on Knoxville"}
+    assistant_msg = new_history[-1]
+    assert assistant_msg["status"] == "ok"
+    assert "Centred on Knoxville." in assistant_msg["text"]
+    assert "Executed tools: set_center" in assistant_msg["text"]
+    assert tool_calls == [{"name": "set_center", "args": {"lat": 35.96, "lon": -83.92}}]
+    assert factory.kwargs["provider"] == "openai"
+    assert factory.kwargs["auto_approve"] is True
+    sent_prompt = fake_agent.calls[0]
+    assert "Earlier turn" in sent_prompt
+    assert "Earlier reply" in sent_prompt
+    assert "Centre on Knoxville" in sent_prompt
+
+
+def test_dispatch_prompt_failure_records_error() -> None:
+    """Verify a missing binding produces an error message in the transcript."""
+    new_history, tool_calls = app.dispatch_prompt(
+        "Hello",
+        history=[],
+        binding=None,
+        binding_error="anymap is not installed",
+        provider="openai",
+        model_id="gpt-test",
+        fast=False,
+        auto_approve=False,
+    )
+    assert tool_calls == []
+    assert new_history[0] == {"role": "user", "text": "Hello"}
+    assert new_history[1]["status"] == "error"
+    assert "anymap is not installed" in new_history[1]["text"]
+
+
+def test_dispatch_prompt_handles_agent_exception() -> None:
+    """Verify chat exceptions are surfaced as error messages, not raised."""
+
+    class BoomAgent:
+        def chat(self, prompt: str):
+            raise RuntimeError("network down")
+
+    def factory(binding, **kwargs):
+        return BoomAgent()
+
+    binding = app.UiMapBinding(map_obj=object(), map_library="anymap", factory=factory)
+
+    new_history, tool_calls = app.dispatch_prompt(
+        "Hello",
+        history=[],
+        binding=binding,
+        provider="openai",
+        model_id="gpt-test",
+        fast=False,
+        auto_approve=False,
+        create_agent=factory,
+    )
+    assert tool_calls == []
+    assert new_history[-1]["status"] == "error"
+    assert "network down" in new_history[-1]["text"]

--- a/tests/test_ui_app.py
+++ b/tests/test_ui_app.py
@@ -1,0 +1,121 @@
+"""Tests for GeoAgent Solara UI helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+from geoagent.core.safety import ConfirmRequest
+from geoagent.ui import app
+
+
+def test_default_model_for_provider() -> None:
+    """Verify provider default model ids."""
+    assert app.default_model_for_provider("openai-codex") == "gpt-5.5"
+    assert app.default_model_for_provider("anthropic") == "claude-sonnet-4-6"
+    assert app.default_model_for_provider("unknown") == ""
+
+
+def test_confirmation_callback_denies_by_default() -> None:
+    """Verify confirmation-required tools are denied unless auto-approve is on."""
+    request = ConfirmRequest(tool_name="remove_layer", args={"name": "A"})
+    assert app.confirmation_callback(False)(request) is False
+    assert app.confirmation_callback(True)(request) is True
+    assert app.confirmation_preview(False) is False
+    assert app.confirmation_preview(True) is True
+
+
+def test_create_ui_map_binding_prefers_anymap(monkeypatch) -> None:
+    """Verify the UI prefers anymap when it is importable."""
+    calls: list[tuple[object, dict]] = []
+
+    class FakeMap:
+        pass
+
+    def fake_for_anymap(map_obj, **kwargs):
+        calls.append((map_obj, kwargs))
+        return "agent"
+
+    fake_anymap = types.SimpleNamespace(Map=FakeMap)
+    monkeypatch.setitem(sys.modules, "anymap", fake_anymap)
+    monkeypatch.delitem(sys.modules, "leafmap", raising=False)
+    monkeypatch.setattr("geoagent.for_anymap", fake_for_anymap)
+
+    binding = app.create_ui_map_binding()
+    assert binding.map_library == "anymap"
+    assert isinstance(binding.map_obj, FakeMap)
+
+    agent = app.create_bound_agent(
+        binding,
+        provider="openai",
+        model_id="gpt-test",
+        fast=True,
+        auto_approve=True,
+    )
+    assert agent == "agent"
+    assert calls
+    assert calls[0][1]["config"].provider == "openai"
+    assert calls[0][1]["config"].model == "gpt-test"
+    assert calls[0][1]["fast"] is True
+    assert calls[0][1]["confirm"](ConfirmRequest(tool_name="x", args={})) is True
+
+
+def test_create_ui_map_binding_falls_back_to_leafmap(monkeypatch) -> None:
+    """Verify leafmap is used when anymap is unavailable."""
+
+    class FakeMap:
+        pass
+
+    def fake_for_leafmap(map_obj, **kwargs):
+        return "agent"
+
+    fake_leafmap = types.SimpleNamespace(Map=FakeMap)
+    monkeypatch.setitem(sys.modules, "anymap", None)
+    monkeypatch.setitem(sys.modules, "leafmap", fake_leafmap)
+    monkeypatch.setattr("geoagent.for_leafmap", fake_for_leafmap)
+
+    binding = app.create_ui_map_binding()
+    assert binding.map_library == "leafmap"
+    assert isinstance(binding.map_obj, FakeMap)
+
+
+def test_create_ui_map_binding_missing_dependencies(monkeypatch) -> None:
+    """Verify missing map packages produce an actionable error."""
+    monkeypatch.setitem(sys.modules, "anymap", None)
+    monkeypatch.setitem(sys.modules, "leafmap", None)
+
+    try:
+        app.create_ui_map_binding()
+    except RuntimeError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("Expected missing map packages to fail")
+
+    assert "GeoAgent[anymap,ui]" in message
+    assert "GeoAgent[leafmap,ui]" in message
+
+
+def test_ui_package_imports_without_provider_credentials() -> None:
+    """Verify the UI package import does not initialize model providers."""
+    module = importlib.import_module("geoagent.ui")
+    assert hasattr(module, "launch_ui")
+
+
+def test_solara_pages_import_with_stubbed_solara(monkeypatch) -> None:
+    """Verify Solara page modules import without provider credentials."""
+    fake_solara = types.ModuleType("solara")
+    fake_solara.component = lambda fn: fn
+    monkeypatch.setitem(sys.modules, "solara", fake_solara)
+    for name in (
+        "geoagent.ui.workspace",
+        "geoagent.ui.pages.00_home",
+        "geoagent.ui.pages.01_chat",
+    ):
+        sys.modules.pop(name, None)
+
+    home = importlib.import_module("geoagent.ui.pages.00_home")
+    chat = importlib.import_module("geoagent.ui.pages.01_chat")
+
+    assert callable(home.Page)
+    assert callable(chat.Page)


### PR DESCRIPTION
## Summary
- Add a Solara map-bound chat workspace at `geoagent/ui/workspace.py` with provider, model, fast-mode, and auto-approve controls plus session chat history and compact tool-call output.
- Wire the existing Solara pages (`00_home.py`, `01_chat.py`) to the new workspace and add `geoagent/ui/app.py` runtime helpers (map binding, provider defaults, confirmation policy).
- Default the UI's confirmation policy to deny gated tools, pin `starlette<1.0` for the `ui` extra, refresh README and `docs/ui.md` accordingly.

## Test plan
- [x] `pytest tests/test_ui_app.py -q`
- [x] `pre-commit run --all-files`
- [ ] `geoagent ui` opens the workspace and a prompt round-trips against an `anymap` map with auto-approve off.