### PR TITLE
fix: actionable error message for chat worker TLS failures

### DIFF
--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -58,6 +58,10 @@ Workflow guidance:
 - Search before displaying footprints or rasters.
 - If the user gives no location, use the current QGIS map extent.
 - For raster display, choose a specific data link from search results.
+- When the user asks how many water pixels are in a loaded OPERA raster or
+  mosaic, use count_water_pixels rather than generating a PyQGIS script.
+- For other categorical raster questions, use analyze_categorical_raster to
+  count class values and percentages.
 - Keep responses concise and include result counts, date range, and relevant
   first-result identifiers when available.
 """

--- a/geoagent/tools/nasa_opera.py
+++ b/geoagent/tools/nasa_opera.py
@@ -302,9 +302,7 @@ def _count_raster_class_values(
         height = int(ds.RasterYSize)
         nodata = raster_band.GetNoDataValue()
         selected_values = (
-            {int(value) for value in class_values}
-            if class_values is not None
-            else None
+            {int(value) for value in class_values} if class_values is not None else None
         )
         counts: dict[int, int] = (
             {int(value): 0 for value in class_values}

--- a/geoagent/tools/nasa_opera.py
+++ b/geoagent/tools/nasa_opera.py
@@ -224,6 +224,146 @@ def _add_qgis_raster_layer(
     return _on_gui(_run)
 
 
+def _parse_class_values(values: Any, *, fallback: tuple[int, ...]) -> list[int]:
+    """Parse a class-value argument into integer raster class values."""
+    if values is None or values == "":
+        return list(fallback)
+    if isinstance(values, str):
+        raw_items = re.split(r"[,;\s]+", values.strip())
+    elif isinstance(values, (list, tuple, set)):
+        raw_items = list(values)
+    else:
+        raw_items = [values]
+
+    parsed: list[int] = []
+    for item in raw_items:
+        if item in (None, ""):
+            continue
+        value = int(float(str(item).strip()))
+        if value not in parsed:
+            parsed.append(value)
+    return parsed or list(fallback)
+
+
+def _resolve_raster_layer_source(
+    iface: Any,
+    project_getter: Callable[[], Any],
+    layer_name: Optional[str],
+) -> dict[str, Any]:
+    """Resolve a QGIS raster layer name to a source URI on the GUI thread."""
+
+    def _run() -> dict[str, Any]:
+        proj = project_getter()
+        candidates: list[Any] = []
+        if layer_name:
+            candidates.extend(proj.mapLayersByName(layer_name))
+            if not candidates:
+                needle = layer_name.lower()
+                candidates.extend(
+                    layer
+                    for layer in proj.mapLayers().values()
+                    if needle in str(layer.name()).lower()
+                )
+        else:
+            active = getattr(iface, "activeLayer", lambda: None)()
+            if active is not None:
+                candidates.append(active)
+            candidates.extend(proj.mapLayersByName("OPERA Mosaic"))
+
+        for layer in candidates:
+            source = str(layer.source() or "")
+            if source:
+                return {"layer_name": str(layer.name()), "source": source}
+        return {"error": "No matching raster layer with a readable source was found."}
+
+    return _on_gui(_run)
+
+
+def _count_raster_class_values(
+    source: str,
+    *,
+    band: int,
+    class_values: Optional[list[int]] = None,
+    max_categories: int = 50,
+) -> dict[str, Any]:
+    """Count categorical raster pixels for selected or discovered values."""
+    from osgeo import gdal  # type: ignore[import-not-found]
+    import numpy as np
+
+    ds = gdal.Open(source)
+    if ds is None:
+        return {"error": f"GDAL could not open raster source: {source}"}
+    try:
+        raster_band = ds.GetRasterBand(int(band))
+        if raster_band is None:
+            return {"error": f"Raster band {band} is not available."}
+
+        width = int(ds.RasterXSize)
+        height = int(ds.RasterYSize)
+        nodata = raster_band.GetNoDataValue()
+        selected_values = (
+            {int(value) for value in class_values}
+            if class_values is not None
+            else None
+        )
+        counts: dict[int, int] = (
+            {int(value): 0 for value in class_values}
+            if class_values is not None
+            else {}
+        )
+        valid_pixels = 0
+        chunk_size = 1024
+
+        for yoff in range(0, height, chunk_size):
+            ysize = min(chunk_size, height - yoff)
+            for xoff in range(0, width, chunk_size):
+                xsize = min(chunk_size, width - xoff)
+                arr = raster_band.ReadAsArray(xoff, yoff, xsize, ysize)
+                if arr is None:
+                    continue
+                if nodata is not None:
+                    mask = arr != nodata
+                    valid_pixels += int(np.count_nonzero(mask))
+                    data = arr[mask]
+                else:
+                    valid_pixels += int(arr.size)
+                    data = arr
+                if selected_values is None:
+                    unique, unique_counts = np.unique(data, return_counts=True)
+                    for value, count in zip(unique, unique_counts):
+                        key = int(value)
+                        counts[key] = counts.get(key, 0) + int(count)
+                else:
+                    for value in counts:
+                        counts[value] += int(np.count_nonzero(data == value))
+
+        sorted_counts = dict(
+            sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        )
+        category_count = len(sorted_counts)
+        limit = max(1, int(max_categories))
+        truncated = category_count > limit
+        if truncated:
+            sorted_counts = dict(list(sorted_counts.items())[:limit])
+
+        return {
+            "success": True,
+            "band": int(band),
+            "width": width,
+            "height": height,
+            "total_pixels": width * height,
+            "valid_pixels": valid_pixels,
+            "class_counts": sorted_counts,
+            "matched_pixel_count": sum(sorted_counts.values()),
+            "category_count": category_count,
+            "returned_category_count": len(sorted_counts),
+            "truncated": truncated,
+            "nodata": nodata,
+        }
+    finally:
+        ds = None
+
+
 def _granule_links(granule: Any) -> list[str]:
     """Return data links from an earthaccess granule."""
     if hasattr(granule, "data_links"):
@@ -624,6 +764,113 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
             result["source_count"] = len(accessible)
         return result
 
+    @geo_tool(
+        category="nasa_opera",
+        name="count_water_pixels",
+        long_running=True,
+        requires_packages=("osgeo", "numpy"),
+    )
+    def count_water_pixels(
+        layer_name: Optional[str] = "OPERA Mosaic",
+        band: int = 1,
+        water_values: Any = "1,2",
+    ) -> dict[str, Any]:
+        """Count DSWx water pixels in a loaded OPERA raster or mosaic.
+
+        Args:
+            layer_name: QGIS raster layer name or unique substring. Defaults to
+                ``OPERA Mosaic``.
+            band: Raster band number to inspect, normally band 1 for DSWx WTR.
+            water_values: Water class values to count. The default ``1,2``
+                counts open water and partial surface water classes.
+        """
+        values = _parse_class_values(water_values, fallback=(1, 2))
+        resolved = _resolve_raster_layer_source(iface, _project, layer_name)
+        if resolved.get("error"):
+            return resolved
+
+        result = _count_raster_class_values(
+            resolved["source"],
+            band=int(band),
+            class_values=values,
+        )
+        if result.get("success"):
+            result["layer_name"] = resolved["layer_name"]
+            result["source"] = resolved["source"]
+            result["water_values"] = values
+            result["water_pixel_count"] = result.pop("matched_pixel_count")
+            result["note"] = (
+                "Default DSWx water classes are 1=open water and "
+                "2=partial surface water."
+            )
+        return result
+
+    @geo_tool(
+        category="nasa_opera",
+        name="analyze_categorical_raster",
+        long_running=True,
+        requires_packages=("osgeo", "numpy"),
+    )
+    def analyze_categorical_raster(
+        layer_name: Optional[str] = None,
+        band: int = 1,
+        category_values: Any = None,
+        category_labels: Optional[dict[str, str]] = None,
+        max_categories: int = 50,
+    ) -> dict[str, Any]:
+        """Summarize category pixel counts for a loaded raster layer.
+
+        Args:
+            layer_name: QGIS raster layer name or unique substring. When
+                omitted, the active layer is used, then ``OPERA Mosaic``.
+            band: Raster band number to inspect.
+            category_values: Optional category values to count. Omit to count
+                every category found in the raster band.
+            category_labels: Optional mapping from category value to label.
+            max_categories: Maximum category rows returned when discovering
+                all categories.
+        """
+        values = (
+            _parse_class_values(category_values, fallback=())
+            if category_values not in (None, "")
+            else None
+        )
+        resolved = _resolve_raster_layer_source(iface, _project, layer_name)
+        if resolved.get("error"):
+            return resolved
+
+        result = _count_raster_class_values(
+            resolved["source"],
+            band=int(band),
+            class_values=values,
+            max_categories=max_categories,
+        )
+        if not result.get("success"):
+            return result
+
+        labels = category_labels or {}
+        categories: list[dict[str, Any]] = []
+        for value, count in result["class_counts"].items():
+            percent = (
+                (count / result["valid_pixels"] * 100.0)
+                if result["valid_pixels"]
+                else 0.0
+            )
+            categories.append(
+                {
+                    "value": value,
+                    "label": str(labels.get(str(value), labels.get(value, ""))),
+                    "pixel_count": count,
+                    "percent_of_valid_pixels": round(percent, 4),
+                }
+            )
+
+        result["layer_name"] = resolved["layer_name"]
+        result["source"] = resolved["source"]
+        result["category_values"] = values
+        result["categories"] = categories
+        return result
+
     return [
         get_available_datasets,
         get_dataset_info,
@@ -631,6 +878,8 @@ def nasa_opera_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
         display_footprints,
         display_raster,
         create_mosaic,
+        count_water_pixels,
+        analyze_categorical_raster,
     ]
 
 

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -394,6 +394,45 @@ def _apply_environment_from_settings(settings):
                 os.environ[env_name] = value
 
 
+def _format_chat_worker_error(exc, provider="", agent_mode=""):
+    """Return an actionable UI error for chat worker exceptions."""
+    raw = str(exc) or exc.__class__.__name__
+    lower = raw.lower()
+    provider_label = provider or "the selected provider"
+    mode_label = agent_mode or "this mode"
+
+    if (
+        "tlsv1_alert_decode_error" in lower
+        or "api connection error" in lower
+        or "connection error" == lower.strip()
+        or "httpx.connecterror" in lower
+        or "httpcore.connecterror" in lower
+    ):
+        advice = (
+            "The model provider connection failed while OpenGeoAgent was "
+            f"running {mode_label}. The NASA OPERA tools were not the source "
+            "of this TLS error; the failing request was the model call."
+        )
+        if provider == "openai-codex":
+            advice += (
+                "\n\nYou are using openai-codex, which talks to the ChatGPT/Codex "
+                "backend. For longer OPERA tool workflows, switch Settings > "
+                "Model to provider=openai with an OPENAI_API_KEY, or try again "
+                "with streaming disabled. For OPERA searches that do not need "
+                "natural language, use the direct "
+                "submit_nasa_opera_search_task(...) helper."
+            )
+        else:
+            advice += (
+                f"\n\nCheck network/proxy/TLS access for {provider_label}, then "
+                "try again. If streaming is enabled, try disabling it once to "
+                "reduce the number of provider requests."
+            )
+        return f"{advice}\n\nOriginal error: {raw}"
+
+    return raw
+
+
 def _transcription_model_from_settings(settings):
     """Return the configured OpenAI speech-to-text model."""
     saved = _setting(settings, "transcription_model", "", str).strip()
@@ -1853,11 +1892,21 @@ class ChatWorker(QThread):
                 }
             )
         except Exception as exc:
+            formatted_error = _format_chat_worker_error(
+                exc,
+                provider=self.provider,
+                agent_mode=self.agent_mode,
+            )
+            QgsMessageLog.logMessage(
+                f"Chat worker failed:\n{traceback.format_exc()}",
+                "OpenGeoAgent",
+                Qgis.MessageLevel.Critical,
+            )
             self.finished.emit(
                 {
                     "success": False,
                     "answer": "",
-                    "error": f"{exc}\n\n{traceback.format_exc()}",
+                    "error": formatted_error,
                     "images": [],
                     "tools": "",
                     "cancelled": "",

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -398,20 +398,29 @@ def _format_chat_worker_error(exc, provider="", agent_mode=""):
     """Return an actionable UI error for chat worker exceptions."""
     raw = str(exc) or exc.__class__.__name__
     lower = raw.lower()
+    cls_name = exc.__class__.__name__.lower()
     provider_label = provider or "the selected provider"
     mode_label = agent_mode or "this mode"
+    is_opera_mode = "opera" in agent_mode.lower()
 
     if (
         "tlsv1_alert_decode_error" in lower
         or "api connection error" in lower
-        or "connection error" == lower.strip()
-        or "httpx.connecterror" in lower
-        or "httpcore.connecterror" in lower
+        or "connection error" in lower
+        or "connecterror" in lower
+        or "connecterror" in cls_name
+        or "connectionerror" in cls_name
+        or "ssl" in cls_name
     ):
+        tool_attribution = (
+            "The NASA OPERA tools were not the source of this TLS error; "
+            if is_opera_mode
+            else "OpenGeoAgent tools were not the source of this error; "
+        )
         advice = (
             "The model provider connection failed while OpenGeoAgent was "
-            f"running {mode_label}. The NASA OPERA tools were not the source "
-            "of this TLS error; the failing request was the model call."
+            f"running {mode_label}. {tool_attribution}"
+            "the failing request was the model call."
         )
         if provider == "openai-codex":
             advice += (

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -9,6 +9,7 @@ from open_geoagent.dialogs.chat_dock import (
     _console_ready_pyqgis_script,
     _conversation_markdown,
     _format_tool_calls,
+    _format_chat_worker_error,
     _grab_screen_rect,
     _grab_widget_global_rect,
     _image_to_png_bytes,
@@ -217,6 +218,23 @@ def test_build_chat_content_adds_image_blocks() -> None:
         {"text": "Describe this map screenshot."},
         {"image": {"format": "png", "source": {"bytes": b"png-bytes"}}},
     ]
+
+
+def test_format_chat_worker_error_explains_codex_tls_failure() -> None:
+    """Verify provider TLS failures produce actionable plugin guidance."""
+    error = _format_chat_worker_error(
+        RuntimeError(
+            "[SSL: TLSV1_ALERT_DECODE_ERROR] tlsv1 alert decode error (_ssl.c:1010)"
+        ),
+        provider="openai-codex",
+        agent_mode="NASA OPERA",
+    )
+
+    assert "model provider connection failed" in error
+    assert "NASA OPERA tools were not the source" in error
+    assert "provider=openai" in error
+    assert "streaming disabled" in error
+    assert "submit_nasa_opera_search_task" in error
 
 
 def test_format_tool_calls_includes_full_stac_asset_url() -> None:

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -237,6 +237,24 @@ def test_format_chat_worker_error_explains_codex_tls_failure() -> None:
     assert "submit_nasa_opera_search_task" in error
 
 
+def test_format_chat_worker_error_detects_httpx_connect_error_by_class() -> None:
+    """Class-name-based detection should catch httpx.ConnectError-style failures."""
+
+    class ConnectError(Exception):
+        """Mimic httpx.ConnectError so str(exc) lacks the module path."""
+
+    error = _format_chat_worker_error(
+        ConnectError("All connection attempts failed"),
+        provider="openai",
+        agent_mode="General QGIS",
+    )
+
+    assert "model provider connection failed" in error
+    assert "OpenGeoAgent tools were not the source" in error
+    assert "NASA OPERA" not in error
+    assert "Check network/proxy/TLS access for openai" in error
+
+
 def test_format_tool_calls_includes_full_stac_asset_url() -> None:
     """Verify STAC signed URLs are preserved outside compact arg display."""
     href = "https://example.blob.core.windows.net/container/path/file.tif?" + (

--- a/tests/test_nasa_opera_tools.py
+++ b/tests/test_nasa_opera_tools.py
@@ -57,8 +57,6 @@ def test_for_nasa_opera_registers_opera_and_qgis_tools() -> None:
     assert "get_available_datasets" in names
     assert "get_dataset_info" in names
     assert "display_footprints" in names
-    assert "count_water_pixels" in names
-    assert "analyze_categorical_raster" in names
     assert "list_project_layers" in names
     assert agent.context.metadata["integration"] == "nasa_opera"
 

--- a/tests/test_nasa_opera_tools.py
+++ b/tests/test_nasa_opera_tools.py
@@ -110,9 +110,7 @@ def test_count_water_pixels_uses_loaded_mosaic_source(monkeypatch) -> None:
 def test_analyze_categorical_raster_adds_labels_and_percentages(monkeypatch) -> None:
     """Verify categorical raster summaries include labels and percentages."""
     project = MockQGISProject()
-    project.addMapLayer(
-        MockQGISLayer("Classification", "/tmp/classes.tif", "raster")
-    )
+    project.addMapLayer(MockQGISLayer("Classification", "/tmp/classes.tif", "raster"))
     iface = MockQGISIface(project)
     tools = {t.tool_name: t for t in nasa_opera_tools(iface, project)}
     captured = {}

--- a/tests/test_nasa_opera_tools.py
+++ b/tests/test_nasa_opera_tools.py
@@ -10,7 +10,7 @@ import pytest
 
 from geoagent import for_nasa_opera
 from geoagent.tools.nasa_opera import nasa_opera_tools, submit_nasa_opera_chat_task
-from geoagent.testing import MockQGISIface, MockQGISProject
+from geoagent.testing import MockQGISIface, MockQGISLayer, MockQGISProject
 
 
 class _MockModel:
@@ -57,8 +57,120 @@ def test_for_nasa_opera_registers_opera_and_qgis_tools() -> None:
     assert "get_available_datasets" in names
     assert "get_dataset_info" in names
     assert "display_footprints" in names
+    assert "count_water_pixels" in names
+    assert "analyze_categorical_raster" in names
     assert "list_project_layers" in names
     assert agent.context.metadata["integration"] == "nasa_opera"
+
+
+def test_count_water_pixels_uses_loaded_mosaic_source(monkeypatch) -> None:
+    """Verify OPERA water counting resolves a loaded QGIS raster layer."""
+    project = MockQGISProject()
+    project.addMapLayer(
+        MockQGISLayer("OPERA Mosaic", "/tmp/opera_mosaic.vrt", "raster")
+    )
+    iface = MockQGISIface(project)
+    tools = {t.tool_name: t for t in nasa_opera_tools(iface, project)}
+    captured = {}
+
+    def _fake_count(source, *, band, class_values):
+        captured["source"] = source
+        captured["band"] = band
+        captured["class_values"] = class_values
+        return {
+            "success": True,
+            "band": band,
+            "width": 3,
+            "height": 2,
+            "total_pixels": 6,
+            "valid_pixels": 6,
+            "class_counts": {1: 2, 2: 1},
+            "matched_pixel_count": 3,
+            "nodata": 255,
+        }
+
+    monkeypatch.setattr(
+        "geoagent.tools.nasa_opera._count_raster_class_values",
+        _fake_count,
+    )
+
+    result = tools["count_water_pixels"](water_values="1,2")
+
+    assert captured == {
+        "source": "/tmp/opera_mosaic.vrt",
+        "band": 1,
+        "class_values": [1, 2],
+    }
+    assert result["success"] is True
+    assert result["layer_name"] == "OPERA Mosaic"
+    assert result["water_pixel_count"] == 3
+    assert result["class_counts"] == {1: 2, 2: 1}
+
+
+def test_analyze_categorical_raster_adds_labels_and_percentages(monkeypatch) -> None:
+    """Verify categorical raster summaries include labels and percentages."""
+    project = MockQGISProject()
+    project.addMapLayer(
+        MockQGISLayer("Classification", "/tmp/classes.tif", "raster")
+    )
+    iface = MockQGISIface(project)
+    tools = {t.tool_name: t for t in nasa_opera_tools(iface, project)}
+    captured = {}
+
+    def _fake_count(source, *, band, class_values=None, max_categories=50):
+        captured["source"] = source
+        captured["band"] = band
+        captured["class_values"] = class_values
+        captured["max_categories"] = max_categories
+        return {
+            "success": True,
+            "band": band,
+            "width": 3,
+            "height": 2,
+            "total_pixels": 6,
+            "valid_pixels": 5,
+            "class_counts": {4: 3, 1: 2},
+            "matched_pixel_count": 5,
+            "category_count": 2,
+            "returned_category_count": 2,
+            "truncated": False,
+            "nodata": 255,
+        }
+
+    monkeypatch.setattr(
+        "geoagent.tools.nasa_opera._count_raster_class_values",
+        _fake_count,
+    )
+
+    result = tools["analyze_categorical_raster"](
+        layer_name="Class",
+        category_values="1,4",
+        category_labels={"1": "water", "4": "vegetation"},
+        max_categories=10,
+    )
+
+    assert captured == {
+        "source": "/tmp/classes.tif",
+        "band": 1,
+        "class_values": [1, 4],
+        "max_categories": 10,
+    }
+    assert result["success"] is True
+    assert result["layer_name"] == "Classification"
+    assert result["categories"] == [
+        {
+            "value": 4,
+            "label": "vegetation",
+            "pixel_count": 3,
+            "percent_of_valid_pixels": 60.0,
+        },
+        {
+            "value": 1,
+            "label": "water",
+            "pixel_count": 2,
+            "percent_of_valid_pixels": 40.0,
+        },
+    ]
 
 
 def test_for_nasa_opera_chat_in_background_returns_thread(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Format chat worker exceptions into a clear UI message that distinguishes provider TLS/connection failures from NASA OPERA tool errors.
- Log the full traceback to the QGIS message log so debug detail is preserved without dumping it into the chat error pane.
- Add provider-specific guidance for openai-codex (suggesting provider=openai, disabling streaming, or the direct submit_nasa_opera_search_task helper).

## Test plan
- [x] pytest qgis_geoagent/tests/test_chat_tool_inputs.py::test_format_chat_worker_error_explains_codex_tls_failure
- [x] pre-commit run --all-files
- [ ] Manual: trigger a provider TLS error in the QGIS plugin and confirm the chat dock shows the new actionable message while the full traceback appears in the QGIS log panel.