### PR TITLE
fix: resolve QGIS Python interpreter on macOS app bundles

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.4.1"
+version = "1.5.0"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -76,7 +76,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.4.1"
+current_version = "1.5.0"
 commit = true
 tag = true
 
@@ -89,6 +89,11 @@ replace = 'version = "{new_version}"'
 filename = "geoagent/__init__.py"
 search = '__version__ = "{current_version}"'
 replace = '__version__ = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "qgis_geoagent/open_geoagent/metadata.txt"
+search = "version={current_version}"
+replace = "version={new_version}"
 
 [tool.ruff]
 line-length = 88

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -80,11 +80,11 @@ adds its site-packages directory when the plugin loads.
 Manual fallback:
 
 ```bash
-pip install "GeoAgent[providers]>=1.4.1"
-pip install "GeoAgent[stac]>=1.4.1"
-pip install "GeoAgent[whitebox]>=1.4.1"
-pip install "GeoAgent[earthdata,nasa-opera]>=1.4.1"
-pip install "GeoAgent[earthengine]>=1.4.1"
+pip install "GeoAgent[providers]>=1.5.0"
+pip install "GeoAgent[stac]>=1.5.0"
+pip install "GeoAgent[whitebox]>=1.5.0"
+pip install "GeoAgent[earthdata,nasa-opera]>=1.5.0"
+pip install "GeoAgent[earthengine]>=1.5.0"
 ```
 
 GEE Data Catalogs mode also expects the `gee_data_catalogs` Python module from

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -19,6 +19,7 @@ import importlib.metadata
 import importlib.util
 import os
 import platform
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -354,26 +355,178 @@ def _uv_usable() -> bool:
         return False
 
 
