### PR TITLE
fix: make Gemini max-tokens optional and clarify max-token errors

### DIFF
--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -275,9 +275,36 @@ def _looks_like_json_parse_failure(exc: Exception) -> bool:
     return any(marker in text for marker in markers)
 
 
+def _looks_like_max_tokens_reached(exc: Exception) -> bool:
+    """Return True when Strands stopped because model output hit its cap."""
+    text = f"{type(exc).__name__}: {exc}".lower()
+    markers = (
+        "maxtokensreachedexception",
+        "max_tokens limit",
+        "stop_reason=max_tokens",
+        "stop reason: max_tokens",
+        "maximum token limit reached",
+        "exceeded the maximum output token limit",
+    )
+    return any(marker in text for marker in markers)
+
+
 def _format_chat_exception(exc: Exception) -> str:
     """Convert low-level provider/tool-call exceptions into user guidance."""
     original = str(exc).strip() or type(exc).__name__
+    if _looks_like_max_tokens_reached(exc):
+        return (
+            "The model hit its configured output-token limit before the agent "
+            "loop could finish. This usually means the model spent too many "
+            "tokens deciding or forming a tool call, or the accumulated tool "
+            "context became too large.\n\n"
+            f"Original error: {original}\n\n"
+            "How to correct it:\n"
+            "- Increase the model max tokens in settings.\n"
+            "- Retry with a more specific request, including the dataset, "
+            "region, date range, and layer name.\n"
+            "- Break long workflows into smaller steps if it keeps failing."
+        )
     if not _looks_like_json_parse_failure(exc):
         return original
     return (

--- a/geoagent/core/agent.py
+++ b/geoagent/core/agent.py
@@ -344,7 +344,7 @@ class GeoAgent:
             cfg = cfg.model_copy(update={"provider": provider})
         if model_id is not None:
             cfg = cfg.model_copy(update={"model": model_id})
-        if fast and cfg.max_tokens > 2048:
+        if fast and cfg.max_tokens is not None and cfg.max_tokens > 2048:
             cfg = cfg.model_copy(update={"max_tokens": 2048})
         self._config = cfg
         self._fast = fast

--- a/geoagent/core/config.py
+++ b/geoagent/core/config.py
@@ -54,7 +54,8 @@ class GeoAgentConfig(BaseModel):
         provider: Model provider id.
         model: Model id for the provider. If omitted, a provider default is used.
         temperature: Sampling temperature.
-        max_tokens: Maximum tokens in the model response.
+        max_tokens: Optional maximum tokens in the model response. ``None``
+            leaves the output limit to the provider or Strands default.
         ollama_host: Ollama server base URL (e.g. ``http://127.0.0.1:11434``).
         openai_codex_base_url: ChatGPT/Codex backend base URL.
         litellm_base_url: Optional LiteLLM proxy or OpenAI-compatible base URL.
@@ -65,7 +66,7 @@ class GeoAgentConfig(BaseModel):
     provider: ProviderName = Field(default_factory=_default_provider_from_env)
     model: Optional[str] = None
     temperature: float = 0.0
-    max_tokens: int = 4096
+    max_tokens: Optional[int] = None
     ollama_host: Optional[str] = Field(
         default=None, description="Ollama base URL, e.g. http://127.0.0.1:11434"
     )

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from geoagent.core.config import GeoAgentConfig, ProviderName
 
+
 def _openai_token_params(model_id: str, max_tokens: int | None) -> dict[str, int]:
     """Return the token-limit parameter supported by the OpenAI model family."""
     if max_tokens is None:

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from geoagent.core.config import GeoAgentConfig, ProviderName
 
+GEMINI_MIN_MAX_OUTPUT_TOKENS = 8192
+
 
 def _openai_token_params(model_id: str, max_tokens: int) -> dict[str, int]:
     """Return the token-limit parameter supported by the OpenAI model family."""
@@ -40,6 +42,11 @@ def _model_uses_default_temperature_only(model_id: str) -> bool:
             "openai/o4",
         )
     )
+
+
+def _gemini_max_output_tokens(max_tokens: int) -> int:
+    """Return a practical Gemini output cap for agentic tool workflows."""
+    return max(int(max_tokens), GEMINI_MIN_MAX_OUTPUT_TOKENS)
 
 
 def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any:
@@ -149,7 +156,7 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
             model_id=model_id,
             params={
                 "temperature": cfg.temperature,
-                "max_output_tokens": cfg.max_tokens,
+                "max_output_tokens": _gemini_max_output_tokens(cfg.max_tokens),
             },
         )
 

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -7,11 +7,10 @@ from typing import Any
 
 from geoagent.core.config import GeoAgentConfig, ProviderName
 
-GEMINI_MIN_MAX_OUTPUT_TOKENS = 8192
-
-
-def _openai_token_params(model_id: str, max_tokens: int) -> dict[str, int]:
+def _openai_token_params(model_id: str, max_tokens: int | None) -> dict[str, int]:
     """Return the token-limit parameter supported by the OpenAI model family."""
+    if max_tokens is None:
+        return {}
     normalized = str(model_id or "").lower()
     completion_prefixes = (
         "gpt-5",
@@ -44,9 +43,11 @@ def _model_uses_default_temperature_only(model_id: str) -> bool:
     )
 
 
-def _gemini_max_output_tokens(max_tokens: int) -> int:
-    """Return a practical Gemini output cap for agentic tool workflows."""
-    return max(int(max_tokens), GEMINI_MIN_MAX_OUTPUT_TOKENS)
+def _token_param(name: str, max_tokens: int | None) -> dict[str, int]:
+    """Return a provider token parameter only when explicitly configured."""
+    if max_tokens is None:
+        return {}
+    return {name: int(max_tokens)}
 
 
 def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any:
@@ -68,7 +69,8 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         model_id = cfg.model or os.environ.get(
             "BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-6"
         )
-        params = {"temperature": cfg.temperature, "max_tokens": cfg.max_tokens}
+        params = {"temperature": cfg.temperature}
+        params.update(_token_param("max_tokens", cfg.max_tokens))
         return BedrockModel(model_id=model_id, params=params)
 
     if provider == "openai":
@@ -133,11 +135,14 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
 
         model_id = cfg.model or os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-6")
         client_args = dict(cfg.client_args)
+        kwargs: dict[str, Any] = {}
+        if cfg.max_tokens is not None:
+            kwargs["max_tokens"] = int(cfg.max_tokens)
         return AnthropicModel(
             client_args=client_args or None,
             model_id=model_id,
-            max_tokens=cfg.max_tokens,
             params={"temperature": cfg.temperature},
+            **kwargs,
         )
 
     if provider == "gemini":
@@ -151,13 +156,12 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
         if api_key and "api_key" not in client_args:
             client_args["api_key"] = api_key
+        params = {"temperature": cfg.temperature}
+        params.update(_token_param("max_output_tokens", cfg.max_tokens))
         return GeminiModel(
             client_args=client_args or None,
             model_id=model_id,
-            params={
-                "temperature": cfg.temperature,
-                "max_output_tokens": _gemini_max_output_tokens(cfg.max_tokens),
-            },
+            params=params,
         )
 
     if provider == "ollama":
@@ -167,11 +171,14 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
             "OLLAMA_HOST", "http://127.0.0.1:11434"
         )
         model_id = cfg.model or os.environ.get("OLLAMA_MODEL", "qwen3.5:4b")
+        kwargs = {}
+        if cfg.max_tokens is not None:
+            kwargs["max_tokens"] = int(cfg.max_tokens)
         return OllamaModel(
             host,
             model_id=model_id,
             temperature=cfg.temperature,
-            max_tokens=cfg.max_tokens,
+            **kwargs,
         )
 
     if provider == "litellm":
@@ -185,7 +192,7 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         base_url = cfg.litellm_base_url or os.environ.get("LITELLM_BASE_URL")
         if base_url and "base_url" not in client_args:
             client_args["base_url"] = base_url