+def _python_executable_names() -> List[str]:
+    """Return expected Python executable names for the current runtime."""
+    versioned = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    names = [versioned, f"python{sys.version_info.major}", "python3", "python"]
+    if sys.platform == "win32":
+        return [f"{name}.exe" for name in names]
+    return names
+
+
+def _looks_like_python_executable(path: Optional[str]) -> bool:
+    """Return True when *path* names a Python interpreter binary."""
+    if not path:
+        return False
+    name = os.path.basename(path).lower()
+    if sys.platform == "win32" and name.endswith(".exe"):
+        name = name[:-4]
+    return bool(re.fullmatch(r"python(?:\d+(?:\.\d+)?)?", name))
+
+
+def _add_existing_python_candidate(
+    candidates: List[str], seen: set, path: Optional[str]
+) -> None:
+    """Append *path* when it exists and looks like a Python interpreter."""
+    if not path or not _looks_like_python_executable(path):
+        return
+    normalized = os.path.abspath(path)
+    if normalized in seen or not os.path.isfile(normalized):
+        return
+    candidates.append(normalized)
+    seen.add(normalized)
+
+
+def _macos_bundle_dirs(path: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(Contents/MacOS, Contents)`` dirs for paths inside a macOS app."""
+    if not path:
+        return None, None
+    normalized = os.path.abspath(path)
+    marker = os.path.join("Contents", "MacOS")
+    parts = normalized.split(os.sep)
+    for idx in range(len(parts) - 1):
+        if parts[idx] == "Contents" and parts[idx + 1] == "MacOS":
+            macos_dir = os.sep.join(parts[: idx + 2])
+            if normalized.startswith(os.sep):
+                macos_dir = os.sep + macos_dir.lstrip(os.sep)
+            contents_dir = os.path.dirname(macos_dir)
+            return macos_dir, contents_dir
+    if normalized.endswith(marker):
+        return normalized, os.path.dirname(normalized)
+    return None, None
+
+
+def _add_macos_python_candidates(candidates: List[str], seen: set) -> None:
+    """Add Python candidates from common QGIS.app bundle layouts."""
+    roots = [
+        getattr(sys, "_base_executable", None),
+        sys.executable,
+        getattr(sys, "_base_prefix", None),
+        sys.prefix,
+    ]
+    names = _python_executable_names()
+
+    for root in roots:
+        macos_dir, contents_dir = _macos_bundle_dirs(root)
+        if not macos_dir or not contents_dir:
+            continue
+
+        for name in names:
+            _add_existing_python_candidate(
+                candidates, seen, os.path.join(macos_dir, name)
+            )
+            _add_existing_python_candidate(
+                candidates, seen, os.path.join(macos_dir, "bin", name)
+            )
+
+        framework_versions = [
+            f"{sys.version_info.major}.{sys.version_info.minor}",
+            "Current",
+        ]
+        for version in framework_versions:
+            framework_bin = os.path.join(
+                contents_dir,
+                "Frameworks",
+                "Python.framework",
+                "Versions",
+                version,
+                "bin",
+            )
+            for name in names:
+                _add_existing_python_candidate(
+                    candidates, seen, os.path.join(framework_bin, name)
+                )
+
+        _add_existing_python_candidate(
+            candidates,
+            seen,
+            os.path.join(
+                contents_dir,
+                "Resources",
+                "Python.app",
+                "Contents",
+                "MacOS",
+                "Python",
+            ),
+        )
+
+
 def _find_python_executable() -> str:
     """Find a working Python executable for subprocess calls.
 
-    On QGIS Windows, ``sys.executable`` may point to ``qgis-bin.exe`` rather
-    than a Python interpreter, which would launch another QGIS instance when
-    used in subprocess calls. This function searches for the actual Python
-    executable using multiple strategies.
+    In QGIS, ``sys.executable`` can point to the QGIS application binary
+    instead of a Python interpreter. On macOS this is commonly
+    ``.../QGIS.app/Contents/MacOS/QGIS``; using it with ``uv`` or
+    ``python -m venv`` launches a second QGIS instance and causes flags such as
+    ``-I`` and ``-c`` to be treated as data sources. This function searches for
+    the actual Python executable using multiple platform-specific strategies.
 
     Returns:
-        Path to a Python executable, or ``sys.executable`` as fallback.
-    """
-    if platform.system() != "Windows":
-        return sys.executable
+        Path to a Python executable.
 
-    # Strategy 1: Check if sys.executable is already Python
+    Raises:
+        RuntimeError: If no Python interpreter can be found.
+    """
+    candidates: List[str] = []
+    seen = set()
+
+    # Strategy 1: Python may expose the real interpreter separately from the
+    # GUI application executable.
+    _add_existing_python_candidate(
+        candidates, seen, getattr(sys, "_base_executable", None)
+    )
+    _add_existing_python_candidate(candidates, seen, sys.executable)
+    if candidates:
+        return candidates[0]
+
+    if platform.system() == "Darwin" or sys.platform == "darwin":
+        _add_macos_python_candidates(candidates, seen)
+        if candidates:
+            return candidates[0]
+
+    if platform.system() != "Windows":
+        for prefix in (getattr(sys, "_base_prefix", None), sys.prefix):
+            for name in _python_executable_names():
+                _add_existing_python_candidate(
+                    candidates, seen, os.path.join(str(prefix), "bin", name)
+                )
+                _add_existing_python_candidate(
+                    candidates, seen, os.path.join(str(prefix), name)
+                )
+
+        exe_dir = os.path.dirname(sys.executable)
+        for name in _python_executable_names():
+            _add_existing_python_candidate(
+                candidates, seen, os.path.join(exe_dir, name)
+            )
+
+        for name in _python_executable_names():
+            _add_existing_python_candidate(candidates, seen, shutil.which(name))
+        if candidates:
+            return candidates[0]
+
+        raise RuntimeError(
+            "Could not find a Python interpreter for dependency installation.\n"
+            f"sys.executable is not Python: {sys.executable}\n"
+            "OpenGeoAgent cannot safely run QGIS itself as a Python executable."
+        )
+
+    # Strategy 2: Check if sys.executable is already Python
     exe_name = os.path.basename(sys.executable).lower()
     if exe_name in ("python.exe", "python3.exe"):
         return sys.executable
 
-    # Strategy 2: Use sys._base_prefix to find the Python installation.
+    # Strategy 3: Use sys._base_prefix to find the Python installation.
     # On QGIS Windows, sys._base_prefix typically points to
     # C:\Program Files\QGIS 3.x\apps\Python3x\
     base_prefix = getattr(sys, "_base_prefix", None) or sys.prefix
@@ -381,14 +534,14 @@ def _find_python_executable() -> str:
     if os.path.isfile(python_in_prefix):
         return python_in_prefix
 
-    # Strategy 3: Look for python.exe next to sys.executable
+    # Strategy 4: Look for python.exe next to sys.executable
     exe_dir = os.path.dirname(sys.executable)
     for name in ("python.exe", "python3.exe"):
         candidate = os.path.join(exe_dir, name)
         if os.path.isfile(candidate):
             return candidate
 
-    # Strategy 4: Walk up from sys.executable to find apps/Python3x/python.exe
+    # Strategy 5: Walk up from sys.executable to find apps/Python3x/python.exe
     # Typical QGIS layout: .../QGIS 3.x/bin/qgis-bin.exe
     #                       .../QGIS 3.x/apps/Python3x/python.exe
     parent = os.path.dirname(exe_dir)
@@ -415,12 +568,16 @@ def _find_python_executable() -> str:
         if best_candidate:
             return best_candidate
 
-    # Strategy 5: Use shutil.which as last resort
+    # Strategy 6: Use shutil.which as last resort
     which_python = shutil.which("python")
     if which_python:
         return which_python
 
-    return sys.executable
+    raise RuntimeError(
+        "Could not find a Python interpreter for dependency installation.\n"
+        f"sys.executable is not Python: {sys.executable}\n"
+        "OpenGeoAgent cannot safely run QGIS itself as a Python executable."
+    )
 
 
 def _create_venv_with_env_builder(venv_dir: str) -> bool:
@@ -429,10 +586,10 @@ def _create_venv_with_env_builder(venv_dir: str) -> bool:
     .. warning::
         ``EnvBuilder`` internally uses ``sys.executable`` to copy the Python
         binary into the venv.  On QGIS Windows ``sys.executable`` is
-        ``qgis-bin.exe``, so this would copy QGIS itself and later subprocess
-        calls would launch a new QGIS instance.  Therefore this function is
-        **skipped** when ``sys.executable`` does not look like a Python
-        interpreter.
+        ``qgis-bin.exe`` and on macOS it may be the ``QGIS`` app binary, so
+        this would copy QGIS itself and later subprocess calls would launch a
+        new QGIS instance. Therefore this function is **skipped** when
+        ``sys.executable`` does not look like a Python interpreter.
 
     Args:
         venv_dir: Path where the venv should be created.
@@ -441,8 +598,7 @@ def _create_venv_with_env_builder(venv_dir: str) -> bool:
         True if the venv was created and the Python executable exists.
     """
     # Guard: only safe when sys.executable is actually Python.
-    exe_name = os.path.basename(sys.executable).lower()
-    if exe_name not in ("python.exe", "python3.exe", "python", "python3"):
+    if not _looks_like_python_executable(sys.executable):
         return False
 
     try:
@@ -546,12 +702,12 @@ def create_venv(venv_dir: str) -> str:
     require pip to be bootstrapped inside the venv.
 
     Otherwise uses a multi-strategy approach to handle embedded Python
-    environments (e.g. QGIS on Windows) where ``sys.executable`` may point
-    to ``qgis-bin.exe`` rather than ``python.exe``.
+    environments where ``sys.executable`` may point to the QGIS application
+    binary rather than a Python interpreter.
 
     Pip fallback strategy order:
         1. Subprocess using the real Python executable found by
-           ``_find_python_executable()`` (primary, works on Windows QGIS).
+           ``_find_python_executable()`` (primary for QGIS app bundles).
         2. In-process ``venv.EnvBuilder`` (fallback, only when
            ``sys.executable`` is already a Python interpreter).
         3. Recovery: copy the real Python executable into the venv when the

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -495,13 +495,21 @@ def _find_python_executable() -> str:
             return candidates[0]
 
     if platform.system() != "Windows":
-        for prefix in (getattr(sys, "_base_prefix", None), sys.prefix):
+        prefix_candidates = (
+            getattr(sys, "base_prefix", None),
+            getattr(sys, "base_exec_prefix", None),
+            getattr(sys, "_base_prefix", None),
+            sys.prefix,
+        )
+        for prefix in prefix_candidates:
+            if not prefix:
+                continue
             for name in _python_executable_names():
                 _add_existing_python_candidate(
-                    candidates, seen, os.path.join(str(prefix), "bin", name)
+                    candidates, seen, os.path.join(prefix, "bin", name)
                 )
                 _add_existing_python_candidate(
-                    candidates, seen, os.path.join(str(prefix), name)
+                    candidates, seen, os.path.join(prefix, name)
                 )
 
         exe_dir = os.path.dirname(sys.executable)

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -31,7 +31,7 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 # Dependency specs: (import_name, pip_install_name)
 MIN_PYTHON_VERSION = (3, 11)
 CORE_RUNTIME_PACKAGES = [
-    ("geoagent", "GeoAgent[providers]>=1.4.1"),
+    ("geoagent", "GeoAgent[providers]>=1.5.0"),
     ("strands", "strands-agents>=1.37"),
     ("pydantic", "pydantic>=2.0"),
 ]
@@ -819,7 +819,7 @@ def create_venv(venv_dir: str) -> str:
         "This can happen when QGIS bundles Python in a way that prevents\n"
         "standard venv creation.\n\n"
         "You can try installing manually with:\n"
-        '  pip install "GeoAgent[providers]>=1.4.1"\n\n'
+        '  pip install "GeoAgent[providers]>=1.5.0"\n\n'
         "Details:\n" + "\n".join(f"  {d}" for d in details)
     )
 
@@ -961,7 +961,7 @@ class DepsInstallWorker(QThread):
                         False,
                         "pip is not available in the virtual environment.\n"
                         "Please install dependencies manually:\n"
-                        'pip install "GeoAgent[providers]>=1.4.1"',
+                        'pip install "GeoAgent[providers]>=1.5.0"',
                     )
                     return
             self.progress.emit(15, "Package installer ready.")

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -822,7 +822,7 @@ class SettingsDockWidget(QDockWidget):
                 self,
                 "Installation Failed",
                 f"Failed to install dependencies:\n\n{message}\n\n"
-                'Manual fallback: pip install "GeoAgent[providers]>=1.4.1"',
+                'Manual fallback: pip install "GeoAgent[providers]>=1.5.0"',
             )
 
         self._deps_worker = None

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.4.1
+version=1.5.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,10 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.5.0 - Minor update for macOS dependency installation
+        - Improved dependency installer Python detection for macOS QGIS app bundles
+        - Raised the plugin dependency guidance to GeoAgent 1.5.0
+
     1.4.1 - Patch update for GEE Data Catalogs styling
         - Raised the plugin dependency guidance to GeoAgent 1.4.1
 

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -93,6 +93,90 @@ def test_uv_usable_requires_successful_verification(monkeypatch) -> None:
     assert deps_manager._uv_usable() is False
 
 
+def test_find_python_executable_uses_macos_base_executable(
+    monkeypatch, tmp_path
+) -> None:
+    """macOS QGIS exposes the GUI binary as sys.executable in some builds."""
+    import sys
+
+    from open_geoagent import deps_manager
+
+    macos_dir = tmp_path / "QGIS.app" / "Contents" / "MacOS"
+    macos_dir.mkdir(parents=True)
+    qgis_binary = macos_dir / "QGIS"
+    python_binary = macos_dir / (
+        f"python{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    qgis_binary.write_text("", encoding="utf-8")
+    python_binary.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(deps_manager.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(deps_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(deps_manager.sys, "executable", str(qgis_binary))
+    monkeypatch.setattr(
+        deps_manager.sys, "_base_executable", str(python_binary), raising=False
+    )
+
+    assert deps_manager._find_python_executable() == str(python_binary)
+
+
+def test_find_python_executable_finds_macos_bundle_python(
+    monkeypatch, tmp_path
+) -> None:
+    """The resolver should find Python inside QGIS.app, not return QGIS."""
+    import sys
+
+    from open_geoagent import deps_manager
+
+    macos_dir = tmp_path / "QGIS.app" / "Contents" / "MacOS"
+    macos_dir.mkdir(parents=True)
+    qgis_binary = macos_dir / "QGIS"
+    python_binary = macos_dir / (
+        f"python{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    qgis_binary.write_text("", encoding="utf-8")
+    python_binary.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(deps_manager.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(deps_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(deps_manager.sys, "executable", str(qgis_binary))
+    monkeypatch.setattr(
+        deps_manager.sys, "_base_executable", str(qgis_binary), raising=False
+    )
+    monkeypatch.setattr(deps_manager.sys, "_base_prefix", str(macos_dir), raising=False)
+    monkeypatch.setattr(deps_manager.sys, "prefix", str(macos_dir))
+    monkeypatch.setattr(deps_manager.shutil, "which", lambda _name: None)
+
+    assert deps_manager._find_python_executable() == str(python_binary)
+
+
+def test_find_python_executable_refuses_non_python_without_candidate(
+    monkeypatch, tmp_path
+) -> None:
+    """The installer must fail clearly instead of running a QGIS binary."""
+    from open_geoagent import deps_manager
+
+    qgis_binary = tmp_path / "QGIS"
+    qgis_binary.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(deps_manager.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(deps_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(deps_manager.sys, "executable", str(qgis_binary))
+    monkeypatch.setattr(
+        deps_manager.sys, "_base_executable", str(qgis_binary), raising=False
+    )
+    monkeypatch.setattr(deps_manager.sys, "_base_prefix", str(tmp_path), raising=False)
+    monkeypatch.setattr(deps_manager.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(deps_manager.shutil, "which", lambda _name: None)
+
+    try:
+        deps_manager._find_python_executable()
+    except RuntimeError as exc:
+        assert "cannot safely run QGIS itself" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError")
+
+
 def test_provider_test_worker_uses_ollama_safe_smoke_prompt(monkeypatch) -> None:
     """Ollama smoke tests should avoid GeoAgent's full prompt/token budget."""
     import sys

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -166,6 +166,10 @@ def test_find_python_executable_refuses_non_python_without_candidate(
         deps_manager.sys, "_base_executable", str(qgis_binary), raising=False
     )
     monkeypatch.setattr(deps_manager.sys, "_base_prefix", str(tmp_path), raising=False)
+    monkeypatch.setattr(deps_manager.sys, "base_prefix", str(tmp_path), raising=False)
+    monkeypatch.setattr(
+        deps_manager.sys, "base_exec_prefix", str(tmp_path), raising=False
+    )
     monkeypatch.setattr(deps_manager.sys, "prefix", str(tmp_path))
     monkeypatch.setattr(deps_manager.shutil, "which", lambda _name: None)
 

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -25,7 +25,7 @@ def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
     monkeypatch.setattr(
         deps_manager,
         "CORE_RUNTIME_PACKAGES",
-        [("geoagent", "GeoAgent[providers]>=1.4.1"), ("strands", "strands-agents")],
+        [("geoagent", "GeoAgent[providers]>=1.5.0"), ("strands", "strands-agents")],
     )
     monkeypatch.setattr(deps_manager, "ensure_venv_packages_available", lambda: True)
 
@@ -49,7 +49,7 @@ def test_required_dependencies_include_core_runtime_packages() -> None:
     """Dependency gate should catch partial GeoAgent installs."""
     from open_geoagent.deps_manager import REQUIRED_PACKAGES
 
-    assert ("geoagent", "GeoAgent[providers]>=1.4.1") in REQUIRED_PACKAGES
+    assert ("geoagent", "GeoAgent[providers]>=1.5.0") in REQUIRED_PACKAGES
     assert ("strands", "strands-agents>=1.37") in REQUIRED_PACKAGES
     assert ("pydantic", "pydantic>=2.0") in REQUIRED_PACKAGES
 


### PR DESCRIPTION
## Summary
- On macOS QGIS, `sys.executable` can point to the QGIS app binary, so `_find_python_executable` previously fell back to that path and dependency installs launched a second QGIS process instead of running Python.
- Search the QGIS.app bundle (`Contents/MacOS`, `Contents/Frameworks/Python.framework/Versions/.../bin`) and validate that candidates look like a Python interpreter before returning them.
- Raise a clear `RuntimeError` when no Python interpreter can be located, instead of silently returning the QGIS binary as a fallback.

## Test plan
- [x] `pre-commit run --all-files`
- [x] New tests in `qgis_geoagent/tests/test_settings_diagnostics.py` cover the macOS bundle resolution and the no-Python error path
- [ ] Manual smoke test on a macOS QGIS install