-        params = {"max_tokens": cfg.max_tokens}
+        params = _token_param("max_tokens", cfg.max_tokens)
         if not _model_uses_default_temperature_only(model_id):
             params["temperature"] = cfg.temperature
         return LiteLLMModel(

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -417,6 +417,32 @@ def _format_chat_worker_error(exc, provider="", agent_mode=""):
     is_opera_mode = "opera" in agent_mode.lower()
 
     if (
+        "maxtokensreachedexception" in cls_name
+        or "max_tokens limit" in lower
+        or "stop_reason=max_tokens" in lower
+        or "maximum token limit reached" in lower
+        or "exceeded the maximum output token limit" in lower
+    ):
+        advice = (
+            "The model hit its output-token limit before OpenGeoAgent could "
+            f"finish the {mode_label} tool workflow. This is a model budget "
+            "stop, not a QGIS or Earth Engine load failure."
+        )
+        if provider == "gemini":
+            advice += (
+                "\n\nFor Gemini, increase Settings > Model > Max tokens to "
+                "16384 or 32768 if this persists. Gemini thinking/tool-call "
+                "turns can consume more output tokens than the final visible "
+                "answer."
+            )
+        else:
+            advice += (
+                f"\n\nIncrease Settings > Model > Max tokens for "
+                f"{provider_label}, or retry with a narrower request."
+            )
+        return f"{advice}\n\nOriginal error: {raw}"
+
+    if (
         "tlsv1_alert_decode_error" in lower
         or "api connection error" in lower
         or "connection error" in lower

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -71,6 +71,7 @@ from qgis.PyQt.QtWidgets import (
 
 SETTINGS_PREFIX = "OpenGeoAgent/"
 DEFAULT_PROVIDER = "openai-codex"
+MAX_TOKENS_AUTO_VALUE = 0
 DEFAULT_MODELS = {
     "bedrock": "us.anthropic.claude-sonnet-4-6",
     "openai": "gpt-5.5",
@@ -378,6 +379,35 @@ def _default_model_for_provider(provider):
 def _setting(settings, key, default="", value_type=str):
     """Read a plugin setting value."""
     return settings.value(f"{SETTINGS_PREFIX}{key}", default, type=value_type)
+
+
+def _max_tokens_from_settings(settings):
+    """Read the optional max-token setting; blank/auto means provider default."""
+    value = settings.value(f"{SETTINGS_PREFIX}max_tokens", "", type=str)
+    text = str(value or "").strip()
+    if not text or text.lower() in {"auto", "none", "null"}:
+        return None
+    try:
+        parsed = int(text)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _max_tokens_to_setting(value):
+    """Return the QSettings value for an optional max-token selection."""
+    if value is None:
+        return ""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return ""
+    return parsed if parsed > 0 else ""
+
+
+def _max_tokens_to_display(value):
+    """Return a diagnostics-friendly display value for optional max tokens."""
+    return value if value is not None else "Auto"
 
 
 def _apply_environment_from_settings(settings):
@@ -3394,7 +3424,7 @@ class ChatDockWidget(QDockWidget):
         permission_profile = self.permission_combo.currentText()
         if permission_profile == "Trusted auto-approve":
             auto_approve_tools = True
-        max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        max_tokens = _max_tokens_from_settings(self.settings)
         image_model = _image_model_from_settings(self.settings)
         if not prompt:
             prompt = "Describe the attached image."

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -416,12 +416,13 @@ def _format_chat_worker_error(exc, provider="", agent_mode=""):
     mode_label = agent_mode or "this mode"
     is_opera_mode = "opera" in agent_mode.lower()
 
-    if (
-        "maxtokensreachedexception" in cls_name
-        or "max_tokens limit" in lower
-        or "stop_reason=max_tokens" in lower
-        or "maximum token limit reached" in lower
-        or "exceeded the maximum output token limit" in lower
+    try:
+        from geoagent.core.agent import _looks_like_max_tokens_reached
+    except Exception:
+        _looks_like_max_tokens_reached = None
+
+    if _looks_like_max_tokens_reached is not None and _looks_like_max_tokens_reached(
+        exc
     ):
         advice = (
             "The model hit its output-token limit before OpenGeoAgent could "
@@ -2009,15 +2010,25 @@ class ChatWorker(QThread):
             list(tool_metrics.keys()) if isinstance(tool_metrics, dict) else []
         )
         stop_reason = str(getattr(final_result, "stop_reason", "end_turn"))
-        success = stop_reason not in ("cancelled", "guardrail_intervened")
+        failure_stop_reasons = ("cancelled", "guardrail_intervened", "max_tokens")
+        success = stop_reason not in failure_stop_reasons
         if self.isInterruptionRequested():
             success = False
+
+        if success:
+            error_text = ""
+        else:
+            error_text = _format_chat_worker_error(
+                RuntimeError(f"stop_reason={stop_reason}"),
+                provider=self.provider,
+                agent_mode=self.agent_mode,
+            )
 
         self.finished.emit(
             {
                 "success": success,
                 "answer": "".join(chunks) or final_text,
-                "error": "" if success else f"stop_reason={stop_reason}",
+                "error": error_text,
                 "images": images,
                 "tools": ", ".join(executed_tools),
                 "tool_calls": tool_calls,

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -395,14 +395,21 @@ def _max_tokens_from_settings(settings):
 
 
 def _max_tokens_to_setting(value):
-    """Return the QSettings value for an optional max-token selection."""
+    """Return the QSettings value for an optional max-token selection.
+
+    Positive values below the historical 256-token minimum are clamped up to
+    256 so that the new Auto sentinel (0) does not silently allow tiny limits
+    that the spinbox previously disallowed.
+    """
     if value is None:
         return ""
     try:
         parsed = int(value)
     except (TypeError, ValueError):
         return ""
-    return parsed if parsed > 0 else ""
+    if parsed <= 0:
+        return ""
+    return max(parsed, 256)
 
 
 def _max_tokens_to_display(value):

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -35,10 +35,14 @@ from .chat_dock import (
     DEFAULT_TRANSCRIPTION_MODEL,
     DEFAULT_VOICE_SHORTCUT,
     IMAGE_MODELS,
+    MAX_TOKENS_AUTO_VALUE,
     PROVIDERS,
     SETTINGS_PREFIX,
     TRANSCRIPTION_MODELS,
     VOICE_SHORTCUT_SETTING,
+    _max_tokens_from_settings,
+    _max_tokens_to_display,
+    _max_tokens_to_setting,
 )
 from ..oauth import (
     CODEX_DEFAULT_CONFIG,
@@ -202,9 +206,7 @@ def collect_diagnostics(
                 type=str,
             )
             or DEFAULT_VOICE_SHORTCUT,
-            "max_tokens": settings.value(
-                f"{SETTINGS_PREFIX}max_tokens", 4096, type=int
-            ),
+            "max_tokens": _max_tokens_to_display(_max_tokens_from_settings(settings)),
         },
         "credential_presence": credential_presence,
         "latest_install_status": latest_install_status,
@@ -236,7 +238,6 @@ class ProviderTestWorker(QThread):
             from geoagent.core.model import resolve_model
             from strands import Agent
 
-            token_floor = 4096 if self.provider == "ollama" else 1024
             cfg = GeoAgentConfig(
                 provider=self.provider,
                 model=self.model_id or None,
@@ -245,7 +246,7 @@ class ProviderTestWorker(QThread):
                     if _model_requires_default_temperature(self.provider, self.model_id)
                     else 0
                 ),
-                max_tokens=max(int(self.max_tokens or token_floor), token_floor),
+                max_tokens=self.max_tokens,
             )
             model = resolve_model(cfg)
             agent = Agent(
@@ -538,8 +539,9 @@ class SettingsDockWidget(QDockWidget):
         form.addRow("", self.fast_check)
 
         self.max_tokens_spin = QSpinBox()
-        self.max_tokens_spin.setRange(256, 32768)
-        self.max_tokens_spin.setValue(4096)
+        self.max_tokens_spin.setRange(MAX_TOKENS_AUTO_VALUE, 32768)
+        self.max_tokens_spin.setSpecialValueText("Auto")
+        self.max_tokens_spin.setValue(MAX_TOKENS_AUTO_VALUE)
         self.max_tokens_spin.setSingleStep(256)
         form.addRow("Max tokens:", self.max_tokens_spin)
 
@@ -973,7 +975,7 @@ class SettingsDockWidget(QDockWidget):
             self.settings.value(f"{SETTINGS_PREFIX}fast_mode", False, type=bool)
         )
         self.max_tokens_spin.setValue(
-            self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+            _max_tokens_from_settings(self.settings) or MAX_TOKENS_AUTO_VALUE
         )
         transcription_model = (
             self.settings.value(
@@ -1052,7 +1054,8 @@ class SettingsDockWidget(QDockWidget):
             f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
         )
         self.settings.setValue(
-            f"{SETTINGS_PREFIX}max_tokens", self.max_tokens_spin.value()
+            f"{SETTINGS_PREFIX}max_tokens",
+            _max_tokens_to_setting(self.max_tokens_spin.value()),
         )
         self.settings.setValue(
             f"{SETTINGS_PREFIX}transcription_model",
@@ -1097,7 +1100,7 @@ class SettingsDockWidget(QDockWidget):
         self._provider_test_worker = ProviderTestWorker(
             provider,
             model_id,
-            self.max_tokens_spin.value(),
+            _max_tokens_from_settings(self.settings),
             self.settings,
             self,
         )

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -7,8 +7,15 @@ import sys
 import time
 
 from qgis.PyQt.QtCore import Qt, QSettings, QThread, QTimer, QUrl, pyqtSignal
-from qgis.PyQt.QtGui import QDesktopServices, QFont, QGuiApplication, QKeySequence
+from qgis.PyQt.QtGui import (
+    QDesktopServices,
+    QFont,
+    QGuiApplication,
+    QKeySequence,
+    QValidator,
+)
 from qgis.PyQt.QtWidgets import (
+    QAbstractSpinBox,
     QCheckBox,
     QComboBox,
     QDockWidget,
@@ -268,6 +275,37 @@ def _enum_value(cls, enum_name, member_name):
     """Return an enum member from either scoped or legacy Qt APIs."""
     container = getattr(cls, enum_name, cls)
     return getattr(container, member_name)
+
+
+class _OptionalMaxTokensSpinBox(QSpinBox):
+    """Spin box that treats blank or Auto text as provider-default tokens."""
+
+    def validate(self, text, pos):
+        """Accept blank/Auto text so users can clear the field."""
+        cleaned = str(text or "").strip()
+        if not cleaned or "auto".startswith(cleaned.lower()):
+            state = _enum_value(QValidator, "State", "Acceptable")
+            return state, text, pos
+        return super().validate(text, pos)
+
+    def valueFromText(self, text):
+        """Convert blank/Auto text to the Auto sentinel."""
+        cleaned = str(text or "").strip()
+        if not cleaned or "auto".startswith(cleaned.lower()):
+            return MAX_TOKENS_AUTO_VALUE
+        return super().valueFromText(text)
+
+    def textFromValue(self, value):
+        """Display the Auto sentinel as text instead of ``0``."""
+        if int(value) <= MAX_TOKENS_AUTO_VALUE:
+            return "Auto"
+        return super().textFromValue(value)
+
+    def fixup(self, text):
+        """Normalize blank text to Auto during spinbox correction."""
+        if not str(text or "").strip():
+            return "Auto"
+        return super().fixup(text)
 
 
 def _key_sequence_text(sequence):
@@ -538,9 +576,12 @@ class SettingsDockWidget(QDockWidget):
         self.fast_check = QCheckBox("Use fast GeoAgent prompt")
         form.addRow("", self.fast_check)
 
-        self.max_tokens_spin = QSpinBox()
+        self.max_tokens_spin = _OptionalMaxTokensSpinBox()
         self.max_tokens_spin.setRange(MAX_TOKENS_AUTO_VALUE, 32768)
         self.max_tokens_spin.setSpecialValueText("Auto")
+        self.max_tokens_spin.setCorrectionMode(
+            _enum_value(QAbstractSpinBox, "CorrectionMode", "CorrectToNearestValue")
+        )
         self.max_tokens_spin.setValue(MAX_TOKENS_AUTO_VALUE)
         self.max_tokens_spin.setSingleStep(256)
         form.addRow("Max tokens:", self.max_tokens_spin)

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -18,6 +18,7 @@ from open_geoagent.dialogs.chat_dock import (
     _latest_executable_snippet,
     _latest_pyqgis_script,
     _markdown_to_basic_html,
+    _max_tokens_to_setting,
     _message_images_html,
     _message_images_markdown,
     _prepare_output_images,
@@ -98,6 +99,23 @@ def test_format_chat_worker_error_explains_gemini_token_limit() -> None:
     assert "output-token limit" in error
     assert "not a QGIS or Earth Engine load failure" in error
     assert "16384 or 32768" in error
+
+
+def test_max_tokens_to_setting_clamps_below_minimum() -> None:
+    """Verify positive values below 256 are normalized to the historical floor.
+
+    The spinbox now allows 0 to expose the Auto sentinel, which incidentally
+    lets users type 1-255. Those should snap to 256 on save so the saved
+    config never holds a value the spinbox previously disallowed.
+    """
+
+    assert _max_tokens_to_setting(0) == ""
+    assert _max_tokens_to_setting(None) == ""
+    assert _max_tokens_to_setting(1) == 256
+    assert _max_tokens_to_setting(255) == 256
+    assert _max_tokens_to_setting(256) == 256
+    assert _max_tokens_to_setting(4096) == 4096
+    assert _max_tokens_to_setting(32768) == 32768
 
 
 def test_format_chat_worker_error_matches_streaming_stop_reason_phrasings() -> None:

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -100,6 +100,25 @@ def test_format_chat_worker_error_explains_gemini_token_limit() -> None:
     assert "16384 or 32768" in error
 
 
+def test_format_chat_worker_error_matches_streaming_stop_reason_phrasings() -> None:
+    """Verify both ``stop_reason=max_tokens`` and ``stop reason: max_tokens`` match.
+
+    The QGIS UI must catch every max-token phrasing the core agent recognizes,
+    so the streaming path and exception path stay in sync.
+    """
+
+    for raw in (
+        "stop_reason=max_tokens",
+        "Stop reason: max_tokens",
+    ):
+        error = _format_chat_worker_error(
+            RuntimeError(raw),
+            provider="gemini",
+            agent_mode="STAC",
+        )
+        assert "output-token limit" in error, raw
+
+
 def test_markdown_renderer_supports_image_references() -> None:
     """Verify Markdown image output is rendered as inline HTML."""
     html = _markdown_to_basic_html("![Map](https://example.com/map.png)")

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -84,6 +84,22 @@ def test_conversation_markdown_includes_output_images() -> None:
     assert "![Map](</tmp/open geoagent/map.png>)" in text
 
 
+def test_format_chat_worker_error_explains_gemini_token_limit() -> None:
+    """Verify Gemini max-token stops are reported as model budget failures."""
+
+    error = _format_chat_worker_error(
+        RuntimeError(
+            "Agent has reached an unrecoverable state due to max_tokens limit."
+        ),
+        provider="gemini",
+        agent_mode="GEE Data Catalogs",
+    )
+
+    assert "output-token limit" in error
+    assert "not a QGIS or Earth Engine load failure" in error
+    assert "16384 or 32768" in error
+
+
 def test_markdown_renderer_supports_image_references() -> None:
     """Verify Markdown image output is rendered as inline HTML."""
     html = _markdown_to_basic_html("![Map](https://example.com/map.png)")

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -221,7 +221,7 @@ def test_provider_test_worker_uses_ollama_safe_smoke_prompt(monkeypatch) -> None
     worker.run()
 
     assert emitted["result"]["success"] is True
-    assert captured["config"]["max_tokens"] == 4096
+    assert captured["config"]["max_tokens"] == 256
     assert captured["agent_kwargs"]["tools"] == []
     assert "provider connectivity test" in captured["agent_kwargs"]["system_prompt"]
     assert captured["prompt"].startswith("/no_think")

--- a/tests/test_model_providers.py
+++ b/tests/test_model_providers.py
@@ -167,6 +167,75 @@ def test_openai_codex_requires_token(monkeypatch) -> None:
         resolve_model(GeoAgentConfig(provider="openai-codex"))
 
 
+def test_resolve_gemini_uses_agentic_token_floor(monkeypatch) -> None:
+    """Verify Gemini gets enough output budget for multi-step tool calls."""
+
+    class FakeGeminiModel:
+        """Capture Gemini constructor arguments."""
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module = types.ModuleType("strands.models.gemini")
+    module.GeminiModel = FakeGeminiModel
+    monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models",
+        types.ModuleType("strands.models"),
+    )
+    monkeypatch.setitem(sys.modules, "strands.models.gemini", module)
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    model = resolve_model(
+        GeoAgentConfig(
+            provider="gemini",
+            model="gemini-3.1-pro-preview",
+            temperature=0,
+            max_tokens=4096,
+        )
+    )
+
+    assert isinstance(model, FakeGeminiModel)
+    assert model.kwargs == {
+        "client_args": {"api_key": "test-key"},
+        "model_id": "gemini-3.1-pro-preview",
+        "params": {"temperature": 0, "max_output_tokens": 8192},
+    }
+
+
+def test_resolve_gemini_preserves_larger_token_limit(monkeypatch) -> None:
+    """Verify explicit large Gemini limits are preserved."""
+
+    class FakeGeminiModel:
+        """Capture Gemini constructor arguments."""
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module = types.ModuleType("strands.models.gemini")
+    module.GeminiModel = FakeGeminiModel
+    monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models",
+        types.ModuleType("strands.models"),
+    )
+    monkeypatch.setitem(sys.modules, "strands.models.gemini", module)
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    model = resolve_model(
+        GeoAgentConfig(
+            provider="gemini",
+            model="gemini-3.1-pro-preview",
+            max_tokens=16384,
+        )
+    )
+
+    assert model.kwargs["params"]["max_output_tokens"] == 16384
+
+
 def test_resolve_litellm_model(monkeypatch) -> None:
     """Verify that LiteLLM config resolves to the Strands LiteLLM model."""
 

--- a/tests/test_model_providers.py
+++ b/tests/test_model_providers.py
@@ -40,6 +40,11 @@ def test_litellm_config_is_valid() -> None:
     assert cfg.model == "openai/gpt-5.5"
 
 
+def test_max_tokens_defaults_to_provider_auto() -> None:
+    """Verify default config leaves output token limits to the provider."""
+    assert GeoAgentConfig().max_tokens is None
+
+
 def test_openai_codex_config_is_valid() -> None:
     """Verify that OpenAI Codex OAuth is accepted as a provider."""
     cfg = GeoAgentConfig(provider="openai-codex", model="gpt-5.5")
@@ -167,8 +172,8 @@ def test_openai_codex_requires_token(monkeypatch) -> None:
         resolve_model(GeoAgentConfig(provider="openai-codex"))
 
 
-def test_resolve_gemini_uses_agentic_token_floor(monkeypatch) -> None:
-    """Verify Gemini gets enough output budget for multi-step tool calls."""
+def test_resolve_gemini_auto_omits_max_output_tokens(monkeypatch) -> None:
+    """Verify Gemini auto mode leaves max output tokens to the provider."""
 
     class FakeGeminiModel:
         """Capture Gemini constructor arguments."""
@@ -192,7 +197,6 @@ def test_resolve_gemini_uses_agentic_token_floor(monkeypatch) -> None:
             provider="gemini",
             model="gemini-3.1-pro-preview",
             temperature=0,
-            max_tokens=4096,
         )
     )
 
@@ -200,12 +204,12 @@ def test_resolve_gemini_uses_agentic_token_floor(monkeypatch) -> None:
     assert model.kwargs == {
         "client_args": {"api_key": "test-key"},
         "model_id": "gemini-3.1-pro-preview",
-        "params": {"temperature": 0, "max_output_tokens": 8192},
+        "params": {"temperature": 0},
     }
 
 
-def test_resolve_gemini_preserves_larger_token_limit(monkeypatch) -> None:
-    """Verify explicit large Gemini limits are preserved."""
+def test_resolve_gemini_preserves_explicit_token_limit(monkeypatch) -> None:
+    """Verify explicit Gemini token limits are preserved."""
 
     class FakeGeminiModel:
         """Capture Gemini constructor arguments."""


### PR DESCRIPTION
## Summary
- Treat `max_tokens` as optional across providers. For Gemini in particular, omit `max_output_tokens` when no explicit limit is set so the provider's native output budget is used. Explicit user values are preserved as-is.
- Add an Auto sentinel (0) to the QGIS settings spinbox so users can opt into provider-default behavior. Positive values below the historical 256-token minimum are clamped up to 256 on save so the saved config never holds a tiny limit the spinbox previously disallowed.
- Convert opaque max-token stops into actionable guidance in both the core agent and the QGIS chat dock. Streaming runs route the same guidance through `_format_chat_worker_error` so users see it instead of a truncated answer. Detection markers are now shared between the core helper and the UI.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_model_providers.py qgis_geoagent/tests/test_chat_tool_inputs.py -q`
- [ ] Manual: trigger a long Gemini tool workflow that previously stopped on `max_tokens` and confirm the new guidance is shown.