### PR TITLE
feat: add browser MapLibre agent factory and WebSocket runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ ENV/
 # mypy
 .mypy_cache/
 
+# JavaScript dependencies
+node_modules/
+
 # IDE settings
 .vscode/
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ and `pydantic`. Geospatial packages and provider clients are optional extras:
 | `GeoAgent[geoai]`       | geoai integration dependencies.                                   |
 | `GeoAgent[earthengine]` | Google Earth Engine dependencies.                                 |
 | `GeoAgent[ui]`          | Solara UI dependencies.                                           |
+| `GeoAgent[browser]`     | FastAPI WebSocket backend for browser MapLibre apps.              |
 | `GeoAgent[providers]`   | OpenAI, Anthropic, Gemini, Ollama, and LiteLLM provider clients.  |
 | `GeoAgent[all]`         | Most optional integrations. QGIS itself remains system-installed. |
 
@@ -237,6 +238,24 @@ The Solara UI opens directly to a map chat workspace with provider/model
 controls, fast mode, session chat history, compact tool-call results, and a
 conservative confirmation policy. Confirmation-required tools are denied by
 default unless you enable auto-approve in the UI.
+
+Use GeoAgent from a custom browser MapLibre app:
+
+```bash
+pip install "GeoAgent[browser]"
+geoagent codex login
+geoagent browser --host 127.0.0.1 --port 8765 --model gpt-5.5
+```
+
+Then open the end-to-end example in
+`examples/browser_maplibre/`. The page connects to `/geoagent/ws`, sends chat
+prompts, executes `map_command` messages against a live MapLibre map, and
+returns `map_command_result` messages to the backend. The browser backend uses
+the `openai-codex` provider by default; pass `--provider` to use a different
+provider.
+
+A TypeScript/Vite version is available in
+`examples/browser_maplibre_typescript/`.
 
 Use GeoAgent inside QGIS:
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ provider.
 A TypeScript/Vite version is available in
 `examples/browser_maplibre_typescript/`.
 
+For local sessions where you want PyQGIS-style fallback behavior, add
+`--allow-browser-code`. This exposes `run_maplibre_script`, allowing the agent
+to execute generated MapLibre JavaScript in the browser when no dedicated tool
+fits the request.
+
+To let the agent remove or clear browser map layers in trusted local sessions,
+add `--auto-approve-browser-tools`.
+
 Use GeoAgent inside QGIS:
 
 ```python

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,8 @@ Runnable Jupyter notebooks live under **`docs/examples/`**:
 - **`docs/examples/live_mapping.ipynb`** — leafmap MapLibre + Claude; camera comes from **`m.view_state`** (see `get_map_state` tool).
 - **`docs/examples/qgis_agent.ipynb`** — QGIS-oriented tools using mock `iface` in Jupyter; snippet for real QGIS included.
 - **`docs/examples/stac_workflow.ipynb`** — STAC catalog search, asset inspection, and mock QGIS raster loading.
+- **`examples/browser_maplibre/`** — end-to-end browser MapLibre client for the `geoagent browser` WebSocket backend.
+- **`examples/browser_maplibre_typescript/`** — TypeScript/Vite version of the browser MapLibre WebSocket client.
 - **`examples/nasa_opera_qgis.py`** — NASA OPERA search and footprints workflow for the QGIS Python console.
 
 Install extras as shown in each notebook (`GeoAgent[anthropic]`, `GeoAgent[anthropic,leafmap]`, `GeoAgent[stac]`).

--- a/examples/browser_maplibre/README.md
+++ b/examples/browser_maplibre/README.md
@@ -44,6 +44,24 @@ Destructive tools such as `remove_layer` and `clear_layers` are denied by the
 backend's default confirmation policy. This is intentional for browser
 sessions.
 
+For trusted local sessions where the agent should be able to remove or clear
+browser map layers, start the backend with:
+
+```bash
+geoagent browser --host 127.0.0.1 --port 8765 --model gpt-5.5 --auto-approve-browser-tools
+```
+
+To allow PyQGIS-style fallback code execution for local browser sessions, start
+the backend with:
+
+```bash
+geoagent browser --host 127.0.0.1 --port 8765 --model gpt-5.5 --allow-browser-code
+```
+
+This exposes `run_maplibre_script`, which lets the agent execute generated
+MapLibre JavaScript in the page when no dedicated browser map tool fits.
+Use both flags together if you want layer removal and generated JavaScript.
+
 ## Protocol
 
 The page handles `map_command` messages from `/geoagent/ws` and returns
@@ -67,6 +85,7 @@ The page handles `map_command` messages from `/geoagent/ws` and returns
 - `screenshot_map`
 - `remove_layer`
 - `clear_layers`
+- `run_maplibre_script` when the backend is started with `--allow-browser-code`
 
 `add_vector_data` expects a GeoJSON URL in this example because the Python tool
 does not provide enough metadata to render arbitrary vector tile sources.

--- a/examples/browser_maplibre/README.md
+++ b/examples/browser_maplibre/README.md
@@ -1,0 +1,72 @@
+# Browser MapLibre Example
+
+This example is a small end-to-end browser client for
+`geoagent browser`. It creates a MapLibre map, connects to the GeoAgent
+WebSocket backend, sends chat prompts, and executes browser map commands sent
+by the agent.
+
+For a buildable TypeScript/Vite version, see
+`examples/browser_maplibre_typescript/`.
+
+## Run
+
+From the repository root, install the browser backend and log in with the
+default ChatGPT/Codex OAuth provider:
+
+```bash
+python -m pip install -e ".[browser]"
+geoagent codex login
+geoagent browser --host 127.0.0.1 --port 8765 --model gpt-5.5
+```
+
+In a second terminal, serve this directory:
+
+```bash
+cd examples/browser_maplibre
+python -m http.server 8000
+```
+
+Open <http://127.0.0.1:8000>, click **Connect**, then try prompts such as:
+
+```text
+Add a red marker for Knoxville and zoom to it.
+```
+
+```text
+Add an OpenStreetMap tile layer and list the layers.
+```
+
+```text
+Change the basemap to dark, then get the current map state.
+```
+
+Destructive tools such as `remove_layer` and `clear_layers` are denied by the
+backend's default confirmation policy. This is intentional for browser
+sessions.
+
+## Protocol
+
+The page handles `map_command` messages from `/geoagent/ws` and returns
+`map_command_result` messages. The supported command names match
+`geoagent.tools.browser_maplibre`:
+
+- `list_layers`
+- `get_map_state`
+- `set_center`
+- `fly_to`
+- `set_zoom`
+- `zoom_to_bounds`
+- `change_basemap`
+- `add_marker`
+- `add_geojson_data`
+- `add_vector_data`
+- `add_xyz_tile_layer`
+- `set_layer_visibility`
+- `set_layer_opacity`
+- `query_rendered_features`
+- `screenshot_map`
+- `remove_layer`
+- `clear_layers`
+
+`add_vector_data` expects a GeoJSON URL in this example because the Python tool
+does not provide enough metadata to render arbitrary vector tile sources.

--- a/examples/browser_maplibre/index.html
+++ b/examples/browser_maplibre/index.html
@@ -1,0 +1,1047 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GeoAgent Browser MapLibre Example</title>
+    <link
+      href="https://unpkg.com/maplibre-gl@5.12.0/dist/maplibre-gl.css"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        --border: #d7dde5;
+        --ink: #17202a;
+        --muted: #5f6b7a;
+        --panel: #ffffff;
+        --panel-soft: #f6f8fb;
+        --primary: #0f766e;
+        --danger: #b42318;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        color: var(--ink);
+        background: #eef2f6;
+      }
+
+      #map {
+        position: fixed;
+        inset: 0;
+      }
+
+      .panel {
+        position: fixed;
+        z-index: 2;
+        top: 16px;
+        left: 16px;
+        width: min(430px, calc(100vw - 32px));
+        max-height: calc(100vh - 32px);
+        display: grid;
+        grid-template-rows: auto auto;
+        gap: 12px;
+        padding: 14px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: color-mix(in srgb, var(--panel) 94%, transparent);
+        box-shadow: 0 18px 50px rgb(15 23 42 / 18%);
+      }
+
+      .title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .title-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 17px;
+        line-height: 1.2;
+        font-weight: 700;
+      }
+
+      .status {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+        padding: 0 8px;
+        border-radius: 999px;
+        background: #edf2f7;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      .status.connected {
+        background: #dff6ee;
+        color: #076448;
+      }
+
+      .status.error {
+        background: #fee4e2;
+        color: var(--danger);
+      }
+
+      label {
+        display: grid;
+        gap: 5px;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 650;
+      }
+
+      input,
+      textarea,
+      button {
+        font: inherit;
+      }
+
+      input,
+      textarea {
+        width: 100%;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: #fff;
+        color: var(--ink);
+      }
+
+      input {
+        height: 36px;
+        padding: 0 10px;
+      }
+
+      textarea {
+        min-height: 86px;
+        resize: vertical;
+        padding: 9px 10px;
+        line-height: 1.35;
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 8px;
+        align-items: end;
+      }
+
+      .actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      button {
+        min-height: 36px;
+        padding: 0 12px;
+        border: 1px solid transparent;
+        border-radius: 6px;
+        background: var(--primary);
+        color: #fff;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      button.secondary {
+        border-color: var(--border);
+        background: #fff;
+        color: var(--ink);
+      }
+
+      .panel-toggle {
+        display: inline-grid;
+        place-items: center;
+        width: 28px;
+        min-height: 28px;
+        height: 28px;
+        padding: 0;
+        border-radius: 6px;
+        color: var(--muted);
+      }
+
+      .panel-toggle svg {
+        width: 16px;
+        height: 16px;
+        stroke: currentColor;
+      }
+
+      .connect-toggle {
+        min-width: 92px;
+        min-height: 34px;
+        height: 34px;
+        padding: 0 10px;
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.55;
+      }
+
+      .panel-body {
+        display: grid;
+        gap: 12px;
+        min-height: 0;
+      }
+
+      .panel.collapsed {
+        width: 29px;
+        height: 29px;
+        max-height: 29px;
+        padding: 0;
+        gap: 0;
+      }
+
+      .panel.collapsed .title {
+        display: grid;
+        place-items: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      .panel.collapsed .title-actions {
+        display: grid;
+        place-items: center;
+      }
+
+      .panel.collapsed h1,
+      .panel.collapsed .status,
+      .panel.collapsed .panel-body {
+        display: none;
+      }
+
+      .panel.collapsed .panel-toggle {
+        width: 29px;
+        height: 29px;
+        min-height: 29px;
+        border: 0;
+        background: var(--primary);
+        color: #fff;
+      }
+
+      .panel.collapsed .panel-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
+
+      .log {
+        overflow: auto;
+        min-height: 160px;
+        max-height: min(280px, calc(100vh - 360px));
+        padding: 10px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--panel-soft);
+        font-size: 13px;
+        line-height: 1.4;
+      }
+
+      .entry {
+        margin: 0 0 10px;
+        padding-bottom: 10px;
+        border-bottom: 1px solid #e3e8ef;
+      }
+
+      .entry:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: 0;
+      }
+
+      .role {
+        margin-bottom: 3px;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      .text {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+
+      .hint {
+        margin: 0;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.35;
+      }
+
+      @media (max-width: 700px) {
+        .panel {
+          top: auto;
+          right: 10px;
+          bottom: 10px;
+          left: 10px;
+          width: auto;
+          max-height: min(72vh, 620px);
+        }
+
+        .panel.collapsed {
+          width: 29px;
+          height: 29px;
+          max-height: 29px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map" aria-label="MapLibre map"></div>
+
+    <section class="panel" aria-label="GeoAgent chat panel">
+      <div class="title">
+        <h1>GeoAgent</h1>
+        <div class="title-actions">
+          <span id="status" class="status">Disconnected</span>
+          <button
+            id="panel-toggle"
+            class="secondary panel-toggle"
+            type="button"
+            aria-expanded="true"
+            aria-label="Collapse panel"
+            title="Collapse panel"
+          >
+            <svg
+              id="panel-toggle-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m18 15-6-6-6 6"></path>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div id="panel-body" class="panel-body">
+        <div class="row">
+          <label>
+            WebSocket URL
+            <input id="ws-url" value="ws://127.0.0.1:8765/geoagent/ws" />
+          </label>
+          <button id="connect" class="connect-toggle" type="button">Connect</button>
+        </div>
+
+        <div id="log" class="log" aria-live="polite"></div>
+
+        <form id="chat-form">
+          <label>
+            Prompt
+            <textarea
+              id="prompt"
+              placeholder="Add a red marker for Knoxville and zoom to it."
+            ></textarea>
+          </label>
+          <div class="actions" style="margin-top: 8px">
+            <button id="send" type="submit" disabled>Send</button>
+            <button id="clear-log" class="secondary" type="button">Clear</button>
+          </div>
+        </form>
+
+        <p class="hint">
+          Start `geoagent browser` first. This page executes map commands in the
+          live browser map and sends results back to the Python agent.
+        </p>
+      </div>
+    </section>
+
+    <script src="https://unpkg.com/maplibre-gl@5.12.0/dist/maplibre-gl.js"></script>
+    <script>
+      const BASEMAPS = {
+        positron: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+        dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+        voyager: "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json",
+        demotiles: "https://demotiles.maplibre.org/style.json",
+        openstreetmap: "osm",
+        osm: {
+          version: 8,
+          sources: {
+            osm: {
+              type: "raster",
+              tiles: [
+                "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
+              ],
+              tileSize: 256,
+              attribution: "OpenStreetMap contributors",
+            },
+          },
+          layers: [{ id: "osm", type: "raster", source: "osm" }],
+        },
+      };
+
+      const map = new maplibregl.Map({
+        container: "map",
+        style: BASEMAPS.positron,
+        center: [-98.5795, 39.8283],
+        zoom: 3,
+        preserveDrawingBuffer: true,
+      });
+      map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+      const statusEl = document.querySelector("#status");
+      const connectButton = document.querySelector("#connect");
+      const panelEl = document.querySelector(".panel");
+      const panelToggleButton = document.querySelector("#panel-toggle");
+      const sendButton = document.querySelector("#send");
+      const wsUrlInput = document.querySelector("#ws-url");
+      const logEl = document.querySelector("#log");
+      const form = document.querySelector("#chat-form");
+      const promptEl = document.querySelector("#prompt");
+      const clearLogButton = document.querySelector("#clear-log");
+
+      let ws = null;
+      let sessionId = null;
+      let mapId = "default";
+      let busy = false;
+      let streamingAssistantTextEl = null;
+      let streamingAssistantText = "";
+      const history = [];
+      const overlays = new Map();
+
+      function setStatus(text, kind = "") {
+        statusEl.textContent = text;
+        statusEl.className = `status ${kind}`.trim();
+      }
+
+      function appendLog(role, text) {
+        const entry = document.createElement("div");
+        entry.className = "entry";
+        const roleEl = document.createElement("div");
+        roleEl.className = "role";
+        roleEl.textContent = role;
+        const textEl = document.createElement("div");
+        textEl.className = "text";
+        textEl.textContent = text;
+        entry.append(roleEl, textEl);
+        logEl.append(entry);
+        logEl.scrollTop = logEl.scrollHeight;
+        return textEl;
+      }
+
+      function updateControls() {
+        const connected = ws && ws.readyState === WebSocket.OPEN && sessionId;
+        sendButton.disabled = !connected || busy || !promptEl.value.trim();
+        connectButton.disabled = ws && ws.readyState === WebSocket.CONNECTING;
+      }
+
+      function togglePanel() {
+        const collapsed = !panelEl.classList.contains("collapsed");
+        panelEl.classList.toggle("collapsed", collapsed);
+        panelToggleButton.setAttribute("aria-expanded", String(!collapsed));
+        panelToggleButton.setAttribute(
+          "aria-label",
+          collapsed ? "Expand panel" : "Collapse panel",
+        );
+        panelToggleButton.title = collapsed ? "Expand panel" : "Collapse panel";
+        const iconPath = panelToggleButton.querySelector("path");
+        if (iconPath) {
+          iconPath.setAttribute("d", collapsed ? "m6 9 6 6 6-6" : "m18 15-6-6-6 6");
+        }
+      }
+
+      function waitForMapIdle() {
+        return new Promise((resolve) => {
+          if (map.loaded()) {
+            resolve();
+            return;
+          }
+          map.once("idle", resolve);
+        });
+      }
+
+      function slug(value) {
+        return String(value || "layer")
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9_-]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 60) || "layer";
+      }
+
+      function removeOverlay(name) {
+        const key = Array.from(overlays.keys()).find(
+          (item) => item === name || slug(item) === slug(name),
+        );
+        if (!key || !overlays.has(key)) {
+          return false;
+        }
+        const overlay = overlays.get(key);
+        for (const layerId of overlay.layerIds || []) {
+          if (map.getLayer(layerId)) {
+            map.removeLayer(layerId);
+          }
+        }
+        for (const sourceId of overlay.sourceIds || []) {
+          if (map.getSource(sourceId)) {
+            map.removeSource(sourceId);
+          }
+        }
+        if (overlay.marker) {
+          overlay.marker.remove();
+        }
+        overlays.delete(key);
+        return true;
+      }
+
+      function serializableFeature(feature) {
+        return {
+          type: "Feature",
+          geometry: feature.geometry || null,
+          properties: feature.properties || {},
+          layer: feature.layer
+            ? {
+                id: feature.layer.id,
+                type: feature.layer.type,
+                source: feature.layer.source,
+              }
+            : undefined,
+        };
+      }
+
+      function geojsonLayerPaint(style = {}) {
+        const color = style.color || style["line-color"] || "#1c7ed6";
+        const fillColor = style["fill-color"] || style.fillColor || color;
+        const lineColor = style["line-color"] || style.lineColor || color;
+        const circleColor = style["circle-color"] || style.circleColor || color;
+        const opacity = Number(style.opacity ?? style["fill-opacity"] ?? 0.35);
+        return {
+          fill: {
+            "fill-color": fillColor,
+            "fill-opacity": Math.max(0, Math.min(1, opacity)),
+          },
+          line: {
+            "line-color": lineColor,
+            "line-width": Number(style["line-width"] || style.lineWidth || 2),
+          },
+          circle: {
+            "circle-color": circleColor,
+            "circle-radius": Number(style["circle-radius"] || style.radius || 6),
+            "circle-stroke-color": "#ffffff",
+            "circle-stroke-width": 1,
+          },
+        };
+      }
+
+      async function addGeoJsonOverlay({ name, data, url, style = {} }) {
+        await waitForMapIdle();
+        removeOverlay(name);
+        const sourceId = `geoagent-src-${slug(name)}`;
+        const baseId = `geoagent-layer-${slug(name)}`;
+        const paint = geojsonLayerPaint(style);
+        map.addSource(sourceId, {
+          type: "geojson",
+          data: url || data,
+        });
+        const layerDefs = [
+          {
+            id: `${baseId}-fill`,
+            type: "fill",
+            filter: ["==", ["geometry-type"], "Polygon"],
+            paint: paint.fill,
+          },
+          {
+            id: `${baseId}-line`,
+            type: "line",
+            filter: [
+              "any",
+              ["==", ["geometry-type"], "LineString"],
+              ["==", ["geometry-type"], "Polygon"],
+            ],
+            paint: paint.line,
+          },
+          {
+            id: `${baseId}-point`,
+            type: "circle",
+            filter: ["==", ["geometry-type"], "Point"],
+            paint: paint.circle,
+          },
+        ];
+        for (const def of layerDefs) {
+          map.addLayer({ ...def, source: sourceId });
+        }
+        overlays.set(name, {
+          kind: "geojson",
+          name,
+          data,
+          url,
+          style,
+          sourceIds: [sourceId],
+          layerIds: layerDefs.map((item) => item.id),
+        });
+      }
+
+      async function addRasterOverlay({ name, url, attribution = "" }) {
+        await waitForMapIdle();
+        removeOverlay(name);
+        const sourceId = `geoagent-src-${slug(name)}`;
+        const layerId = `geoagent-layer-${slug(name)}`;
+        map.addSource(sourceId, {
+          type: "raster",
+          tiles: [url],
+          tileSize: 256,
+          attribution,
+        });
+        map.addLayer({
+          id: layerId,
+          type: "raster",
+          source: sourceId,
+        });
+        overlays.set(name, {
+          kind: "raster",
+          name,
+          url,
+          attribution,
+          sourceIds: [sourceId],
+          layerIds: [layerId],
+        });
+      }
+
+      function addMarkerOverlay(args) {
+        const name = args.name || `marker-${overlays.size + 1}`;
+        removeOverlay(name);
+        const marker = new maplibregl.Marker({
+          color: args.color || "#3388ff",
+        })
+          .setLngLat([Number(args.lon), Number(args.lat)])
+          .addTo(map);
+        marker.getElement().title = args.tooltip || args.popup || name;
+        if (args.popup) {
+          marker.setPopup(new maplibregl.Popup().setText(args.popup));
+        }
+        overlays.set(name, {
+          kind: "marker",
+          name,
+          marker,
+          lngLat: [Number(args.lon), Number(args.lat)],
+          layerIds: [],
+          sourceIds: [],
+        });
+        return name;
+      }
+
+      async function restoreOverlaysAfterStyleChange() {
+        const saved = Array.from(overlays.values()).map((overlay) => ({
+          ...overlay,
+        }));
+        for (const overlay of saved) {
+          if (overlay.kind === "geojson") {
+            await addGeoJsonOverlay(overlay);
+          } else if (overlay.kind === "raster") {
+            await addRasterOverlay(overlay);
+          }
+        }
+      }
+
+      async function executeCommand(command, args = {}) {
+        await waitForMapIdle();
+
+        if (command === "list_layers") {
+          const styleLayers = (map.getStyle().layers || []).map((layer) => ({
+            id: layer.id,
+            type: layer.type,
+            source: layer.source || null,
+            visible: (layer.layout || {}).visibility !== "none",
+            user_added: layer.id.startsWith("geoagent-layer-"),
+          }));
+          const markerLayers = Array.from(overlays.values())
+            .filter((overlay) => overlay.kind === "marker")
+            .map((overlay) => ({
+              id: overlay.name,
+              type: "marker",
+              source: null,
+              visible: true,
+              user_added: true,
+            }));
+          return [...styleLayers, ...markerLayers];
+        }
+
+        if (command === "get_map_state") {
+          const center = map.getCenter();
+          const bounds = map.getBounds();
+          return {
+            center: [center.lng, center.lat],
+            zoom: map.getZoom(),
+            bearing: map.getBearing(),
+            pitch: map.getPitch(),
+            bounds: {
+              west: bounds.getWest(),
+              south: bounds.getSouth(),
+              east: bounds.getEast(),
+              north: bounds.getNorth(),
+            },
+            user_layers: Array.from(overlays.keys()),
+          };
+        }
+
+        if (command === "set_center") {
+          map.jumpTo({
+            center: [Number(args.lon), Number(args.lat)],
+            zoom: args.zoom == null ? map.getZoom() : Number(args.zoom),
+          });
+          return "Centered map.";
+        }
+
+        if (command === "fly_to") {
+          map.flyTo({
+            center: [Number(args.lon), Number(args.lat)],
+            zoom: args.zoom == null ? map.getZoom() : Number(args.zoom),
+          });
+          return "Moved map.";
+        }
+
+        if (command === "set_zoom") {
+          map.setZoom(Number(args.zoom));
+          return "Zoom updated.";
+        }
+
+        if (command === "zoom_to_bounds") {
+          map.fitBounds(
+            [
+              [Number(args.west), Number(args.south)],
+              [Number(args.east), Number(args.north)],
+            ],
+            { padding: 48, maxZoom: 16 },
+          );
+          return "Zoomed to bounds.";
+        }
+
+        if (command === "change_basemap") {
+          const rawStyle = String(args.style || "positron").trim();
+          let style = BASEMAPS[rawStyle.toLowerCase()] || rawStyle;
+          if (typeof style === "string" && BASEMAPS[style]) {
+            style = BASEMAPS[style];
+          }
+          map.setStyle(style);
+          await new Promise((resolve) => map.once("style.load", resolve));
+          await restoreOverlaysAfterStyleChange();
+          return `Basemap changed to ${rawStyle}.`;
+        }
+
+        if (command === "add_marker") {
+          const name = addMarkerOverlay(args);
+          return `Added marker ${name}.`;
+        }
+
+        if (command === "add_geojson_data") {
+          await addGeoJsonOverlay({
+            name: args.name || "geojson",
+            data: args.data,
+            style: args.style || {},
+          });
+          return `Added GeoJSON layer ${args.name || "geojson"}.`;
+        }
+
+        if (command === "add_vector_data") {
+          await addGeoJsonOverlay({
+            name: args.name || "vector-data",
+            url: args.url,
+            style: args.style || {},
+          });
+          return `Added GeoJSON URL layer ${args.name || "vector-data"}.`;
+        }
+
+        if (command === "add_xyz_tile_layer") {
+          await addRasterOverlay({
+            name: args.name || "xyz-tiles",
+            url: args.url,
+            attribution: args.attribution || "",
+          });
+          return `Added XYZ tile layer ${args.name || "xyz-tiles"}.`;
+        }
+
+        if (command === "set_layer_visibility") {
+          const overlay = overlays.get(args.name);
+          const visibility = args.visible ? "visible" : "none";
+          if (overlay) {
+            for (const layerId of overlay.layerIds || []) {
+              if (map.getLayer(layerId)) {
+                map.setLayoutProperty(layerId, "visibility", visibility);
+              }
+            }
+            return `Layer ${args.name} visibility updated.`;
+          }
+          if (map.getLayer(args.name)) {
+            map.setLayoutProperty(args.name, "visibility", visibility);
+            return `Layer ${args.name} visibility updated.`;
+          }
+          throw new Error(`Layer not found: ${args.name}`);
+        }
+
+        if (command === "set_layer_opacity") {
+          const opacity = Math.max(0, Math.min(1, Number(args.opacity)));
+          const overlay = overlays.get(args.name);
+          const layerIds = overlay ? overlay.layerIds : [args.name];
+          let changed = false;
+          for (const layerId of layerIds || []) {
+            const layer = map.getLayer(layerId);
+            if (!layer) {
+              continue;
+            }
+            const prop =
+              layer.type === "raster"
+                ? "raster-opacity"
+                : layer.type === "fill"
+                  ? "fill-opacity"
+                  : layer.type === "line"
+                    ? "line-opacity"
+                    : layer.type === "circle"
+                      ? "circle-opacity"
+                      : null;
+            if (prop) {
+              map.setPaintProperty(layerId, prop, opacity);
+              changed = true;
+            }
+          }
+          if (!changed) {
+            throw new Error(`Layer not found or opacity unsupported: ${args.name}`);
+          }
+          return `Layer ${args.name} opacity updated.`;
+        }
+
+        if (command === "query_rendered_features") {
+          const canvas = map.getCanvas();
+          const point =
+            args.x == null || args.y == null
+              ? [canvas.clientWidth / 2, canvas.clientHeight / 2]
+              : [Number(args.x), Number(args.y)];
+          const layers = [];
+          if (Array.isArray(args.layers)) {
+            for (const requested of args.layers) {
+              const overlay = overlays.get(requested);
+              if (overlay) {
+                layers.push(...(overlay.layerIds || []));
+              } else if (map.getLayer(requested)) {
+                layers.push(requested);
+              }
+            }
+          }
+          const options = layers.length ? { layers } : {};
+          return map
+            .queryRenderedFeatures(point, options)
+            .slice(0, 50)
+            .map(serializableFeature);
+        }
+
+        if (command === "screenshot_map") {
+          return {
+            data_url: map.getCanvas().toDataURL("image/png"),
+            width: map.getCanvas().width,
+            height: map.getCanvas().height,
+          };
+        }
+
+        if (command === "remove_layer") {
+          if (!removeOverlay(args.name)) {
+            throw new Error(`User-added layer not found: ${args.name}`);
+          }
+          return `Removed layer ${args.name}.`;
+        }
+
+        if (command === "clear_layers") {
+          for (const name of Array.from(overlays.keys())) {
+            removeOverlay(name);
+          }
+          return "Cleared user-added layers.";
+        }
+
+        throw new Error(`Unsupported command: ${command}`);
+      }
+
+      function connect() {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.close();
+          return;
+        }
+        setStatus("Connecting");
+        ws = new WebSocket(wsUrlInput.value.trim());
+        updateControls();
+
+        ws.addEventListener("open", () => {
+          setStatus("Connected", "connected");
+          connectButton.textContent = "Disconnect";
+          appendLog("system", "Connected to GeoAgent browser backend.");
+          updateControls();
+        });
+
+        ws.addEventListener("close", () => {
+          sessionId = null;
+          setStatus("Disconnected");
+          connectButton.textContent = "Connect";
+          appendLog("system", "Disconnected.");
+          updateControls();
+        });
+
+        ws.addEventListener("error", () => {
+          setStatus("WebSocket error", "error");
+          const url = wsUrlInput.value.trim();
+          const httpsMixedContent =
+            window.location.protocol === "https:" && url.startsWith("ws://");
+          const detail = httpsMixedContent
+            ? "This page is running over HTTPS, so the browser may block ws:// connections. Serve the example from http://127.0.0.1:8000 or use a TLS WebSocket endpoint."
+            : "If the backend is running, stop it and start it again so it loads the current GeoAgent checkout.";
+          appendLog("error", `Could not connect to the GeoAgent backend. ${detail}`);
+          updateControls();
+        });
+
+        ws.addEventListener("message", async (event) => {
+          const message = JSON.parse(event.data);
+
+          if (message.type === "session") {
+            sessionId = message.sessionId;
+            mapId = message.mapId || "default";
+            appendLog("system", `Session ${sessionId}`);
+            updateControls();
+            return;
+          }
+
+          if (message.type === "chat_status") {
+            busy = message.status === "running";
+            if (busy) {
+              streamingAssistantTextEl = null;
+              streamingAssistantText = "";
+            }
+            setStatus(busy ? "Running" : "Connected", "connected");
+            updateControls();
+            return;
+          }
+
+          if (message.type === "chat_delta") {
+            const text = String(message.text || "");
+            if (!text) {
+              return;
+            }
+            if (!streamingAssistantTextEl) {
+              streamingAssistantTextEl = appendLog("assistant", "");
+            }
+            streamingAssistantText += text;
+            streamingAssistantTextEl.textContent = streamingAssistantText;
+            logEl.scrollTop = logEl.scrollHeight;
+            return;
+          }
+
+          if (message.type === "chat_tool") {
+            if (message.name) {
+              appendLog("tool", `Running ${message.name}`);
+            }
+            return;
+          }
+
+          if (message.type === "chat_result") {
+            busy = false;
+            setStatus(message.ok ? "Connected" : "Error", message.ok ? "connected" : "error");
+            const answer = message.answer || message.error || "No response.";
+            if (message.ok && streamingAssistantTextEl) {
+              streamingAssistantTextEl.textContent = answer;
+            } else {
+              appendLog(message.ok ? "assistant" : "error", answer);
+            }
+            if (message.executed_tools && message.executed_tools.length) {
+              appendLog("tools", message.executed_tools.join(", "));
+            }
+            history.push({ role: "assistant", text: answer, status: message.ok ? "ok" : "error" });
+            streamingAssistantTextEl = null;
+            streamingAssistantText = "";
+            updateControls();
+            return;
+          }
+
+          if (message.type === "map_command") {
+            try {
+              const result = await executeCommand(message.command, message.args || {});
+              ws.send(
+                JSON.stringify({
+                  type: "map_command_result",
+                  id: message.id,
+                  ok: true,
+                  result,
+                }),
+              );
+              appendLog("map", `${message.command}: ok`);
+            } catch (error) {
+              ws.send(
+                JSON.stringify({
+                  type: "map_command_result",
+                  id: message.id,
+                  ok: false,
+                  error: String(error && error.message ? error.message : error),
+                }),
+              );
+              appendLog("map error", `${message.command}: ${error.message || error}`);
+            }
+            return;
+          }
+
+          if (message.type === "error") {
+            appendLog("error", message.error || "Unknown backend error.");
+          }
+        });
+      }
+
+      function sendPrompt() {
+        const text = promptEl.value.trim();
+        if (!text || !ws || ws.readyState !== WebSocket.OPEN || !sessionId) {
+          return;
+        }
+        history.push({ role: "user", text });
+        appendLog("user", text);
+        streamingAssistantTextEl = null;
+        streamingAssistantText = "";
+        promptEl.value = "";
+        busy = true;
+        setStatus("Running", "connected");
+        updateControls();
+        ws.send(
+          JSON.stringify({
+            type: "chat",
+            mapId,
+            message: text,
+            history,
+          }),
+        );
+      }
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        sendPrompt();
+      });
+
+      promptEl.addEventListener("input", updateControls);
+      promptEl.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+          event.preventDefault();
+          sendPrompt();
+        }
+      });
+      connectButton.addEventListener("click", connect);
+      panelToggleButton.addEventListener("click", togglePanel);
+      clearLogButton.addEventListener("click", () => {
+        logEl.replaceChildren();
+      });
+
+      appendLog(
+        "system",
+        "Start `geoagent browser --port 8765`, then connect this page.",
+      );
+    </script>
+  </body>
+</html>

--- a/examples/browser_maplibre/index.html
+++ b/examples/browser_maplibre/index.html
@@ -8,6 +8,10 @@
       href="https://unpkg.com/maplibre-gl@5.12.0/dist/maplibre-gl.css"
       rel="stylesheet"
     />
+    <link
+      href="https://unpkg.com/maplibre-gl-layer-control@0.14.1/dist/maplibre-gl-layer-control.css"
+      rel="stylesheet"
+    />
     <style>
       :root {
         color-scheme: light;
@@ -106,14 +110,14 @@
         font-weight: 650;
       }
 
-      input,
-      textarea,
-      button {
+      .panel input,
+      .panel textarea,
+      .panel button {
         font: inherit;
       }
 
-      input,
-      textarea {
+      .panel input,
+      .panel textarea {
         width: 100%;
         border: 1px solid var(--border);
         border-radius: 6px;
@@ -121,12 +125,12 @@
         color: var(--ink);
       }
 
-      input {
+      .panel input {
         height: 36px;
         padding: 0 10px;
       }
 
-      textarea {
+      .panel textarea {
         min-height: 86px;
         resize: vertical;
         padding: 9px 10px;
@@ -145,7 +149,7 @@
         gap: 8px;
       }
 
-      button {
+      .panel button {
         min-height: 36px;
         padding: 0 12px;
         border: 1px solid transparent;
@@ -156,24 +160,30 @@
         cursor: pointer;
       }
 
-      button.secondary {
+      .panel button.secondary {
         border-color: var(--border);
         background: #fff;
         color: var(--ink);
       }
 
-      .panel-toggle {
+      .panel button.panel-toggle,
+      .panel button.secondary.panel-toggle {
         display: inline-grid;
         place-items: center;
         width: 28px;
+        min-width: 28px;
         min-height: 28px;
         height: 28px;
         padding: 0;
+        border: 1px solid var(--border);
         border-radius: 6px;
+        background: #fff;
         color: var(--muted);
+        line-height: 1;
+        font-weight: 700;
       }
 
-      .panel-toggle svg {
+      .panel button.panel-toggle svg {
         width: 16px;
         height: 16px;
         stroke: currentColor;
@@ -186,7 +196,7 @@
         padding: 0 10px;
       }
 
-      button:disabled {
+      .panel button:disabled {
         cursor: not-allowed;
         opacity: 0.55;
       }
@@ -198,43 +208,35 @@
       }
 
       .panel.collapsed {
-        width: 29px;
-        height: 29px;
-        max-height: 29px;
-        padding: 0;
-        gap: 0;
-      }
-
-      .panel.collapsed .title {
-        display: grid;
-        place-items: center;
-        width: 100%;
-        height: 100%;
-      }
-
-      .panel.collapsed .title-actions {
-        display: grid;
-        place-items: center;
-      }
-
-      .panel.collapsed h1,
-      .panel.collapsed .status,
-      .panel.collapsed .panel-body {
         display: none;
       }
 
-      .panel.collapsed .panel-toggle {
+      .geoagent-map-control {
+        display: none;
+      }
+
+      .geoagent-map-control button {
+        display: grid;
+        place-items: center;
         width: 29px;
         height: 29px;
         min-height: 29px;
+        padding: 0;
         border: 0;
-        background: var(--primary);
-        color: #fff;
+        border-radius: 0;
+        background: transparent;
+        color: var(--ink);
+        font-weight: 400;
       }
 
-      .panel.collapsed .panel-toggle svg {
-        width: 18px;
-        height: 18px;
+      .geoagent-map-control button:hover {
+        background-color: rgb(0 0 0 / 5%);
+      }
+
+      .geoagent-map-control svg {
+        width: 16px;
+        height: 16px;
+        stroke: currentColor;
       }
 
       .log {
@@ -292,11 +294,6 @@
           max-height: min(72vh, 620px);
         }
 
-        .panel.collapsed {
-          width: 29px;
-          height: 29px;
-          max-height: 29px;
-        }
       }
     </style>
   </head>
@@ -364,8 +361,12 @@
     </section>
 
     <script src="https://unpkg.com/maplibre-gl@5.12.0/dist/maplibre-gl.js"></script>
-    <script>
+    <script type="module">
+      import { LayerControl } from "https://unpkg.com/maplibre-gl-layer-control@0.14.1/dist/index.mjs";
+
+      const maplibregl = window.maplibregl;
       const BASEMAPS = {
+        liberty: "https://tiles.openfreemap.org/styles/liberty",
         positron: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
         dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
         voyager: "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json",
@@ -388,15 +389,81 @@
           layers: [{ id: "osm", type: "raster", source: "osm" }],
         },
       };
+      const DEFAULT_BASEMAP = BASEMAPS.liberty;
 
       const map = new maplibregl.Map({
         container: "map",
-        style: BASEMAPS.positron,
+        style: DEFAULT_BASEMAP,
         center: [-98.5795, 39.8283],
         zoom: 3,
+        maxPitch: 85,
         preserveDrawingBuffer: true,
       });
       map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+      let layerControl = null;
+
+      function basemapStyleUrl(style) {
+        return typeof style === "string" && /^https?:\/\//.test(style) ? style : null;
+      }
+
+      function removeLayerControl() {
+        if (layerControl) {
+          map.removeControl(layerControl);
+          layerControl = null;
+        }
+      }
+
+      function installLayerControl(style) {
+        removeLayerControl();
+        const styleUrl = basemapStyleUrl(style);
+        layerControl = new LayerControl({
+          collapsed: true,
+          ...(styleUrl ? { basemapStyleUrl: styleUrl } : {}),
+          panelWidth: 320,
+          panelMinWidth: 240,
+          panelMaxWidth: 420,
+        });
+        map.addControl(layerControl, "top-right");
+      }
+
+      map.once("load", () => installLayerControl(DEFAULT_BASEMAP));
+
+      let geoAgentControlEl = null;
+      class GeoAgentControl {
+        onAdd() {
+          const container = document.createElement("div");
+          container.className = "maplibregl-ctrl maplibregl-ctrl-group geoagent-map-control";
+          const button = document.createElement("button");
+          button.type = "button";
+          button.title = "Expand GeoAgent";
+          button.setAttribute("aria-label", "Expand GeoAgent");
+          button.innerHTML = `
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m6 9 6 6 6-6"></path>
+            </svg>
+          `;
+          button.addEventListener("click", () => setPanelCollapsed(false));
+          container.append(button);
+          geoAgentControlEl = container;
+          return container;
+        }
+
+        onRemove() {
+          if (geoAgentControlEl && geoAgentControlEl.parentNode) {
+            geoAgentControlEl.parentNode.removeChild(geoAgentControlEl);
+          }
+          geoAgentControlEl = null;
+        }
+      }
+      map.addControl(new GeoAgentControl(), "top-left");
 
       const statusEl = document.querySelector("#status");
       const connectButton = document.querySelector("#connect");
@@ -444,9 +511,11 @@
         connectButton.disabled = ws && ws.readyState === WebSocket.CONNECTING;
       }
 
-      function togglePanel() {
-        const collapsed = !panelEl.classList.contains("collapsed");
+      function setPanelCollapsed(collapsed) {
         panelEl.classList.toggle("collapsed", collapsed);
+        if (geoAgentControlEl) {
+          geoAgentControlEl.style.display = collapsed ? "block" : "none";
+        }
         panelToggleButton.setAttribute("aria-expanded", String(!collapsed));
         panelToggleButton.setAttribute(
           "aria-label",
@@ -457,6 +526,10 @@
         if (iconPath) {
           iconPath.setAttribute("d", collapsed ? "m6 9 6 6 6-6" : "m18 15-6-6-6 6");
         }
+      }
+
+      function togglePanel() {
+        setPanelCollapsed(!panelEl.classList.contains("collapsed"));
       }
 
       function waitForMapIdle() {
@@ -476,6 +549,32 @@
           .replace(/[^a-z0-9_-]+/g, "-")
           .replace(/^-+|-+$/g, "")
           .slice(0, 60) || "layer";
+      }
+
+      function uniqueSourceId(baseId) {
+        let sourceId = baseId;
+        let index = 2;
+        while (map.getSource(sourceId)) {
+          sourceId = `${baseId}-${index}`;
+          index += 1;
+        }
+        return sourceId;
+      }
+
+      function uniqueLayerBaseId(baseId, suffixes) {
+        let layerBaseId = baseId;
+        let index = 2;
+        while (suffixes.some((suffix) => map.getLayer(`${layerBaseId}${suffix}`))) {
+          layerBaseId = `${baseId}-${index}`;
+          index += 1;
+        }
+        return layerBaseId;
+      }
+
+      function isOverlayLayerId(layerId) {
+        return Array.from(overlays.values()).some((overlay) =>
+          (overlay.layerIds || []).includes(layerId),
+        );
       }
 
       function removeOverlay(name) {
@@ -527,6 +626,7 @@
         return {
           fill: {
             "fill-color": fillColor,
+            "fill-outline-color": lineColor,
             "fill-opacity": Math.max(0, Math.min(1, opacity)),
           },
           line: {
@@ -542,41 +642,217 @@
         };
       }
 
-      async function addGeoJsonOverlay({ name, data, url, style = {} }) {
-        await waitForMapIdle();
-        removeOverlay(name);
-        const sourceId = `geoagent-src-${slug(name)}`;
-        const baseId = `geoagent-layer-${slug(name)}`;
-        const paint = geojsonLayerPaint(style);
-        map.addSource(sourceId, {
-          type: "geojson",
-          data: url || data,
-        });
-        const layerDefs = [
-          {
+      async function fetchGeoJson(url) {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Could not fetch GeoJSON (${response.status}) from ${url}`);
+        }
+        return response.json();
+      }
+
+      function extendBounds(bounds, coordinate) {
+        if (!Array.isArray(coordinate) || coordinate.length < 2) {
+          return bounds;
+        }
+        const lon = Number(coordinate[0]);
+        const lat = Number(coordinate[1]);
+        if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+          return bounds;
+        }
+        if (!bounds) {
+          return [lon, lat, lon, lat];
+        }
+        bounds[0] = Math.min(bounds[0], lon);
+        bounds[1] = Math.min(bounds[1], lat);
+        bounds[2] = Math.max(bounds[2], lon);
+        bounds[3] = Math.max(bounds[3], lat);
+        return bounds;
+      }
+
+      function extendGeometryBounds(bounds, geometry) {
+        if (!geometry) {
+          return bounds;
+        }
+        if (geometry.type === "GeometryCollection") {
+          for (const item of geometry.geometries || []) {
+            bounds = extendGeometryBounds(bounds, item);
+          }
+          return bounds;
+        }
+        const visit = (coordinates) => {
+          if (!Array.isArray(coordinates)) {
+            return;
+          }
+          if (
+            coordinates.length >= 2 &&
+            typeof coordinates[0] === "number" &&
+            typeof coordinates[1] === "number"
+          ) {
+            bounds = extendBounds(bounds, coordinates);
+            return;
+          }
+          for (const item of coordinates) {
+            visit(item);
+          }
+        };
+        visit(geometry.coordinates);
+        return bounds;
+      }
+
+      function geoJsonBounds(geojson) {
+        if (!geojson) {
+          return null;
+        }
+        if (Array.isArray(geojson.bbox) && geojson.bbox.length >= 4) {
+          const dimension = geojson.bbox.length / 2;
+          const bbox = [
+            geojson.bbox[0],
+            geojson.bbox[1],
+            geojson.bbox[dimension],
+            geojson.bbox[dimension + 1],
+          ].map(Number);
+          if (bbox.every(Number.isFinite)) {
+            return bbox;
+          }
+        }
+        if (geojson.type === "FeatureCollection") {
+          return (geojson.features || []).reduce(
+            (bounds, feature) => extendGeometryBounds(bounds, feature.geometry),
+            null,
+          );
+        }
+        if (geojson.type === "Feature") {
+          return extendGeometryBounds(null, geojson.geometry);
+        }
+        return extendGeometryBounds(null, geojson);
+      }
+
+      function collectGeometryTypes(types, geometry) {
+        if (!geometry) {
+          return types;
+        }
+        if (geometry.type === "GeometryCollection") {
+          for (const item of geometry.geometries || []) {
+            collectGeometryTypes(types, item);
+          }
+          return types;
+        }
+        types.add(geometry.type);
+        return types;
+      }
+
+      function geoJsonGeometryTypes(geojson) {
+        const types = new Set();
+        if (!geojson) {
+          return types;
+        }
+        if (geojson.type === "FeatureCollection") {
+          for (const feature of geojson.features || []) {
+            collectGeometryTypes(types, feature.geometry);
+          }
+          return types;
+        }
+        if (geojson.type === "Feature") {
+          return collectGeometryTypes(types, geojson.geometry);
+        }
+        return collectGeometryTypes(types, geojson);
+      }
+
+      function geojsonLayerDefs(baseId, paint, geojson) {
+        const geometryTypes = geoJsonGeometryTypes(geojson);
+        const hasKnownTypes = geometryTypes.size > 0;
+        const hasPolygons =
+          !hasKnownTypes ||
+          geometryTypes.has("Polygon") ||
+          geometryTypes.has("MultiPolygon");
+        const hasLines =
+          !hasKnownTypes ||
+          geometryTypes.has("LineString") ||
+          geometryTypes.has("MultiLineString");
+        const hasPoints =
+          !hasKnownTypes ||
+          geometryTypes.has("Point") ||
+          geometryTypes.has("MultiPoint");
+        const layerDefs = [];
+        if (hasPolygons) {
+          layerDefs.push({
             id: `${baseId}-fill`,
+            suffix: "-fill",
             type: "fill",
             filter: ["==", ["geometry-type"], "Polygon"],
             paint: paint.fill,
-          },
-          {
+          });
+        }
+        if (hasLines) {
+          layerDefs.push({
             id: `${baseId}-line`,
+            suffix: "-line",
             type: "line",
-            filter: [
-              "any",
-              ["==", ["geometry-type"], "LineString"],
-              ["==", ["geometry-type"], "Polygon"],
-            ],
+            filter: ["==", ["geometry-type"], "LineString"],
             paint: paint.line,
-          },
-          {
+          });
+        }
+        if (hasPoints) {
+          layerDefs.push({
             id: `${baseId}-point`,
+            suffix: "-point",
             type: "circle",
             filter: ["==", ["geometry-type"], "Point"],
             paint: paint.circle,
-          },
-        ];
-        for (const def of layerDefs) {
+          });
+        }
+        return layerDefs;
+      }
+
+      function zoomToGeoJsonBounds(bounds) {
+        if (!bounds) {
+          return false;
+        }
+        const [west, south, east, north] = bounds;
+        if (![west, south, east, north].every(Number.isFinite)) {
+          return false;
+        }
+        if (west === east && south === north) {
+          map.easeTo({
+            center: [west, south],
+            zoom: Math.max(map.getZoom(), 12),
+          });
+          return true;
+        }
+        map.fitBounds(
+          [
+            [west, south],
+            [east, north],
+          ],
+          { padding: 48, maxZoom: 16 },
+        );
+        return true;
+      }
+
+      async function addGeoJsonOverlay({ name, data, url, style = {}, zoomTo = false }) {
+        await waitForMapIdle();
+        removeOverlay(name);
+        const sourceId = uniqueSourceId(`${slug(name)}-source`);
+        const paint = geojsonLayerPaint(style);
+        let sourceData = data;
+        if (!sourceData && url) {
+          try {
+            sourceData = await fetchGeoJson(url);
+          } catch (error) {
+            console.warn(error);
+          }
+        }
+        const initialLayerDefs = geojsonLayerDefs(slug(name), paint, sourceData);
+        const baseId = uniqueLayerBaseId(
+          slug(name),
+          initialLayerDefs.map((item) => item.suffix),
+        );
+        const layerDefs = geojsonLayerDefs(baseId, paint, sourceData);
+        map.addSource(sourceId, {
+          type: "geojson",
+          data: sourceData || url || data || { type: "FeatureCollection", features: [] },
+        });
+        for (const { suffix, ...def } of layerDefs) {
           map.addLayer({ ...def, source: sourceId });
         }
         overlays.set(name, {
@@ -588,13 +864,16 @@
           sourceIds: [sourceId],
           layerIds: layerDefs.map((item) => item.id),
         });
+        if (zoomTo) {
+          zoomToGeoJsonBounds(geoJsonBounds(sourceData || data));
+        }
       }
 
       async function addRasterOverlay({ name, url, attribution = "" }) {
         await waitForMapIdle();
         removeOverlay(name);
-        const sourceId = `geoagent-src-${slug(name)}`;
-        const layerId = `geoagent-layer-${slug(name)}`;
+        const sourceId = uniqueSourceId(`${slug(name)}-source`);
+        const layerId = uniqueLayerBaseId(slug(name), [""]);
         map.addSource(sourceId, {
           type: "raster",
           tiles: [url],
@@ -639,6 +918,49 @@
         return name;
       }
 
+      function serializeScriptResult(value) {
+        if (value === undefined) {
+          return null;
+        }
+        try {
+          return JSON.parse(JSON.stringify(value));
+        } catch {
+          return String(value);
+        }
+      }
+
+      async function runMapLibreScript(args) {
+        const code = String(args.code || "").trim();
+        if (!code) {
+          throw new Error("No MapLibre JavaScript code was provided.");
+        }
+        const description = String(args.description || "");
+        const helpers = Object.freeze({
+          overlays,
+          waitForMapIdle,
+          slug,
+          removeOverlay,
+          addGeoJsonOverlay,
+          addRasterOverlay,
+          addMarkerOverlay,
+          serializeScriptResult,
+        });
+        const fn = new Function(
+          "map",
+          "maplibregl",
+          "helpers",
+          `"use strict"; return (async () => {\n${code}\n})()`,
+        );
+        const result = await fn(map, maplibregl, helpers);
+        return {
+          success: true,
+          message: description || "MapLibre script executed.",
+          result: serializeScriptResult(result),
+          description,
+          maplibre_script: code,
+        };
+      }
+
       async function restoreOverlaysAfterStyleChange() {
         const saved = Array.from(overlays.values()).map((overlay) => ({
           ...overlay,
@@ -661,7 +983,7 @@
             type: layer.type,
             source: layer.source || null,
             visible: (layer.layout || {}).visibility !== "none",
-            user_added: layer.id.startsWith("geoagent-layer-"),
+            user_added: isOverlayLayerId(layer.id),
           }));
           const markerLayers = Array.from(overlays.values())
             .filter((overlay) => overlay.kind === "marker")
@@ -726,14 +1048,16 @@
         }
 
         if (command === "change_basemap") {
-          const rawStyle = String(args.style || "positron").trim();
+          const rawStyle = String(args.style || "liberty").trim();
           let style = BASEMAPS[rawStyle.toLowerCase()] || rawStyle;
           if (typeof style === "string" && BASEMAPS[style]) {
             style = BASEMAPS[style];
           }
+          removeLayerControl();
           map.setStyle(style);
           await new Promise((resolve) => map.once("style.load", resolve));
           await restoreOverlaysAfterStyleChange();
+          installLayerControl(style);
           return `Basemap changed to ${rawStyle}.`;
         }
 
@@ -747,6 +1071,7 @@
             name: args.name || "geojson",
             data: args.data,
             style: args.style || {},
+            zoomTo: true,
           });
           return `Added GeoJSON layer ${args.name || "geojson"}.`;
         }
@@ -756,6 +1081,7 @@
             name: args.name || "vector-data",
             url: args.url,
             style: args.style || {},
+            zoomTo: true,
           });
           return `Added GeoJSON URL layer ${args.name || "vector-data"}.`;
         }
@@ -862,6 +1188,10 @@
             removeOverlay(name);
           }
           return "Cleared user-added layers.";
+        }
+
+        if (command === "run_maplibre_script") {
+          return runMapLibreScript(args);
         }
 
         throw new Error(`Unsupported command: ${command}`);

--- a/examples/browser_maplibre_typescript/README.md
+++ b/examples/browser_maplibre_typescript/README.md
@@ -29,19 +29,95 @@ Open the Vite URL, usually <http://127.0.0.1:5173>, then connect to:
 ws://127.0.0.1:8765/geoagent/ws
 ```
 
-Try prompts such as:
+## Prompt Examples
+
+Basic map navigation:
 
 ```text
 Add a red marker for Knoxville and zoom to it.
 ```
 
 ```text
-Add an OpenStreetMap tile layer and list the layers.
+Fly to Seattle at zoom level 11.
 ```
+
+```text
+Zoom to the bounds west -84.1, south 35.8, east -83.7, north 36.1.
+```
+
+Basemaps and layers:
 
 ```text
 Change the basemap to dark, then get the current map state.
 ```
+
+```text
+Add an OpenStreetMap tile layer named OpenStreetMap and list the layers.
+```
+
+```text
+Add the GeoJSON URL https://raw.githubusercontent.com/plotly/datasets/master/geojson-counties-fips.json as US counties.
+```
+
+```text
+Hide the US counties layer, then show it again.
+```
+
+```text
+Set the US counties layer opacity to 0.4.
+```
+
+Queries and screenshots:
+
+```text
+List all user-added layers.
+```
+
+```text
+What features are visible at the center of the current map?
+```
+
+```text
+Take a screenshot of the current map.
+```
+
+Layer removal, when the backend was started with `--auto-approve-browser-tools`:
+
+```text
+Remove the OpenStreetMap layer.
+```
+
+```text
+Clear all user-added layers.
+```
+
+Generated MapLibre JavaScript, when the backend was started with
+`--allow-browser-code`:
+
+```text
+Tilt the map to pitch 75 and rotate it slightly.
+```
+
+```text
+Add a scale control to the lower-left corner.
+```
+
+```text
+Draw a translucent circle around Knoxville with about a 25 kilometer radius.
+```
+
+To allow PyQGIS-style fallback code execution for local browser sessions, start
+the backend with:
+
+```bash
+geoagent browser --host 127.0.0.1 --port 8765 --model gpt-5.5 --allow-browser-code
+```
+
+This exposes `run_maplibre_script`, which lets the agent execute generated
+MapLibre JavaScript in the page when no dedicated browser map tool fits.
+For trusted local sessions where the agent should be able to remove or clear
+browser map layers, add `--auto-approve-browser-tools`. Use both flags together
+if you want layer removal and generated JavaScript.
 
 ## Scripts
 

--- a/examples/browser_maplibre_typescript/README.md
+++ b/examples/browser_maplibre_typescript/README.md
@@ -1,0 +1,55 @@
+# Browser MapLibre TypeScript Example
+
+This example is the TypeScript/Vite version of the browser MapLibre client for
+`geoagent browser`. It connects to `/geoagent/ws`, sends chat prompts, executes
+browser map commands against a live MapLibre map, and returns command results to
+the Python backend.
+
+## Run
+
+Start the GeoAgent browser backend from the repository root:
+
+```bash
+python -m pip install -e ".[browser]"
+geoagent codex login
+geoagent browser --host 127.0.0.1 --port 8765 --model gpt-5.5
+```
+
+In a second terminal, run the TypeScript client:
+
+```bash
+cd examples/browser_maplibre_typescript
+npm ci
+npm run dev
+```
+
+Open the Vite URL, usually <http://127.0.0.1:5173>, then connect to:
+
+```text
+ws://127.0.0.1:8765/geoagent/ws
+```
+
+Try prompts such as:
+
+```text
+Add a red marker for Knoxville and zoom to it.
+```
+
+```text
+Add an OpenStreetMap tile layer and list the layers.
+```
+
+```text
+Change the basemap to dark, then get the current map state.
+```
+
+## Scripts
+
+```bash
+npm run dev
+npm run build
+npm run typecheck
+```
+
+`add_vector_data` expects a GeoJSON URL in this example because the Python tool
+does not provide enough metadata to render arbitrary vector tile sources.

--- a/examples/browser_maplibre_typescript/index.html
+++ b/examples/browser_maplibre_typescript/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoAgent MapLibre TypeScript</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/browser_maplibre_typescript/package-lock.json
+++ b/examples/browser_maplibre_typescript/package-lock.json
@@ -8,7 +8,8 @@
       "name": "geoagent-browser-maplibre-typescript",
       "version": "0.1.0",
       "dependencies": {
-        "maplibre-gl": "^5.12.0"
+        "maplibre-gl": "^5.12.0",
+        "maplibre-gl-layer-control": "^0.14.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -1103,6 +1104,25 @@
       },
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/maplibre-gl-layer-control": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.14.1.tgz",
+      "integrity": "sha512-WnhDdq7vyp+r+ICErg9wW6Y8dBXxNtkPRCPiAgOjupngapeL8THFLs0qBiQYJtYMsc07wRwlmP4/5g8OroGosg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/minimist": {

--- a/examples/browser_maplibre_typescript/package-lock.json
+++ b/examples/browser_maplibre_typescript/package-lock.json
@@ -1,0 +1,1407 @@
+{
+  "name": "geoagent-browser-maplibre-typescript",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "geoagent-browser-maplibre-typescript",
+      "version": "0.1.0",
+      "dependencies": {
+        "maplibre-gl": "^5.12.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vite": "^7.2.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.5",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
+      "integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
+      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/browser_maplibre_typescript/package.json
+++ b/examples/browser_maplibre_typescript/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "geoagent-browser-maplibre-typescript",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "tsc && vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "maplibre-gl": "^5.12.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^7.2.7"
+  }
+}

--- a/examples/browser_maplibre_typescript/package.json
+++ b/examples/browser_maplibre_typescript/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "maplibre-gl": "^5.12.0"
+    "maplibre-gl": "^5.12.0",
+    "maplibre-gl-layer-control": "^0.14.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/browser_maplibre_typescript/src/main.ts
+++ b/examples/browser_maplibre_typescript/src/main.ts
@@ -1,7 +1,17 @@
 import maplibregl, { type StyleSpecification } from "maplibre-gl";
+import { LayerControl } from "maplibre-gl-layer-control";
 import "./styles.css";
+import "maplibre-gl-layer-control/style.css";
 
 type JsonObject = Record<string, unknown>;
+type BBox = [number, number, number, number];
+interface GeoJsonLayerDefinition {
+  id: string;
+  suffix: string;
+  type: "fill" | "line" | "circle";
+  filter: unknown[];
+  paint: JsonObject;
+}
 
 interface SessionMessage {
   type: "session";
@@ -72,6 +82,7 @@ interface Overlay {
 }
 
 const BASEMAPS: Record<string, string | StyleSpecification> = {
+  liberty: "https://tiles.openfreemap.org/styles/liberty",
   positron: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
   dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
   voyager: "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json",
@@ -94,6 +105,7 @@ const BASEMAPS: Record<string, string | StyleSpecification> = {
     layers: [{ id: "osm", type: "raster", source: "osm" }],
   },
 };
+const DEFAULT_BASEMAP = BASEMAPS.liberty;
 
 const app = document.querySelector<HTMLDivElement>("#app");
 if (!app) {
@@ -164,12 +176,75 @@ app.innerHTML = `
 
 const map = new maplibregl.Map({
   container: "map",
-  style: BASEMAPS.positron,
+  style: DEFAULT_BASEMAP,
   center: [-98.5795, 39.8283],
   zoom: 3,
+  maxPitch: 85,
   canvasContextAttributes: { preserveDrawingBuffer: true },
 });
 map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+let layerControl: LayerControl | null = null;
+
+function basemapStyleUrl(style: string | StyleSpecification): string | undefined {
+  return typeof style === "string" && /^https?:\/\//.test(style) ? style : undefined;
+}
+
+function removeLayerControl(): void {
+  if (layerControl) {
+    map.removeControl(layerControl);
+    layerControl = null;
+  }
+}
+
+function installLayerControl(style: string | StyleSpecification): void {
+  removeLayerControl();
+  const styleUrl = basemapStyleUrl(style);
+  layerControl = new LayerControl({
+    collapsed: true,
+    ...(styleUrl ? { basemapStyleUrl: styleUrl } : {}),
+    panelWidth: 320,
+    panelMinWidth: 240,
+    panelMaxWidth: 420,
+  });
+  map.addControl(layerControl, "top-right");
+}
+
+map.once("load", () => installLayerControl(DEFAULT_BASEMAP));
+
+let geoAgentControlEl: HTMLDivElement | null = null;
+class GeoAgentControl {
+  onAdd(): HTMLElement {
+    const container = document.createElement("div");
+    container.className = "maplibregl-ctrl maplibregl-ctrl-group geoagent-map-control";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.title = "Expand GeoAgent";
+    button.setAttribute("aria-label", "Expand GeoAgent");
+    button.innerHTML = `
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m6 9 6 6 6-6"></path>
+      </svg>
+    `;
+    button.addEventListener("click", () => setPanelCollapsed(false));
+    container.append(button);
+    geoAgentControlEl = container;
+    return container;
+  }
+
+  onRemove(): void {
+    geoAgentControlEl?.parentNode?.removeChild(geoAgentControlEl);
+    geoAgentControlEl = null;
+  }
+}
+map.addControl(new GeoAgentControl(), "top-left");
 
 const statusEl = requiredElement<HTMLSpanElement>("#status");
 const connectButton = requiredElement<HTMLButtonElement>("#connect");
@@ -245,9 +320,11 @@ function updateControls(): void {
   connectButton.disabled = Boolean(ws && ws.readyState === WebSocket.CONNECTING);
 }
 
-function togglePanel(): void {
-  const collapsed = !panelEl.classList.contains("collapsed");
+function setPanelCollapsed(collapsed: boolean): void {
   panelEl.classList.toggle("collapsed", collapsed);
+  if (geoAgentControlEl) {
+    geoAgentControlEl.style.display = collapsed ? "block" : "none";
+  }
   panelToggleButton.setAttribute("aria-expanded", String(!collapsed));
   panelToggleButton.setAttribute(
     "aria-label",
@@ -258,6 +335,10 @@ function togglePanel(): void {
   if (iconPath) {
     iconPath.setAttribute("d", collapsed ? "m6 9 6 6 6-6" : "m18 15-6-6-6 6");
   }
+}
+
+function togglePanel(): void {
+  setPanelCollapsed(!panelEl.classList.contains("collapsed"));
 }
 
 function waitForMapIdle(): Promise<void> {
@@ -278,6 +359,32 @@ function slug(value: unknown): string {
       .replace(/[^a-z0-9_-]+/g, "-")
       .replace(/^-+|-+$/g, "")
       .slice(0, 60) || "layer"
+  );
+}
+
+function uniqueSourceId(baseId: string): string {
+  let sourceId = baseId;
+  let index = 2;
+  while (map.getSource(sourceId)) {
+    sourceId = `${baseId}-${index}`;
+    index += 1;
+  }
+  return sourceId;
+}
+
+function uniqueLayerBaseId(baseId: string, suffixes: string[]): string {
+  let layerBaseId = baseId;
+  let index = 2;
+  while (suffixes.some((suffix) => map.getLayer(`${layerBaseId}${suffix}`))) {
+    layerBaseId = `${baseId}-${index}`;
+    index += 1;
+  }
+  return layerBaseId;
+}
+
+function isOverlayLayerId(layerId: string): boolean {
+  return Array.from(overlays.values()).some((overlay) =>
+    overlay.layerIds.includes(layerId),
   );
 }
 
@@ -340,6 +447,7 @@ function geojsonLayerPaint(style: JsonObject): {
   return {
     fill: {
       "fill-color": fillColor,
+      "fill-outline-color": lineColor,
       "fill-opacity": Math.max(0, Math.min(1, opacity)),
     },
     line: {
@@ -355,48 +463,244 @@ function geojsonLayerPaint(style: JsonObject): {
   };
 }
 
+async function fetchGeoJson(url: string): Promise<GeoJSON.GeoJSON> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Could not fetch GeoJSON (${response.status}) from ${url}`);
+  }
+  return (await response.json()) as GeoJSON.GeoJSON;
+}
+
+function extendBounds(bounds: BBox | null, coordinate: unknown): BBox | null {
+  if (!Array.isArray(coordinate) || coordinate.length < 2) {
+    return bounds;
+  }
+  const lon = Number(coordinate[0]);
+  const lat = Number(coordinate[1]);
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+    return bounds;
+  }
+  if (!bounds) {
+    return [lon, lat, lon, lat];
+  }
+  bounds[0] = Math.min(bounds[0], lon);
+  bounds[1] = Math.min(bounds[1], lat);
+  bounds[2] = Math.max(bounds[2], lon);
+  bounds[3] = Math.max(bounds[3], lat);
+  return bounds;
+}
+
+function extendGeometryBounds(
+  bounds: BBox | null,
+  geometry: GeoJSON.Geometry | null | undefined,
+): BBox | null {
+  if (!geometry) {
+    return bounds;
+  }
+  if (geometry.type === "GeometryCollection") {
+    return geometry.geometries.reduce(
+      (currentBounds, item) => extendGeometryBounds(currentBounds, item),
+      bounds,
+    );
+  }
+  const visit = (coordinates: unknown): void => {
+    if (!Array.isArray(coordinates)) {
+      return;
+    }
+    if (
+      coordinates.length >= 2 &&
+      typeof coordinates[0] === "number" &&
+      typeof coordinates[1] === "number"
+    ) {
+      bounds = extendBounds(bounds, coordinates);
+      return;
+    }
+    for (const item of coordinates) {
+      visit(item);
+    }
+  };
+  visit(geometry.coordinates);
+  return bounds;
+}
+
+function geoJsonBounds(geojson: GeoJSON.GeoJSON | undefined): BBox | null {
+  if (!geojson) {
+    return null;
+  }
+  if (Array.isArray(geojson.bbox) && geojson.bbox.length >= 4) {
+    const dimension = geojson.bbox.length / 2;
+    const bbox = [
+      geojson.bbox[0],
+      geojson.bbox[1],
+      geojson.bbox[dimension],
+      geojson.bbox[dimension + 1],
+    ].map(Number);
+    if (bbox.every(Number.isFinite)) {
+      return bbox as BBox;
+    }
+  }
+  if (geojson.type === "FeatureCollection") {
+    return geojson.features.reduce(
+      (bounds, feature) => extendGeometryBounds(bounds, feature.geometry),
+      null as BBox | null,
+    );
+  }
+  if (geojson.type === "Feature") {
+    return extendGeometryBounds(null, geojson.geometry);
+  }
+  return extendGeometryBounds(null, geojson);
+}
+
+function collectGeometryTypes(
+  types: Set<GeoJSON.GeoJsonGeometryTypes>,
+  geometry: GeoJSON.Geometry | null | undefined,
+): Set<GeoJSON.GeoJsonGeometryTypes> {
+  if (!geometry) {
+    return types;
+  }
+  if (geometry.type === "GeometryCollection") {
+    for (const item of geometry.geometries) {
+      collectGeometryTypes(types, item);
+    }
+    return types;
+  }
+  types.add(geometry.type);
+  return types;
+}
+
+function geoJsonGeometryTypes(
+  geojson: GeoJSON.GeoJSON | undefined,
+): Set<GeoJSON.GeoJsonGeometryTypes> {
+  const types = new Set<GeoJSON.GeoJsonGeometryTypes>();
+  if (!geojson) {
+    return types;
+  }
+  if (geojson.type === "FeatureCollection") {
+    for (const feature of geojson.features) {
+      collectGeometryTypes(types, feature.geometry);
+    }
+    return types;
+  }
+  if (geojson.type === "Feature") {
+    return collectGeometryTypes(types, geojson.geometry);
+  }
+  return collectGeometryTypes(types, geojson);
+}
+
+function geojsonLayerDefs(
+  baseId: string,
+  paint: ReturnType<typeof geojsonLayerPaint>,
+  geojson: GeoJSON.GeoJSON | undefined,
+): GeoJsonLayerDefinition[] {
+  const geometryTypes = geoJsonGeometryTypes(geojson);
+  const hasKnownTypes = geometryTypes.size > 0;
+  const hasPolygons =
+    !hasKnownTypes ||
+    geometryTypes.has("Polygon") ||
+    geometryTypes.has("MultiPolygon");
+  const hasLines =
+    !hasKnownTypes ||
+    geometryTypes.has("LineString") ||
+    geometryTypes.has("MultiLineString");
+  const hasPoints =
+    !hasKnownTypes ||
+    geometryTypes.has("Point") ||
+    geometryTypes.has("MultiPoint");
+  const layerDefs: GeoJsonLayerDefinition[] = [];
+  if (hasPolygons) {
+    layerDefs.push({
+      id: `${baseId}-fill`,
+      suffix: "-fill",
+      type: "fill",
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: paint.fill,
+    });
+  }
+  if (hasLines) {
+    layerDefs.push({
+      id: `${baseId}-line`,
+      suffix: "-line",
+      type: "line",
+      filter: ["==", ["geometry-type"], "LineString"],
+      paint: paint.line,
+    });
+  }
+  if (hasPoints) {
+    layerDefs.push({
+      id: `${baseId}-point`,
+      suffix: "-point",
+      type: "circle",
+      filter: ["==", ["geometry-type"], "Point"],
+      paint: paint.circle,
+    });
+  }
+  return layerDefs;
+}
+
+function zoomToGeoJsonBounds(bounds: BBox | null): boolean {
+  if (!bounds) {
+    return false;
+  }
+  const [west, south, east, north] = bounds;
+  if (![west, south, east, north].every(Number.isFinite)) {
+    return false;
+  }
+  if (west === east && south === north) {
+    map.easeTo({
+      center: [west, south],
+      zoom: Math.max(map.getZoom(), 12),
+    });
+    return true;
+  }
+  map.fitBounds(
+    [
+      [west, south],
+      [east, north],
+    ],
+    { padding: 48, maxZoom: 16 },
+  );
+  return true;
+}
+
 async function addGeoJsonOverlay(overlay: {
   name: string;
   data?: GeoJSON.GeoJSON;
   url?: string;
   style?: JsonObject;
+  zoomTo?: boolean;
 }): Promise<void> {
   await waitForMapIdle();
   removeOverlay(overlay.name);
-  const sourceId = `geoagent-src-${slug(overlay.name)}`;
-  const baseId = `geoagent-layer-${slug(overlay.name)}`;
+  const sourceId = uniqueSourceId(`${slug(overlay.name)}-source`);
   const style = overlay.style ?? {};
   const paint = geojsonLayerPaint(style);
+  let sourceData = overlay.data;
+  if (!sourceData && overlay.url) {
+    try {
+      sourceData = await fetchGeoJson(overlay.url);
+    } catch (error) {
+      console.warn(error);
+    }
+  }
+  const initialLayerDefs = geojsonLayerDefs(slug(overlay.name), paint, sourceData);
+  const baseId = uniqueLayerBaseId(
+    slug(overlay.name),
+    initialLayerDefs.map((item) => item.suffix),
+  );
+  const layerDefs = geojsonLayerDefs(baseId, paint, sourceData);
   map.addSource(sourceId, {
     type: "geojson",
-    data: overlay.url ?? overlay.data ?? { type: "FeatureCollection", features: [] },
+    data:
+      sourceData ??
+      overlay.url ??
+      ({ type: "FeatureCollection", features: [] } as GeoJSON.FeatureCollection),
   });
-  const layerDefs = [
-    {
-      id: `${baseId}-fill`,
-      type: "fill",
-      filter: ["==", ["geometry-type"], "Polygon"],
-      paint: paint.fill,
-    },
-    {
-      id: `${baseId}-line`,
-      type: "line",
-      filter: [
-        "any",
-        ["==", ["geometry-type"], "LineString"],
-        ["==", ["geometry-type"], "Polygon"],
-      ],
-      paint: paint.line,
-    },
-    {
-      id: `${baseId}-point`,
-      type: "circle",
-      filter: ["==", ["geometry-type"], "Point"],
-      paint: paint.circle,
-    },
-  ];
   for (const layer of layerDefs) {
-    map.addLayer({ ...layer, source: sourceId } as maplibregl.LayerSpecification);
+    const { suffix: _suffix, ...layerDefinition } = layer;
+    map.addLayer({
+      ...layerDefinition,
+      source: sourceId,
+    } as maplibregl.LayerSpecification);
   }
   overlays.set(overlay.name, {
     kind: "geojson",
@@ -407,6 +711,9 @@ async function addGeoJsonOverlay(overlay: {
     sourceIds: [sourceId],
     layerIds: layerDefs.map((item) => item.id),
   });
+  if (overlay.zoomTo) {
+    zoomToGeoJsonBounds(geoJsonBounds(sourceData ?? overlay.data));
+  }
 }
 
 async function addRasterOverlay(overlay: {
@@ -416,8 +723,8 @@ async function addRasterOverlay(overlay: {
 }): Promise<void> {
   await waitForMapIdle();
   removeOverlay(overlay.name);
-  const sourceId = `geoagent-src-${slug(overlay.name)}`;
-  const layerId = `geoagent-layer-${slug(overlay.name)}`;
+  const sourceId = uniqueSourceId(`${slug(overlay.name)}-source`);
+  const layerId = uniqueLayerBaseId(slug(overlay.name), [""]);
   map.addSource(sourceId, {
     type: "raster",
     tiles: [overlay.url],
@@ -463,6 +770,53 @@ function addMarkerOverlay(args: JsonObject): string {
   return name;
 }
 
+function serializeScriptResult(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown;
+  } catch {
+    return String(value);
+  }
+}
+
+async function runMapLibreScript(args: JsonObject): Promise<JsonObject> {
+  const code = stringArg(args, "code").trim();
+  if (!code) {
+    throw new Error("No MapLibre JavaScript code was provided.");
+  }
+  const description = stringArg(args, "description");
+  const helpers = Object.freeze({
+    overlays,
+    waitForMapIdle,
+    slug,
+    removeOverlay,
+    addGeoJsonOverlay,
+    addRasterOverlay,
+    addMarkerOverlay,
+    serializeScriptResult,
+  });
+  const fn = new Function(
+    "map",
+    "maplibregl",
+    "helpers",
+    `"use strict"; return (async () => {\n${code}\n})()`,
+  ) as (
+    map: maplibregl.Map,
+    maplibreglApi: typeof maplibregl,
+    helpers: Record<string, unknown>,
+  ) => Promise<unknown>;
+  const result = await fn(map, maplibregl, helpers);
+  return {
+    success: true,
+    message: description || "MapLibre script executed.",
+    result: serializeScriptResult(result),
+    description,
+    maplibre_script: code,
+  };
+}
+
 async function restoreOverlaysAfterStyleChange(): Promise<void> {
   const saved = Array.from(overlays.values()).map((overlay) => ({ ...overlay }));
   for (const overlay of saved) {
@@ -492,7 +846,7 @@ async function executeCommand(command: string, args: JsonObject = {}): Promise<u
       type: layer.type,
       source: "source" in layer ? layer.source : null,
       visible: layer.layout?.visibility !== "none",
-      user_added: layer.id.startsWith("geoagent-layer-"),
+      user_added: isOverlayLayerId(layer.id),
     }));
     const markerLayers = Array.from(overlays.values())
       .filter((overlay) => overlay.kind === "marker")
@@ -557,14 +911,16 @@ async function executeCommand(command: string, args: JsonObject = {}): Promise<u
   }
 
   if (command === "change_basemap") {
-    const rawStyle = stringArg(args, "style", "positron").trim();
+    const rawStyle = stringArg(args, "style", "liberty").trim();
     let style = BASEMAPS[rawStyle.toLowerCase()] ?? rawStyle;
     if (typeof style === "string" && BASEMAPS[style]) {
       style = BASEMAPS[style];
     }
+    removeLayerControl();
     map.setStyle(style);
     await new Promise<void>((resolve) => map.once("style.load", () => resolve()));
     await restoreOverlaysAfterStyleChange();
+    installLayerControl(style);
     return `Basemap changed to ${rawStyle}.`;
   }
 
@@ -578,6 +934,7 @@ async function executeCommand(command: string, args: JsonObject = {}): Promise<u
       name: stringArg(args, "name", "geojson"),
       data: args.data as GeoJSON.GeoJSON,
       style: objectArg(args, "style"),
+      zoomTo: true,
     });
     return `Added GeoJSON layer ${stringArg(args, "name", "geojson")}.`;
   }
@@ -587,6 +944,7 @@ async function executeCommand(command: string, args: JsonObject = {}): Promise<u
       name: stringArg(args, "name", "vector-data"),
       url: stringArg(args, "url"),
       style: objectArg(args, "style"),
+      zoomTo: true,
     });
     return `Added GeoJSON URL layer ${stringArg(args, "name", "vector-data")}.`;
   }
@@ -696,6 +1054,10 @@ async function executeCommand(command: string, args: JsonObject = {}): Promise<u
       removeOverlay(name);
     }
     return "Cleared user-added layers.";
+  }
+
+  if (command === "run_maplibre_script") {
+    return runMapLibreScript(args);
   }
 
   throw new Error(`Unsupported command: ${command}`);

--- a/examples/browser_maplibre_typescript/src/main.ts
+++ b/examples/browser_maplibre_typescript/src/main.ts
@@ -1,0 +1,877 @@
+import maplibregl, { type StyleSpecification } from "maplibre-gl";
+import "./styles.css";
+
+type JsonObject = Record<string, unknown>;
+
+interface SessionMessage {
+  type: "session";
+  sessionId: string;
+  mapId?: string;
+}
+
+interface ChatStatusMessage {
+  type: "chat_status";
+  status: string;
+}
+
+interface ChatResultMessage {
+  type: "chat_result";
+  ok: boolean;
+  answer?: string;
+  error?: string;
+  executed_tools?: string[];
+}
+
+interface ChatDeltaMessage {
+  type: "chat_delta";
+  text?: string;
+}
+
+interface ChatToolMessage {
+  type: "chat_tool";
+  name?: string;
+}
+
+interface MapCommandMessage {
+  type: "map_command";
+  id: string;
+  command: string;
+  args?: JsonObject;
+}
+
+interface ErrorMessage {
+  type: "error";
+  error?: string;
+}
+
+type BackendMessage =
+  | SessionMessage
+  | ChatStatusMessage
+  | ChatDeltaMessage
+  | ChatToolMessage
+  | ChatResultMessage
+  | MapCommandMessage
+  | ErrorMessage;
+
+interface HistoryItem {
+  role: "user" | "assistant";
+  text: string;
+  status?: "ok" | "error";
+}
+
+interface Overlay {
+  kind: "geojson" | "raster" | "marker";
+  name: string;
+  sourceIds: string[];
+  layerIds: string[];
+  marker?: maplibregl.Marker;
+  data?: GeoJSON.GeoJSON;
+  url?: string;
+  style?: JsonObject;
+  attribution?: string;
+}
+
+const BASEMAPS: Record<string, string | StyleSpecification> = {
+  positron: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+  dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+  voyager: "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json",
+  demotiles: "https://demotiles.maplibre.org/style.json",
+  openstreetmap: "osm",
+  osm: {
+    version: 8,
+    sources: {
+      osm: {
+        type: "raster",
+        tiles: [
+          "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        ],
+        tileSize: 256,
+        attribution: "OpenStreetMap contributors",
+      },
+    },
+    layers: [{ id: "osm", type: "raster", source: "osm" }],
+  },
+};
+
+const app = document.querySelector<HTMLDivElement>("#app");
+if (!app) {
+  throw new Error("Missing #app element.");
+}
+
+app.innerHTML = `
+  <div id="map" aria-label="MapLibre map"></div>
+  <section class="panel" aria-label="GeoAgent chat panel">
+    <div class="title">
+      <h1>GeoAgent</h1>
+      <div class="title-actions">
+        <span id="status" class="status">Disconnected</span>
+        <button
+          id="panel-toggle"
+          class="secondary panel-toggle"
+          type="button"
+          aria-expanded="true"
+          aria-label="Collapse panel"
+          title="Collapse panel"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m18 15-6-6-6 6"></path>
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div id="panel-body" class="panel-body">
+      <div class="row">
+        <label>
+          WebSocket URL
+          <input id="ws-url" value="ws://127.0.0.1:8765/geoagent/ws" />
+        </label>
+        <button id="connect" class="connect-toggle" type="button">Connect</button>
+      </div>
+
+      <div id="log" class="log" aria-live="polite"></div>
+
+      <form id="chat-form">
+        <label>
+          Prompt
+          <textarea
+            id="prompt"
+            placeholder="Add a red marker for Knoxville and zoom to it."
+          ></textarea>
+        </label>
+        <div class="actions" style="margin-top: 8px">
+          <button id="send" type="submit" disabled>Send</button>
+          <button id="clear-log" class="secondary" type="button">Clear</button>
+        </div>
+      </form>
+
+      <p class="hint">
+        Start \`geoagent browser\` first. This page executes map commands in the
+        live browser map and sends results back to the Python agent.
+      </p>
+    </div>
+  </section>
+`;
+
+const map = new maplibregl.Map({
+  container: "map",
+  style: BASEMAPS.positron,
+  center: [-98.5795, 39.8283],
+  zoom: 3,
+  canvasContextAttributes: { preserveDrawingBuffer: true },
+});
+map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+const statusEl = requiredElement<HTMLSpanElement>("#status");
+const connectButton = requiredElement<HTMLButtonElement>("#connect");
+const panelEl = requiredElement<HTMLElement>(".panel");
+const panelToggleButton = requiredElement<HTMLButtonElement>("#panel-toggle");
+const sendButton = requiredElement<HTMLButtonElement>("#send");
+const wsUrlInput = requiredElement<HTMLInputElement>("#ws-url");
+const logEl = requiredElement<HTMLDivElement>("#log");
+const form = requiredElement<HTMLFormElement>("#chat-form");
+const promptEl = requiredElement<HTMLTextAreaElement>("#prompt");
+const clearLogButton = requiredElement<HTMLButtonElement>("#clear-log");
+
+let ws: WebSocket | null = null;
+let sessionId: string | null = null;
+let mapId = "default";
+let busy = false;
+let streamingAssistantTextEl: HTMLDivElement | null = null;
+let streamingAssistantText = "";
+const history: HistoryItem[] = [];
+const overlays = new Map<string, Overlay>();
+
+function requiredElement<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`Missing required element: ${selector}`);
+  }
+  return element;
+}
+
+function numberArg(args: JsonObject, key: string): number {
+  const value = args[key];
+  if (typeof value !== "number" && typeof value !== "string") {
+    throw new Error(`Expected numeric argument: ${key}`);
+  }
+  return Number(value);
+}
+
+function stringArg(args: JsonObject, key: string, fallback = ""): string {
+  const value = args[key];
+  return typeof value === "string" ? value : fallback;
+}
+
+function objectArg(args: JsonObject, key: string): JsonObject {
+  const value = args[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : {};
+}
+
+function setStatus(text: string, kind = ""): void {
+  statusEl.textContent = text;
+  statusEl.className = `status ${kind}`.trim();
+}
+
+function appendLog(role: string, text: string): HTMLDivElement {
+  const entry = document.createElement("div");
+  entry.className = "entry";
+  const roleEl = document.createElement("div");
+  roleEl.className = "role";
+  roleEl.textContent = role;
+  const textEl = document.createElement("div");
+  textEl.className = "text";
+  textEl.textContent = text;
+  entry.append(roleEl, textEl);
+  logEl.append(entry);
+  logEl.scrollTop = logEl.scrollHeight;
+  return textEl;
+}
+
+function updateControls(): void {
+  const connected = Boolean(ws && ws.readyState === WebSocket.OPEN && sessionId);
+  sendButton.disabled = !connected || busy || !promptEl.value.trim();
+  connectButton.disabled = Boolean(ws && ws.readyState === WebSocket.CONNECTING);
+}
+
+function togglePanel(): void {
+  const collapsed = !panelEl.classList.contains("collapsed");
+  panelEl.classList.toggle("collapsed", collapsed);
+  panelToggleButton.setAttribute("aria-expanded", String(!collapsed));
+  panelToggleButton.setAttribute(
+    "aria-label",
+    collapsed ? "Expand panel" : "Collapse panel",
+  );
+  panelToggleButton.title = collapsed ? "Expand panel" : "Collapse panel";
+  const iconPath = panelToggleButton.querySelector("path");
+  if (iconPath) {
+    iconPath.setAttribute("d", collapsed ? "m6 9 6 6 6-6" : "m18 15-6-6-6 6");
+  }
+}
+
+function waitForMapIdle(): Promise<void> {
+  return new Promise((resolve) => {
+    if (map.loaded()) {
+      resolve();
+      return;
+    }
+    map.once("idle", () => resolve());
+  });
+}
+
+function slug(value: unknown): string {
+  return (
+    String(value || "layer")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "layer"
+  );
+}
+
+function removeOverlay(name: string): boolean {
+  const key = Array.from(overlays.keys()).find(
+    (item) => item === name || slug(item) === slug(name),
+  );
+  if (!key) {
+    return false;
+  }
+  const overlay = overlays.get(key);
+  if (!overlay) {
+    return false;
+  }
+  for (const layerId of overlay.layerIds) {
+    if (map.getLayer(layerId)) {
+      map.removeLayer(layerId);
+    }
+  }
+  for (const sourceId of overlay.sourceIds) {
+    if (map.getSource(sourceId)) {
+      map.removeSource(sourceId);
+    }
+  }
+  overlay.marker?.remove();
+  overlays.delete(key);
+  return true;
+}
+
+function serializableFeature(feature: maplibregl.MapGeoJSONFeature): JsonObject {
+  return {
+    type: "Feature",
+    geometry: feature.geometry ?? null,
+    properties: feature.properties ?? {},
+    layer: feature.layer
+      ? {
+          id: feature.layer.id,
+          type: feature.layer.type,
+          source: feature.layer.source,
+        }
+      : undefined,
+  };
+}
+
+function geojsonLayerPaint(style: JsonObject): {
+  fill: JsonObject;
+  line: JsonObject;
+  circle: JsonObject;
+} {
+  const color =
+    stringArg(style, "color") || stringArg(style, "line-color") || "#1c7ed6";
+  const fillColor = stringArg(style, "fill-color", stringArg(style, "fillColor", color));
+  const lineColor = stringArg(style, "line-color", stringArg(style, "lineColor", color));
+  const circleColor = stringArg(
+    style,
+    "circle-color",
+    stringArg(style, "circleColor", color),
+  );
+  const opacity = Number(style.opacity ?? style["fill-opacity"] ?? 0.35);
+  return {
+    fill: {
+      "fill-color": fillColor,
+      "fill-opacity": Math.max(0, Math.min(1, opacity)),
+    },
+    line: {
+      "line-color": lineColor,
+      "line-width": Number(style["line-width"] ?? style.lineWidth ?? 2),
+    },
+    circle: {
+      "circle-color": circleColor,
+      "circle-radius": Number(style["circle-radius"] ?? style.radius ?? 6),
+      "circle-stroke-color": "#ffffff",
+      "circle-stroke-width": 1,
+    },
+  };
+}
+
+async function addGeoJsonOverlay(overlay: {
+  name: string;
+  data?: GeoJSON.GeoJSON;
+  url?: string;
+  style?: JsonObject;
+}): Promise<void> {
+  await waitForMapIdle();
+  removeOverlay(overlay.name);
+  const sourceId = `geoagent-src-${slug(overlay.name)}`;
+  const baseId = `geoagent-layer-${slug(overlay.name)}`;
+  const style = overlay.style ?? {};
+  const paint = geojsonLayerPaint(style);
+  map.addSource(sourceId, {
+    type: "geojson",
+    data: overlay.url ?? overlay.data ?? { type: "FeatureCollection", features: [] },
+  });
+  const layerDefs = [
+    {
+      id: `${baseId}-fill`,
+      type: "fill",
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: paint.fill,
+    },
+    {
+      id: `${baseId}-line`,
+      type: "line",
+      filter: [
+        "any",
+        ["==", ["geometry-type"], "LineString"],
+        ["==", ["geometry-type"], "Polygon"],
+      ],
+      paint: paint.line,
+    },
+    {
+      id: `${baseId}-point`,
+      type: "circle",
+      filter: ["==", ["geometry-type"], "Point"],
+      paint: paint.circle,
+    },
+  ];
+  for (const layer of layerDefs) {
+    map.addLayer({ ...layer, source: sourceId } as maplibregl.LayerSpecification);
+  }
+  overlays.set(overlay.name, {
+    kind: "geojson",
+    name: overlay.name,
+    data: overlay.data,
+    url: overlay.url,
+    style,
+    sourceIds: [sourceId],
+    layerIds: layerDefs.map((item) => item.id),
+  });
+}
+
+async function addRasterOverlay(overlay: {
+  name: string;
+  url: string;
+  attribution?: string;
+}): Promise<void> {
+  await waitForMapIdle();
+  removeOverlay(overlay.name);
+  const sourceId = `geoagent-src-${slug(overlay.name)}`;
+  const layerId = `geoagent-layer-${slug(overlay.name)}`;
+  map.addSource(sourceId, {
+    type: "raster",
+    tiles: [overlay.url],
+    tileSize: 256,
+    attribution: overlay.attribution ?? "",
+  });
+  map.addLayer({
+    id: layerId,
+    type: "raster",
+    source: sourceId,
+  });
+  overlays.set(overlay.name, {
+    kind: "raster",
+    name: overlay.name,
+    url: overlay.url,
+    attribution: overlay.attribution,
+    sourceIds: [sourceId],
+    layerIds: [layerId],
+  });
+}
+
+function addMarkerOverlay(args: JsonObject): string {
+  const name = stringArg(args, "name", `marker-${overlays.size + 1}`);
+  removeOverlay(name);
+  const marker = new maplibregl.Marker({
+    color: stringArg(args, "color", "#3388ff"),
+  })
+    .setLngLat([numberArg(args, "lon"), numberArg(args, "lat")])
+    .addTo(map);
+  marker.getElement().title =
+    stringArg(args, "tooltip") || stringArg(args, "popup") || name;
+  const popup = stringArg(args, "popup");
+  if (popup) {
+    marker.setPopup(new maplibregl.Popup().setText(popup));
+  }
+  overlays.set(name, {
+    kind: "marker",
+    name,
+    marker,
+    sourceIds: [],
+    layerIds: [],
+  });
+  return name;
+}
+
+async function restoreOverlaysAfterStyleChange(): Promise<void> {
+  const saved = Array.from(overlays.values()).map((overlay) => ({ ...overlay }));
+  for (const overlay of saved) {
+    if (overlay.kind === "geojson") {
+      await addGeoJsonOverlay({
+        name: overlay.name,
+        data: overlay.data,
+        url: overlay.url,
+        style: overlay.style,
+      });
+    } else if (overlay.kind === "raster" && overlay.url) {
+      await addRasterOverlay({
+        name: overlay.name,
+        url: overlay.url,
+        attribution: overlay.attribution,
+      });
+    }
+  }
+}
+
+async function executeCommand(command: string, args: JsonObject = {}): Promise<unknown> {
+  await waitForMapIdle();
+
+  if (command === "list_layers") {
+    const styleLayers = (map.getStyle().layers ?? []).map((layer) => ({
+      id: layer.id,
+      type: layer.type,
+      source: "source" in layer ? layer.source : null,
+      visible: layer.layout?.visibility !== "none",
+      user_added: layer.id.startsWith("geoagent-layer-"),
+    }));
+    const markerLayers = Array.from(overlays.values())
+      .filter((overlay) => overlay.kind === "marker")
+      .map((overlay) => ({
+        id: overlay.name,
+        type: "marker",
+        source: null,
+        visible: true,
+        user_added: true,
+      }));
+    return [...styleLayers, ...markerLayers];
+  }
+
+  if (command === "get_map_state") {
+    const center = map.getCenter();
+    const bounds = map.getBounds();
+    return {
+      center: [center.lng, center.lat],
+      zoom: map.getZoom(),
+      bearing: map.getBearing(),
+      pitch: map.getPitch(),
+      bounds: {
+        west: bounds.getWest(),
+        south: bounds.getSouth(),
+        east: bounds.getEast(),
+        north: bounds.getNorth(),
+      },
+      user_layers: Array.from(overlays.keys()),
+    };
+  }
+
+  if (command === "set_center") {
+    map.jumpTo({
+      center: [numberArg(args, "lon"), numberArg(args, "lat")],
+      zoom: args.zoom == null ? map.getZoom() : Number(args.zoom),
+    });
+    return "Centered map.";
+  }
+
+  if (command === "fly_to") {
+    map.flyTo({
+      center: [numberArg(args, "lon"), numberArg(args, "lat")],
+      zoom: args.zoom == null ? map.getZoom() : Number(args.zoom),
+    });
+    return "Moved map.";
+  }
+
+  if (command === "set_zoom") {
+    map.setZoom(numberArg(args, "zoom"));
+    return "Zoom updated.";
+  }
+
+  if (command === "zoom_to_bounds") {
+    map.fitBounds(
+      [
+        [numberArg(args, "west"), numberArg(args, "south")],
+        [numberArg(args, "east"), numberArg(args, "north")],
+      ],
+      { padding: 48, maxZoom: 16 },
+    );
+    return "Zoomed to bounds.";
+  }
+
+  if (command === "change_basemap") {
+    const rawStyle = stringArg(args, "style", "positron").trim();
+    let style = BASEMAPS[rawStyle.toLowerCase()] ?? rawStyle;
+    if (typeof style === "string" && BASEMAPS[style]) {
+      style = BASEMAPS[style];
+    }
+    map.setStyle(style);
+    await new Promise<void>((resolve) => map.once("style.load", () => resolve()));
+    await restoreOverlaysAfterStyleChange();
+    return `Basemap changed to ${rawStyle}.`;
+  }
+
+  if (command === "add_marker") {
+    const name = addMarkerOverlay(args);
+    return `Added marker ${name}.`;
+  }
+
+  if (command === "add_geojson_data") {
+    await addGeoJsonOverlay({
+      name: stringArg(args, "name", "geojson"),
+      data: args.data as GeoJSON.GeoJSON,
+      style: objectArg(args, "style"),
+    });
+    return `Added GeoJSON layer ${stringArg(args, "name", "geojson")}.`;
+  }
+
+  if (command === "add_vector_data") {
+    await addGeoJsonOverlay({
+      name: stringArg(args, "name", "vector-data"),
+      url: stringArg(args, "url"),
+      style: objectArg(args, "style"),
+    });
+    return `Added GeoJSON URL layer ${stringArg(args, "name", "vector-data")}.`;
+  }
+
+  if (command === "add_xyz_tile_layer") {
+    await addRasterOverlay({
+      name: stringArg(args, "name", "xyz-tiles"),
+      url: stringArg(args, "url"),
+      attribution: stringArg(args, "attribution"),
+    });
+    return `Added XYZ tile layer ${stringArg(args, "name", "xyz-tiles")}.`;
+  }
+
+  if (command === "set_layer_visibility") {
+    const name = stringArg(args, "name");
+    const overlay = overlays.get(name);
+    const visibility = args.visible ? "visible" : "none";
+    if (overlay) {
+      for (const layerId of overlay.layerIds) {
+        if (map.getLayer(layerId)) {
+          map.setLayoutProperty(layerId, "visibility", visibility);
+        }
+      }
+      return `Layer ${name} visibility updated.`;
+    }
+    if (map.getLayer(name)) {
+      map.setLayoutProperty(name, "visibility", visibility);
+      return `Layer ${name} visibility updated.`;
+    }
+    throw new Error(`Layer not found: ${name}`);
+  }
+
+  if (command === "set_layer_opacity") {
+    const name = stringArg(args, "name");
+    const opacity = Math.max(0, Math.min(1, numberArg(args, "opacity")));
+    const overlay = overlays.get(name);
+    const layerIds = overlay ? overlay.layerIds : [name];
+    let changed = false;
+    for (const layerId of layerIds) {
+      const layer = map.getLayer(layerId);
+      if (!layer) {
+        continue;
+      }
+      const prop =
+        layer.type === "raster"
+          ? "raster-opacity"
+          : layer.type === "fill"
+            ? "fill-opacity"
+            : layer.type === "line"
+              ? "line-opacity"
+              : layer.type === "circle"
+                ? "circle-opacity"
+                : null;
+      if (prop) {
+        map.setPaintProperty(layerId, prop, opacity);
+        changed = true;
+      }
+    }
+    if (!changed) {
+      throw new Error(`Layer not found or opacity unsupported: ${name}`);
+    }
+    return `Layer ${name} opacity updated.`;
+  }
+
+  if (command === "query_rendered_features") {
+    const canvas = map.getCanvas();
+    const point: [number, number] =
+      args.x == null || args.y == null
+        ? [canvas.clientWidth / 2, canvas.clientHeight / 2]
+        : [Number(args.x), Number(args.y)];
+    const layers: string[] = [];
+    if (Array.isArray(args.layers)) {
+      for (const requested of args.layers) {
+        const layerName = String(requested);
+        const overlay = overlays.get(layerName);
+        if (overlay) {
+          layers.push(...overlay.layerIds);
+        } else if (map.getLayer(layerName)) {
+          layers.push(layerName);
+        }
+      }
+    }
+    return map
+      .queryRenderedFeatures(point, layers.length ? { layers } : {})
+      .slice(0, 50)
+      .map(serializableFeature);
+  }
+
+  if (command === "screenshot_map") {
+    return {
+      data_url: map.getCanvas().toDataURL("image/png"),
+      width: map.getCanvas().width,
+      height: map.getCanvas().height,
+    };
+  }
+
+  if (command === "remove_layer") {
+    const name = stringArg(args, "name");
+    if (!removeOverlay(name)) {
+      throw new Error(`User-added layer not found: ${name}`);
+    }
+    return `Removed layer ${name}.`;
+  }
+
+  if (command === "clear_layers") {
+    for (const name of Array.from(overlays.keys())) {
+      removeOverlay(name);
+    }
+    return "Cleared user-added layers.";
+  }
+
+  throw new Error(`Unsupported command: ${command}`);
+}
+
+function connect(): void {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.close();
+    return;
+  }
+  setStatus("Connecting");
+  ws = new WebSocket(wsUrlInput.value.trim());
+  updateControls();
+
+  ws.addEventListener("open", () => {
+    setStatus("Connected", "connected");
+    connectButton.textContent = "Disconnect";
+    appendLog("system", "Connected to GeoAgent browser backend.");
+    updateControls();
+  });
+
+  ws.addEventListener("close", () => {
+    sessionId = null;
+    setStatus("Disconnected");
+    connectButton.textContent = "Connect";
+    appendLog("system", "Disconnected.");
+    updateControls();
+  });
+
+  ws.addEventListener("error", () => {
+    setStatus("WebSocket error", "error");
+    const url = wsUrlInput.value.trim();
+    const httpsMixedContent = window.location.protocol === "https:" && url.startsWith("ws://");
+    const detail = httpsMixedContent
+      ? "This page is running over HTTPS, so the browser may block ws:// connections. Serve the example from http://127.0.0.1:5173 or use a TLS WebSocket endpoint."
+      : "If the backend is running, stop it and start it again so it loads the current GeoAgent checkout.";
+    appendLog("error", `Could not connect to the GeoAgent backend. ${detail}`);
+    updateControls();
+  });
+
+  ws.addEventListener("message", (event: MessageEvent<string>) => {
+    void handleBackendMessage(JSON.parse(event.data) as BackendMessage);
+  });
+}
+
+async function handleBackendMessage(message: BackendMessage): Promise<void> {
+  if (message.type === "session") {
+    sessionId = message.sessionId;
+    mapId = message.mapId || "default";
+    appendLog("system", `Session ${sessionId}`);
+    updateControls();
+    return;
+  }
+
+  if (message.type === "chat_status") {
+    busy = message.status === "running";
+    if (busy) {
+      streamingAssistantTextEl = null;
+      streamingAssistantText = "";
+    }
+    setStatus(busy ? "Running" : "Connected", "connected");
+    updateControls();
+    return;
+  }
+
+  if (message.type === "chat_delta") {
+    const text = String(message.text || "");
+    if (!text) {
+      return;
+    }
+    if (!streamingAssistantTextEl) {
+      streamingAssistantTextEl = appendLog("assistant", "");
+    }
+    streamingAssistantText += text;
+    streamingAssistantTextEl.textContent = streamingAssistantText;
+    logEl.scrollTop = logEl.scrollHeight;
+    return;
+  }
+
+  if (message.type === "chat_tool") {
+    if (message.name) {
+      appendLog("tool", `Running ${message.name}`);
+    }
+    return;
+  }
+
+  if (message.type === "chat_result") {
+    busy = false;
+    setStatus(message.ok ? "Connected" : "Error", message.ok ? "connected" : "error");
+    const answer = message.answer || message.error || "No response.";
+    if (message.ok && streamingAssistantTextEl) {
+      streamingAssistantTextEl.textContent = answer;
+    } else {
+      appendLog(message.ok ? "assistant" : "error", answer);
+    }
+    if (message.executed_tools?.length) {
+      appendLog("tools", message.executed_tools.join(", "));
+    }
+    history.push({ role: "assistant", text: answer, status: message.ok ? "ok" : "error" });
+    streamingAssistantTextEl = null;
+    streamingAssistantText = "";
+    updateControls();
+    return;
+  }
+
+  if (message.type === "map_command") {
+    try {
+      const result = await executeCommand(message.command, message.args ?? {});
+      ws?.send(
+        JSON.stringify({
+          type: "map_command_result",
+          id: message.id,
+          ok: true,
+          result,
+        }),
+      );
+      appendLog("map", `${message.command}: ok`);
+    } catch (error) {
+      const text = error instanceof Error ? error.message : String(error);
+      ws?.send(
+        JSON.stringify({
+          type: "map_command_result",
+          id: message.id,
+          ok: false,
+          error: text,
+        }),
+      );
+      appendLog("map error", `${message.command}: ${text}`);
+    }
+    return;
+  }
+
+  if (message.type === "error") {
+    appendLog("error", message.error || "Unknown backend error.");
+  }
+}
+
+function sendPrompt(): void {
+  const text = promptEl.value.trim();
+  if (!text || !ws || ws.readyState !== WebSocket.OPEN || !sessionId) {
+    return;
+  }
+  history.push({ role: "user", text });
+  appendLog("user", text);
+  streamingAssistantTextEl = null;
+  streamingAssistantText = "";
+  promptEl.value = "";
+  busy = true;
+  setStatus("Running", "connected");
+  updateControls();
+  ws.send(
+    JSON.stringify({
+      type: "chat",
+      mapId,
+      message: text,
+      history,
+    }),
+  );
+}
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  sendPrompt();
+});
+
+promptEl.addEventListener("input", updateControls);
+promptEl.addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+    event.preventDefault();
+    sendPrompt();
+  }
+});
+connectButton.addEventListener("click", connect);
+panelToggleButton.addEventListener("click", togglePanel);
+clearLogButton.addEventListener("click", () => {
+  logEl.replaceChildren();
+});
+
+appendLog("system", "Start `geoagent browser --port 8765`, then connect this page.");

--- a/examples/browser_maplibre_typescript/src/styles.css
+++ b/examples/browser_maplibre_typescript/src/styles.css
@@ -97,14 +97,14 @@ label {
   font-weight: 650;
 }
 
-input,
-textarea,
-button {
+.panel input,
+.panel textarea,
+.panel button {
   font: inherit;
 }
 
-input,
-textarea {
+.panel input,
+.panel textarea {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -112,12 +112,12 @@ textarea {
   color: var(--ink);
 }
 
-input {
+.panel input {
   height: 36px;
   padding: 0 10px;
 }
 
-textarea {
+.panel textarea {
   min-height: 86px;
   resize: vertical;
   padding: 9px 10px;
@@ -136,7 +136,7 @@ textarea {
   gap: 8px;
 }
 
-button {
+.panel button {
   min-height: 36px;
   padding: 0 12px;
   border: 1px solid transparent;
@@ -147,24 +147,30 @@ button {
   cursor: pointer;
 }
 
-button.secondary {
+.panel button.secondary {
   border-color: var(--border);
   background: #fff;
   color: var(--ink);
 }
 
-.panel-toggle {
+.panel button.panel-toggle,
+.panel button.secondary.panel-toggle {
   display: inline-grid;
   place-items: center;
   width: 28px;
+  min-width: 28px;
   min-height: 28px;
   height: 28px;
   padding: 0;
+  border: 1px solid var(--border);
   border-radius: 6px;
+  background: #fff;
   color: var(--muted);
+  line-height: 1;
+  font-weight: 700;
 }
 
-.panel-toggle svg {
+.panel button.panel-toggle svg {
   width: 16px;
   height: 16px;
   stroke: currentColor;
@@ -177,7 +183,7 @@ button.secondary {
   padding: 0 10px;
 }
 
-button:disabled {
+.panel button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
 }
@@ -189,43 +195,35 @@ button:disabled {
 }
 
 .panel.collapsed {
-  width: 29px;
-  height: 29px;
-  max-height: 29px;
-  padding: 0;
-  gap: 0;
-}
-
-.panel.collapsed .title {
-  display: grid;
-  place-items: center;
-  width: 100%;
-  height: 100%;
-}
-
-.panel.collapsed .title-actions {
-  display: grid;
-  place-items: center;
-}
-
-.panel.collapsed h1,
-.panel.collapsed .status,
-.panel.collapsed .panel-body {
   display: none;
 }
 
-.panel.collapsed .panel-toggle {
+.geoagent-map-control {
+  display: none;
+}
+
+.geoagent-map-control button {
+  display: grid;
+  place-items: center;
   width: 29px;
   height: 29px;
   min-height: 29px;
+  padding: 0;
   border: 0;
-  background: var(--primary);
-  color: #fff;
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink);
+  font-weight: 400;
 }
 
-.panel.collapsed .panel-toggle svg {
-  width: 18px;
-  height: 18px;
+.geoagent-map-control button:hover {
+  background-color: rgb(0 0 0 / 5%);
+}
+
+.geoagent-map-control svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
 }
 
 .log {
@@ -281,11 +279,5 @@ button:disabled {
     left: 10px;
     width: auto;
     max-height: min(72vh, 620px);
-  }
-
-  .panel.collapsed {
-    width: 29px;
-    height: 29px;
-    max-height: 29px;
   }
 }

--- a/examples/browser_maplibre_typescript/src/styles.css
+++ b/examples/browser_maplibre_typescript/src/styles.css
@@ -1,0 +1,291 @@
+@import "maplibre-gl/dist/maplibre-gl.css";
+
+:root {
+  color-scheme: light;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --border: #d7dde5;
+  --ink: #17202a;
+  --muted: #5f6b7a;
+  --panel: #ffffff;
+  --panel-soft: #f6f8fb;
+  --primary: #0f766e;
+  --danger: #b42318;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background: #eef2f6;
+}
+
+#map {
+  position: fixed;
+  inset: 0;
+}
+
+.panel {
+  position: fixed;
+  z-index: 2;
+  top: 16px;
+  left: 16px;
+  width: min(430px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
+  box-shadow: 0 18px 50px rgb(15 23 42 / 18%);
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.title-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.status {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: #edf2f7;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status.connected {
+  background: #dff6ee;
+  color: #076448;
+}
+
+.status.error {
+  background: #fee4e2;
+  color: var(--danger);
+}
+
+label {
+  display: grid;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+}
+
+input {
+  height: 36px;
+  padding: 0 10px;
+}
+
+textarea {
+  min-height: 86px;
+  resize: vertical;
+  padding: 9px 10px;
+  line-height: 1.35;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button.secondary {
+  border-color: var(--border);
+  background: #fff;
+  color: var(--ink);
+}
+
+.panel-toggle {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  min-height: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 6px;
+  color: var(--muted);
+}
+
+.panel-toggle svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+}
+
+.connect-toggle {
+  min-width: 92px;
+  min-height: 34px;
+  height: 34px;
+  padding: 0 10px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.panel-body {
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+}
+
+.panel.collapsed {
+  width: 29px;
+  height: 29px;
+  max-height: 29px;
+  padding: 0;
+  gap: 0;
+}
+
+.panel.collapsed .title {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.panel.collapsed .title-actions {
+  display: grid;
+  place-items: center;
+}
+
+.panel.collapsed h1,
+.panel.collapsed .status,
+.panel.collapsed .panel-body {
+  display: none;
+}
+
+.panel.collapsed .panel-toggle {
+  width: 29px;
+  height: 29px;
+  min-height: 29px;
+  border: 0;
+  background: var(--primary);
+  color: #fff;
+}
+
+.panel.collapsed .panel-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.log {
+  overflow: auto;
+  min-height: 160px;
+  max-height: min(280px, calc(100vh - 360px));
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-soft);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.entry {
+  margin: 0 0 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #e3e8ef;
+}
+
+.entry:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.role {
+  margin-bottom: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+@media (max-width: 700px) {
+  .panel {
+    top: auto;
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    width: auto;
+    max-height: min(72vh, 620px);
+  }
+
+  .panel.collapsed {
+    width: 29px;
+    height: 29px;
+    max-height: 29px;
+  }
+}

--- a/examples/browser_maplibre_typescript/tsconfig.json
+++ b/examples/browser_maplibre_typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -31,6 +31,7 @@ from geoagent.core.safety import (
 from geoagent.core.factory import (
     create_agent,
     for_anymap,
+    for_browser_maplibre,
     for_gee_data_catalogs,
     for_geoai,
     for_leafmap,
@@ -55,6 +56,7 @@ __all__ = [
     "GeoToolRegistry",
     "create_agent",
     "for_anymap",
+    "for_browser_maplibre",
     "for_gee_data_catalogs",
     "for_geoai",
     "for_leafmap",

--- a/geoagent/browser/__init__.py
+++ b/geoagent/browser/__init__.py
@@ -1,0 +1,5 @@
+"""Browser-backed GeoAgent runtime helpers."""
+
+from geoagent.browser.session import BrowserMapSession, BrowserMapTimeoutError
+
+__all__ = ["BrowserMapSession", "BrowserMapTimeoutError"]

--- a/geoagent/browser/server.py
+++ b/geoagent/browser/server.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+import time
 from typing import Any
 from uuid import uuid4
 
@@ -10,6 +12,54 @@ from geoagent.browser.session import BrowserMapSession
 from geoagent.core.factory import for_browser_maplibre
 from geoagent.core.safety import auto_approve_safe_only
 from geoagent.ui.app import build_prompt_with_context
+
+
+def _stream_result_to_text(result: Any) -> str:
+    """Extract assistant text from a final Strands streaming result."""
+    message = getattr(result, "message", None)
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and "text" in block:
+            parts.append(str(block["text"]))
+    return "\n".join(parts).strip()
+
+
+def _stream_result_tool_names(result: Any) -> list[str]:
+    """Extract executed tool names from a final Strands streaming result."""
+    metrics = getattr(result, "metrics", None)
+    tool_metrics = getattr(metrics, "tool_metrics", {}) if metrics is not None else {}
+    return list(tool_metrics.keys()) if isinstance(tool_metrics, dict) else []
+
+
+def _chat_result_payload(
+    *,
+    agent: Any,
+    result: Any,
+    answer_text: str,
+    elapsed: float,
+) -> dict[str, Any]:
+    """Build the final browser chat payload for streamed and non-streamed turns."""
+    final_text = _stream_result_to_text(result) if result is not None else ""
+    stop = str(getattr(result, "stop_reason", "end_turn")) if result is not None else ""
+    success = stop not in ("cancelled", "guardrail_intervened")
+    payload: dict[str, Any] = {
+        "type": "chat_result",
+        "ok": success,
+        "answer": final_text or answer_text,
+        "executed_tools": _stream_result_tool_names(result),
+        "tool_calls": list(getattr(agent, "_tool_calls", []) or []),
+        "cancelled_tools": list(getattr(agent, "_cancelled", []) or []),
+        "execution_time": elapsed,
+        "streamed": True,
+    }
+    if not success:
+        payload["error"] = f"stop_reason={stop}"
+    return payload
 
 
 async def _send_json(websocket: Any, payload: dict[str, Any]) -> None:
@@ -29,7 +79,7 @@ async def _run_chat_turn(
     model_id: str | None,
     history: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Run one GeoAgent chat turn in a worker thread."""
+    """Run one GeoAgent chat turn and stream deltas to the browser."""
     try:
         await _send_json(websocket, {"type": "chat_status", "status": "running"})
         agent = for_browser_maplibre(
@@ -39,18 +89,78 @@ async def _run_chat_turn(
             confirm=auto_approve_safe_only,
         )
         prompt = build_prompt_with_context(history, message) if history else message
-        response = await asyncio.to_thread(agent.chat, prompt)
-        payload: dict[str, Any] = {
-            "type": "chat_result",
-            "ok": bool(response.success),
-            "answer": response.answer_text or "",
-            "executed_tools": list(response.executed_tools or []),
-            "tool_calls": list(response.tool_calls or []),
-            "cancelled_tools": list(response.cancelled_tools or []),
-        }
-        if response.error_message:
-            payload["error"] = response.error_message
-        await _send_json(websocket, payload)
+        loop = asyncio.get_running_loop()
+        events: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+
+        async def _consume_stream() -> None:
+            """Drain GeoAgent streaming events in the worker thread."""
+            try:
+                async for event in agent.stream_chat(prompt):
+                    loop.call_soon_threadsafe(events.put_nowait, ("event", event))
+            except BaseException as exc:  # pragma: no cover - defensive worker path
+                loop.call_soon_threadsafe(events.put_nowait, ("error", exc))
+            finally:
+                loop.call_soon_threadsafe(events.put_nowait, ("done", None))
+
+        def _worker() -> None:
+            asyncio.run(_consume_stream())
+
+        started = time.time()
+        thread = threading.Thread(
+            target=_worker,
+            daemon=True,
+            name="GeoAgent-browser-stream-chat",
+        )
+        thread.start()
+
+        answer_parts: list[str] = []
+        final_result: Any = None
+        while True:
+            kind, event = await events.get()
+            if kind == "done":
+                break
+            if kind == "error":
+                raise event
+            if not isinstance(event, dict):
+                continue
+            if "data" in event:
+                text = str(event.get("data") or "")
+                if text:
+                    answer_parts.append(text)
+                    await _send_json(
+                        websocket,
+                        {
+                            "type": "chat_delta",
+                            "text": text,
+                        },
+                    )
+                continue
+            if "current_tool_use" in event:
+                tool_use = event.get("current_tool_use")
+                tool_name = ""
+                if isinstance(tool_use, dict):
+                    tool_name = str(tool_use.get("name") or "")
+                await _send_json(
+                    websocket,
+                    {
+                        "type": "chat_tool",
+                        "name": tool_name,
+                    },
+                )
+                continue
+            if "result" in event:
+                final_result = event.get("result")
+
+        thread.join(timeout=0)
+        await _send_json(
+            websocket,
+            _chat_result_payload(
+                agent=agent,
+                result=final_result,
+                answer_text="".join(answer_parts),
+                elapsed=time.time() - started,
+            ),
+        )
     except Exception as exc:
         await _send_json(
             websocket,
@@ -77,6 +187,10 @@ def create_browser_app(
             "FastAPI is required for `geoagent browser`. Install with "
             "`pip install GeoAgent[browser]`."
         ) from exc
+    # Endpoint annotations are postponed by ``from __future__ import annotations``.
+    # FastAPI resolves them against module globals, not this function's locals.
+    globals()["WebSocket"] = WebSocket
+    globals()["WebSocketDisconnect"] = WebSocketDisconnect
 
     app = FastAPI(title="GeoAgent Browser")
 
@@ -164,10 +278,9 @@ def create_browser_app(
             session.fail_all(str(exc))
             raise
         finally:
-            # ``active_chat`` runs ``agent.chat`` inside ``asyncio.to_thread``;
-            # the worker thread is not actually cancellable, so ``cancel()`` would
-            # only mark the wrapping task while the provider call kept running.
-            # Drop the reference and let the task finish quietly instead.
+            # Streaming chat runs in a worker thread so browser map tools can
+            # synchronously wait on this WebSocket loop. The worker thread is not
+            # cancellable, so drop the reference and let the task finish quietly.
             active_chat = None
 
     return app

--- a/geoagent/browser/server.py
+++ b/geoagent/browser/server.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from geoagent.browser.session import BrowserMapSession
 from geoagent.core.factory import for_browser_maplibre
 from geoagent.core.safety import auto_approve_safe_only
+from geoagent.ui.app import build_prompt_with_context
 
 
 async def _send_json(websocket: Any, payload: dict[str, Any]) -> None:
@@ -26,6 +27,7 @@ async def _run_chat_turn(
     message: str,
     provider: str | None,
     model_id: str | None,
+    history: list[dict[str, Any]] | None = None,
 ) -> None:
     """Run one GeoAgent chat turn in a worker thread."""
     try:
@@ -36,7 +38,8 @@ async def _run_chat_turn(
             model_id=model_id,
             confirm=auto_approve_safe_only,
         )
-        response = await asyncio.to_thread(agent.chat, message)
+        prompt = build_prompt_with_context(history, message) if history else message
+        response = await asyncio.to_thread(agent.chat, prompt)
         payload: dict[str, Any] = {
             "type": "chat_result",
             "ok": bool(response.success),
@@ -140,6 +143,11 @@ def create_browser_app(
                     )
                     continue
 
+                raw_history = message.get("history")
+                history: list[dict[str, Any]] | None = None
+                if isinstance(raw_history, list):
+                    history = [item for item in raw_history if isinstance(item, dict)]
+
                 active_chat = asyncio.create_task(
                     _run_chat_turn(
                         websocket=websocket,
@@ -147,17 +155,20 @@ def create_browser_app(
                         message=chat_message,
                         provider=provider,
                         model_id=model_id,
+                        history=history,
                     )
                 )
         except WebSocketDisconnect:
             session.fail_all("Browser WebSocket disconnected.")
-            if active_chat is not None:
-                active_chat.cancel()
         except Exception as exc:
             session.fail_all(str(exc))
-            if active_chat is not None:
-                active_chat.cancel()
             raise
+        finally:
+            # ``active_chat`` runs ``agent.chat`` inside ``asyncio.to_thread``;
+            # the worker thread is not actually cancellable, so ``cancel()`` would
+            # only mark the wrapping task while the provider call kept running.
+            # Drop the reference and let the task finish quietly instead.
+            active_chat = None
 
     return app
 

--- a/geoagent/browser/server.py
+++ b/geoagent/browser/server.py
@@ -1,0 +1,190 @@
+"""FastAPI WebSocket server for embedded browser GeoAgent chat."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from geoagent.browser.session import BrowserMapSession
+from geoagent.core.factory import for_browser_maplibre
+from geoagent.core.safety import auto_approve_safe_only
+
+
+async def _send_json(websocket: Any, payload: dict[str, Any]) -> None:
+    """Send JSON while tolerating disconnected clients."""
+    try:
+        await websocket.send_json(payload)
+    except Exception:
+        pass
+
+
+async def _run_chat_turn(
+    *,
+    websocket: Any,
+    session: BrowserMapSession,
+    message: str,
+    provider: str | None,
+    model_id: str | None,
+) -> None:
+    """Run one GeoAgent chat turn in a worker thread."""
+    try:
+        await _send_json(websocket, {"type": "chat_status", "status": "running"})
+        agent = for_browser_maplibre(
+            session=session,
+            provider=provider,
+            model_id=model_id,
+            confirm=auto_approve_safe_only,
+        )
+        response = await asyncio.to_thread(agent.chat, message)
+        payload: dict[str, Any] = {
+            "type": "chat_result",
+            "ok": bool(response.success),
+            "answer": response.answer_text or "",
+            "executed_tools": list(response.executed_tools or []),
+            "tool_calls": list(response.tool_calls or []),
+            "cancelled_tools": list(response.cancelled_tools or []),
+        }
+        if response.error_message:
+            payload["error"] = response.error_message
+        await _send_json(websocket, payload)
+    except Exception as exc:
+        await _send_json(
+            websocket,
+            {
+                "type": "chat_result",
+                "ok": False,
+                "answer": "",
+                "error": str(exc),
+            },
+        )
+
+
+def create_browser_app(
+    *,
+    provider: str | None = None,
+    model_id: str | None = None,
+    command_timeout_seconds: float = 30.0,
+) -> Any:
+    """Create the FastAPI app for browser-embedded GeoAgent chat."""
+    try:
+        from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+    except ImportError as exc:  # pragma: no cover - exercised by CLI fallback.
+        raise RuntimeError(
+            "FastAPI is required for `geoagent browser`. Install with "
+            "`pip install GeoAgent[browser]`."
+        ) from exc
+
+    app = FastAPI(title="GeoAgent Browser")
+
+    @app.get("/geoagent/health")
+    async def health() -> dict[str, Any]:
+        return {"ok": True}
+
+    @app.websocket("/geoagent/ws")
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        loop = asyncio.get_running_loop()
+        session_id = str(uuid4())
+        session = BrowserMapSession(
+            websocket=websocket,
+            loop=loop,
+            session_id=session_id,
+            timeout_seconds=command_timeout_seconds,
+        )
+        active_chat: asyncio.Task[None] | None = None
+        await websocket.send_json(
+            {
+                "type": "session",
+                "sessionId": session_id,
+                "mapId": session.map_id,
+            }
+        )
+
+        try:
+            while True:
+                message = await websocket.receive_json()
+                msg_type = message.get("type")
+                if msg_type == "map_command_result":
+                    session.resolve_result(message)
+                    continue
+                if msg_type != "chat":
+                    await websocket.send_json(
+                        {
+                            "type": "error",
+                            "error": f"Unsupported message type: {msg_type!r}",
+                        }
+                    )
+                    continue
+                if active_chat is not None and not active_chat.done():
+                    await websocket.send_json(
+                        {
+                            "type": "chat_result",
+                            "ok": False,
+                            "answer": "",
+                            "error": "A chat turn is already running for this session.",
+                        }
+                    )
+                    continue
+
+                session.map_id = str(message.get("mapId") or "default")
+                chat_message = str(message.get("message") or "").strip()
+                if not chat_message:
+                    await websocket.send_json(
+                        {
+                            "type": "chat_result",
+                            "ok": False,
+                            "answer": "",
+                            "error": "Chat message is empty.",
+                        }
+                    )
+                    continue
+
+                active_chat = asyncio.create_task(
+                    _run_chat_turn(
+                        websocket=websocket,
+                        session=session,
+                        message=chat_message,
+                        provider=provider,
+                        model_id=model_id,
+                    )
+                )
+        except WebSocketDisconnect:
+            session.fail_all("Browser WebSocket disconnected.")
+            if active_chat is not None:
+                active_chat.cancel()
+        except Exception as exc:
+            session.fail_all(str(exc))
+            if active_chat is not None:
+                active_chat.cancel()
+            raise
+
+    return app
+
+
+def run_browser_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    provider: str | None = None,
+    model_id: str | None = None,
+    command_timeout_seconds: float = 30.0,
+) -> None:
+    """Run the browser GeoAgent server with uvicorn."""
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover - exercised by CLI fallback.
+        raise RuntimeError(
+            "Uvicorn is required for `geoagent browser`. Install with "
+            "`pip install GeoAgent[browser]`."
+        ) from exc
+
+    app = create_browser_app(
+        provider=provider,
+        model_id=model_id,
+        command_timeout_seconds=command_timeout_seconds,
+    )
+    uvicorn.run(app, host=host, port=int(port))
+
+
+__all__ = ["create_browser_app", "run_browser_server"]

--- a/geoagent/browser/server.py
+++ b/geoagent/browser/server.py
@@ -13,6 +13,14 @@ from geoagent.core.factory import for_browser_maplibre
 from geoagent.core.safety import auto_approve_safe_only
 from geoagent.ui.app import build_prompt_with_context
 
+_BROWSER_CONFIRM_TOOL_NAMES = frozenset(
+    {
+        "remove_layer",
+        "clear_layers",
+        "run_maplibre_script",
+    }
+)
+
 
 def _stream_result_to_text(result: Any) -> str:
     """Extract assistant text from a final Strands streaming result."""
@@ -62,6 +70,25 @@ def _chat_result_payload(
     return payload
 
 
+def _browser_confirm_callback(
+    allow_browser_code: bool,
+    auto_approve_browser_tools: bool,
+):
+    """Return the browser backend confirmation policy."""
+
+    def _confirm(request: Any) -> bool:
+        if auto_approve_browser_tools and (
+            getattr(request, "category", None) == "browser_map"
+            or request.tool_name in _BROWSER_CONFIRM_TOOL_NAMES
+        ):
+            return True
+        if allow_browser_code and request.tool_name == "run_maplibre_script":
+            return True
+        return auto_approve_safe_only(request)
+
+    return _confirm
+
+
 async def _send_json(websocket: Any, payload: dict[str, Any]) -> None:
     """Send JSON while tolerating disconnected clients."""
     try:
@@ -77,6 +104,8 @@ async def _run_chat_turn(
     message: str,
     provider: str | None,
     model_id: str | None,
+    allow_browser_code: bool,
+    auto_approve_browser_tools: bool,
     history: list[dict[str, Any]] | None = None,
 ) -> None:
     """Run one GeoAgent chat turn and stream deltas to the browser."""
@@ -86,7 +115,11 @@ async def _run_chat_turn(
             session=session,
             provider=provider,
             model_id=model_id,
-            confirm=auto_approve_safe_only,
+            confirm=_browser_confirm_callback(
+                allow_browser_code,
+                auto_approve_browser_tools,
+            ),
+            allow_browser_code=allow_browser_code,
         )
         prompt = build_prompt_with_context(history, message) if history else message
         loop = asyncio.get_running_loop()
@@ -178,6 +211,8 @@ def create_browser_app(
     provider: str | None = None,
     model_id: str | None = None,
     command_timeout_seconds: float = 30.0,
+    allow_browser_code: bool = False,
+    auto_approve_browser_tools: bool = False,
 ) -> Any:
     """Create the FastAPI app for browser-embedded GeoAgent chat."""
     try:
@@ -269,6 +304,8 @@ def create_browser_app(
                         message=chat_message,
                         provider=provider,
                         model_id=model_id,
+                        allow_browser_code=allow_browser_code,
+                        auto_approve_browser_tools=auto_approve_browser_tools,
                         history=history,
                     )
                 )
@@ -293,6 +330,8 @@ def run_browser_server(
     provider: str | None = None,
     model_id: str | None = None,
     command_timeout_seconds: float = 30.0,
+    allow_browser_code: bool = False,
+    auto_approve_browser_tools: bool = False,
 ) -> None:
     """Run the browser GeoAgent server with uvicorn."""
     try:
@@ -307,6 +346,8 @@ def run_browser_server(
         provider=provider,
         model_id=model_id,
         command_timeout_seconds=command_timeout_seconds,
+        allow_browser_code=allow_browser_code,
+        auto_approve_browser_tools=auto_approve_browser_tools,
     )
     uvicorn.run(app, host=host, port=int(port))
 

--- a/geoagent/browser/session.py
+++ b/geoagent/browser/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 import uuid
 from typing import Any
 
@@ -63,6 +64,9 @@ class BrowserMapSession:
         wait_timeout = (
             self.timeout_seconds if timeout_seconds is None else float(timeout_seconds)
         )
+        # Treat ``wait_timeout`` as a total deadline so the send and response
+        # phases share one budget instead of each consuming a full ``wait_timeout``.
+        deadline = time.monotonic() + wait_timeout
         future = asyncio.run_coroutine_threadsafe(
             self.websocket.send_json(payload),
             self.loop,
@@ -73,7 +77,8 @@ class BrowserMapSession:
             self._drop_pending(command_id)
             raise
 
-        if not event.wait(wait_timeout):
+        remaining = max(0.0, deadline - time.monotonic())
+        if not event.wait(remaining):
             self._drop_pending(command_id)
             raise BrowserMapTimeoutError(
                 f"Browser did not return a result for {command!r} within "

--- a/geoagent/browser/session.py
+++ b/geoagent/browser/session.py
@@ -60,17 +60,19 @@ class BrowserMapSession:
             "command": command,
             "args": args or {},
         }
+        wait_timeout = (
+            self.timeout_seconds if timeout_seconds is None else float(timeout_seconds)
+        )
         future = asyncio.run_coroutine_threadsafe(
             self.websocket.send_json(payload),
             self.loop,
         )
         try:
-            future.result(timeout=timeout_seconds or self.timeout_seconds)
+            future.result(timeout=wait_timeout)
         except Exception:
             self._drop_pending(command_id)
             raise
 
-        wait_timeout = timeout_seconds or self.timeout_seconds
         if not event.wait(wait_timeout):
             self._drop_pending(command_id)
             raise BrowserMapTimeoutError(

--- a/geoagent/browser/session.py
+++ b/geoagent/browser/session.py
@@ -1,0 +1,112 @@
+"""WebSocket command broker for browser-hosted maps."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import uuid
+from typing import Any
+
+
+class BrowserMapTimeoutError(TimeoutError):
+    """Raised when the browser does not answer a map command in time."""
+
+
+class BrowserMapSession:
+    """Bridge synchronous GeoAgent tools to one async browser WebSocket.
+
+    Strands tools are synchronous functions. The browser connection is async.
+    This session schedules outgoing command messages on the server event loop
+    and blocks the calling tool thread until the matching browser result arrives.
+    """
+
+    def __init__(
+        self,
+        *,
+        websocket: Any,
+        loop: asyncio.AbstractEventLoop,
+        session_id: str,
+        map_id: str = "default",
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self.websocket = websocket
+        self.loop = loop
+        self.session_id = session_id
+        self.map_id = map_id or "default"
+        self.timeout_seconds = float(timeout_seconds)
+        self._pending: dict[str, tuple[threading.Event, dict[str, Any]]] = {}
+        self._lock = threading.Lock()
+
+    def call(
+        self,
+        command: str,
+        args: dict[str, Any] | None = None,
+        *,
+        map_id: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> Any:
+        """Send a map command to the browser and wait for its result."""
+        command_id = str(uuid.uuid4())
+        event = threading.Event()
+        holder: dict[str, Any] = {}
+        with self._lock:
+            self._pending[command_id] = (event, holder)
+
+        payload = {
+            "type": "map_command",
+            "id": command_id,
+            "sessionId": self.session_id,
+            "mapId": map_id or self.map_id,
+            "command": command,
+            "args": args or {},
+        }
+        future = asyncio.run_coroutine_threadsafe(
+            self.websocket.send_json(payload),
+            self.loop,
+        )
+        try:
+            future.result(timeout=timeout_seconds or self.timeout_seconds)
+        except Exception:
+            self._drop_pending(command_id)
+            raise
+
+        wait_timeout = timeout_seconds or self.timeout_seconds
+        if not event.wait(wait_timeout):
+            self._drop_pending(command_id)
+            raise BrowserMapTimeoutError(
+                f"Browser did not return a result for {command!r} within "
+                f"{wait_timeout:g} seconds."
+            )
+
+        result = holder.get("message", {})
+        if not result.get("ok", False):
+            error = result.get("error") or f"Browser command {command!r} failed."
+            raise RuntimeError(str(error))
+        return result.get("result")
+
+    def resolve_result(self, message: dict[str, Any]) -> bool:
+        """Resolve a pending command from a browser ``map_command_result``."""
+        command_id = str(message.get("id") or "")
+        if not command_id:
+            return False
+        with self._lock:
+            pending = self._pending.pop(command_id, None)
+        if pending is None:
+            return False
+        event, holder = pending
+        holder["message"] = message
+        event.set()
+        return True
+
+    def fail_all(self, error: str) -> None:
+        """Fail all pending commands, usually after WebSocket disconnect."""
+        with self._lock:
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for event, holder in pending:
+            holder["message"] = {"ok": False, "error": error}
+            event.set()
+
+    def _drop_pending(self, command_id: str) -> None:
+        with self._lock:
+            self._pending.pop(command_id, None)

--- a/geoagent/cli.py
+++ b/geoagent/cli.py
@@ -2,6 +2,7 @@
 
 Commands:
   geoagent ui              Launch the Solara UI
+  geoagent browser         Launch the browser WebSocket backend
   geoagent codex login     Login with ChatGPT/Codex OAuth
   geoagent --help          Show help
 """
@@ -44,6 +45,24 @@ def _run_codex_login(args: argparse.Namespace) -> int:
         return 0
     except Exception as exc:
         print(f"Codex login failed: {exc}")
+        return 1
+
+
+def _run_browser_server(args: argparse.Namespace) -> int:
+    """Run the embedded browser GeoAgent WebSocket backend."""
+    try:
+        from geoagent.browser.server import run_browser_server
+
+        run_browser_server(
+            host=args.host,
+            port=args.port,
+            provider=args.provider,
+            model_id=args.model,
+            command_timeout_seconds=args.command_timeout,
+        )
+        return 0
+    except Exception as exc:
+        print(f"Browser server failed: {exc}")
         return 1
 
 
@@ -97,6 +116,22 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", metavar="command")
 
     subparsers.add_parser("ui", help="Launch the Solara UI")
+    browser_parser = subparsers.add_parser(
+        "browser",
+        help="Launch the browser WebSocket backend",
+    )
+    browser_parser.add_argument("--host", default="127.0.0.1")
+    browser_parser.add_argument("--port", type=int, default=8765)
+    browser_parser.add_argument("--provider", default=None)
+    browser_parser.add_argument("--model", default=None, help="Override model id")
+    browser_parser.add_argument(
+        "--command-timeout",
+        type=float,
+        default=30.0,
+        help="Seconds to wait for browser map command results",
+    )
+    browser_parser.set_defaults(func=_run_browser_server)
+
     codex_parser = subparsers.add_parser(
         "codex",
         help="Manage ChatGPT/Codex OAuth login",
@@ -151,6 +186,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "ui":
         return _run_solara_app()
+    if args.command == "browser":
+        return args.func(args)
     if args.command == "codex":
         if hasattr(args, "func"):
             return args.func(args)

--- a/geoagent/cli.py
+++ b/geoagent/cli.py
@@ -122,7 +122,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     browser_parser.add_argument("--host", default="127.0.0.1")
     browser_parser.add_argument("--port", type=int, default=8765)
-    browser_parser.add_argument("--provider", default=None)
+    browser_parser.add_argument(
+        "--provider",
+        default="openai-codex",
+        help="Model provider id. Defaults to openai-codex.",
+    )
     browser_parser.add_argument("--model", default=None, help="Override model id")
     browser_parser.add_argument(
         "--command-timeout",

--- a/geoagent/cli.py
+++ b/geoagent/cli.py
@@ -59,6 +59,8 @@ def _run_browser_server(args: argparse.Namespace) -> int:
             provider=args.provider,
             model_id=args.model,
             command_timeout_seconds=args.command_timeout,
+            allow_browser_code=args.allow_browser_code,
+            auto_approve_browser_tools=args.auto_approve_browser_tools,
         )
         return 0
     except Exception as exc:
@@ -133,6 +135,22 @@ def main(argv: list[str] | None = None) -> int:
         type=float,
         default=30.0,
         help="Seconds to wait for browser map command results",
+    )
+    browser_parser.add_argument(
+        "--allow-browser-code",
+        action="store_true",
+        help=(
+            "Expose and auto-approve run_maplibre_script for local browser "
+            "MapLibre JavaScript execution."
+        ),
+    )
+    browser_parser.add_argument(
+        "--auto-approve-browser-tools",
+        action="store_true",
+        help=(
+            "Auto-approve confirmation-gated browser map tools such as "
+            "remove_layer and clear_layers for trusted local sessions."
+        ),
     )
     browser_parser.set_defaults(func=_run_browser_server)
 

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -314,6 +314,17 @@ Workflow guidance:
   when useful.
 """
 
+BROWSER_MAPLIBRE_CODE_SYSTEM_PROMPT = """\
+Browser JavaScript code execution is enabled for this local session.
+
+When no dedicated browser map tool can perform the requested MapLibre
+operation, write a short JavaScript snippet and run it with
+run_maplibre_script. The snippet executes in the browser with these names in
+scope: map, maplibregl, and helpers. Prefer MapLibre GL JS API calls, keep code
+focused on map operations, and avoid credential handling, storage access,
+unrelated DOM manipulation, or broad network operations.
+"""
+
 
 def _filter_by_imports(tools: list[Any]) -> list[Any]:
     """Drop tools whose declared optional packages are unavailable."""
@@ -643,15 +654,21 @@ def for_browser_maplibre(
     fast: bool = False,
     confirm: ConfirmCallback | None = None,
     extra_tools: Optional[list[Any]] = None,
+    allow_browser_code: bool = False,
 ) -> GeoAgent:
     """Bind an agent to a MapLibre map running in a browser session."""
+    system_prompt = BROWSER_MAPLIBRE_SYSTEM_PROMPT
+    if allow_browser_code:
+        system_prompt = f"{system_prompt}\n\n{BROWSER_MAPLIBRE_CODE_SYSTEM_PROMPT}"
     ctx = GeoAgentContext(
         metadata={
             "integration": "browser_maplibre",
-            "system_prompt": BROWSER_MAPLIBRE_SYSTEM_PROMPT,
+            "system_prompt": system_prompt,
         }
     )
-    tool_list = _filter_by_imports(browser_maplibre_tools(session))
+    tool_list = _filter_by_imports(
+        browser_maplibre_tools(session, allow_code=allow_browser_code)
+    )
     if extra_tools:
         tool_list.extend(extra_tools)
     registry = GeoToolRegistry()

--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -14,6 +14,7 @@ from geoagent.core.registry import (
 from geoagent.core.safety import ConfirmCallback
 from geoagent.core.agent import GeoAgent
 from geoagent.tools.anymap import anymap_tools
+from geoagent.tools.browser_maplibre import browser_maplibre_tools
 from geoagent.tools.geoai import geoai_tools
 from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
 from geoagent.tools.images import image_generation_tools
@@ -294,6 +295,23 @@ Workflow guidance:
   validates the raster.
 - Keep responses concise and include catalog URL, collection, item id, asset
   key, and layer name when available.
+"""
+
+BROWSER_MAPLIBRE_SYSTEM_PROMPT = """\
+You are an AI assistant embedded in a browser web app with access to a live
+MapLibre map through safe browser tools.
+
+Workflow guidance:
+- Use browser map tools for map navigation, layer inspection, marker creation,
+  GeoJSON display, layer visibility, feature queries, and screenshots.
+- Coordinates in user-facing prompts are latitude/longitude, but browser map
+  internals use longitude/latitude. Use the tool parameter names exactly.
+- Do not ask the user to paste JavaScript or run Python for actions that the
+  browser map tools can perform.
+- If a requested operation has no browser map tool, explain the limitation
+  briefly rather than trying to execute arbitrary JavaScript.
+- Keep responses concise and include layer names, locations, and tool results
+  when useful.
 """
 
 
@@ -597,6 +615,48 @@ def for_anymap(
         extra_tools=extra_tools,
         fast=fast,
     )
+    cfg = config or GeoAgentConfig()
+    if provider is not None:
+        cfg = cfg.model_copy(update={"provider": provider})
+    if model_id is not None:
+        cfg = cfg.model_copy(update={"model": model_id})
+    return GeoAgent(
+        context=ctx,
+        config=cfg,
+        tools=tools,
+        registry=registry,
+        model=model,
+        provider=provider,
+        model_id=model_id,
+        fast=fast,
+        confirm=confirm,
+    )
+
+
+def for_browser_maplibre(
+    session: Any,
+    *,
+    config: GeoAgentConfig | None = None,
+    model: Any | None = None,
+    provider: str | None = None,
+    model_id: str | None = None,
+    fast: bool = False,
+    confirm: ConfirmCallback | None = None,
+    extra_tools: Optional[list[Any]] = None,
+) -> GeoAgent:
+    """Bind an agent to a MapLibre map running in a browser session."""
+    ctx = GeoAgentContext(
+        metadata={
+            "integration": "browser_maplibre",
+            "system_prompt": BROWSER_MAPLIBRE_SYSTEM_PROMPT,
+        }
+    )
+    tool_list = _filter_by_imports(browser_maplibre_tools(session))
+    if extra_tools:
+        tool_list.extend(extra_tools)
+    registry = GeoToolRegistry()
+    register_all_tools(registry, tool_list)
+    tools = collect_tools_for_context(tool_list, fast=fast, registry=registry)
     cfg = config or GeoAgentConfig()
     if provider is not None:
         cfg = cfg.model_copy(update={"provider": provider})

--- a/geoagent/tools/browser_maplibre.py
+++ b/geoagent/tools/browser_maplibre.py
@@ -8,7 +8,11 @@ from geoagent.browser.session import BrowserMapSession
 from geoagent.core.decorators import geo_tool
 
 
-def browser_maplibre_tools(session: BrowserMapSession | None) -> list[Any]:
+def browser_maplibre_tools(
+    session: BrowserMapSession | None,
+    *,
+    allow_code: bool = False,
+) -> list[Any]:
     """Build browser MapLibre tools bound to a WebSocket map session."""
     if session is None:
         return []
@@ -181,7 +185,7 @@ def browser_maplibre_tools(session: BrowserMapSession | None) -> list[Any]:
         result = session.call("clear_layers")
         return str(result or "Cleared browser map layers.")
 
-    return [
+    tools = [
         list_layers,
         get_map_state,
         set_center,
@@ -200,6 +204,55 @@ def browser_maplibre_tools(session: BrowserMapSession | None) -> list[Any]:
         remove_layer,
         clear_layers,
     ]
+
+    if allow_code:
+
+        @geo_tool(
+            category="browser_map",
+            requires_confirmation=True,
+            destructive=True,
+        )
+        def run_maplibre_script(code: str, description: str = "") -> dict[str, Any]:
+            """Run a short JavaScript snippet against the live browser MapLibre map.
+
+            Use this only when no dedicated browser map tool can perform the
+            requested operation. The browser page executes the code with ``map``,
+            ``maplibregl``, and a small ``helpers`` object in scope. Do not use
+            this for credential handling, storage access, broad DOM access, or
+            unrelated network operations.
+
+            Args:
+                code: JavaScript code to execute in the browser. It may use
+                    ``await`` and may return a JSON-serializable value.
+                description: One-sentence explanation of the intended map change.
+
+            Returns:
+                A dict with success status, message, returned value, and the
+                executed code.
+            """
+            code = (code or "").strip()
+            if not code:
+                return {
+                    "success": False,
+                    "error": "No MapLibre JavaScript code was provided.",
+                    "maplibre_script": "",
+                }
+            result = session.call(
+                "run_maplibre_script",
+                {"code": code, "description": description},
+            )
+            if isinstance(result, dict):
+                return result
+            return {
+                "success": True,
+                "message": str(result or description or "MapLibre script executed."),
+                "description": description,
+                "maplibre_script": code,
+            }
+
+        tools.append(run_maplibre_script)
+
+    return tools
 
 
 __all__ = ["browser_maplibre_tools"]

--- a/geoagent/tools/browser_maplibre.py
+++ b/geoagent/tools/browser_maplibre.py
@@ -1,0 +1,205 @@
+"""GeoAgent tools for MapLibre maps running in a browser web app."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from geoagent.browser.session import BrowserMapSession
+from geoagent.core.decorators import geo_tool
+
+
+def browser_maplibre_tools(session: BrowserMapSession | None) -> list[Any]:
+    """Build browser MapLibre tools bound to a WebSocket map session."""
+    if session is None:
+        return []
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def list_layers() -> list[dict[str, Any]]:
+        """List layers currently present in the browser MapLibre map."""
+        result = session.call("list_layers")
+        return result if isinstance(result, list) else []
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def get_map_state() -> dict[str, Any]:
+        """Return the browser map camera state and current bounds."""
+        result = session.call("get_map_state")
+        return result if isinstance(result, dict) else {}
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def set_center(lat: float, lon: float, zoom: Optional[float] = None) -> str:
+        """Center the browser map on a latitude/longitude coordinate."""
+        result = session.call(
+            "set_center",
+            {"lat": float(lat), "lon": float(lon), "zoom": zoom},
+        )
+        return str(result or f"Centered map on ({lat}, {lon}).")
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def fly_to(lat: float, lon: float, zoom: Optional[float] = None) -> str:
+        """Animate the browser map to a latitude/longitude coordinate."""
+        result = session.call(
+            "fly_to",
+            {"lat": float(lat), "lon": float(lon), "zoom": zoom},
+        )
+        return str(result or f"Moved map to ({lat}, {lon}).")
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def set_zoom(zoom: float) -> str:
+        """Set the browser map zoom level."""
+        result = session.call("set_zoom", {"zoom": float(zoom)})
+        return str(result or f"Zoom set to {zoom}.")
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def zoom_to_bounds(west: float, south: float, east: float, north: float) -> str:
+        """Zoom the browser map to a bounding box."""
+        result = session.call(
+            "zoom_to_bounds",
+            {
+                "west": float(west),
+                "south": float(south),
+                "east": float(east),
+                "north": float(north),
+            },
+        )
+        return str(result or f"Zoomed to [{west}, {south}, {east}, {north}].")
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def change_basemap(style: str) -> str:
+        """Change the browser MapLibre style URL or style identifier."""
+        result = session.call("change_basemap", {"style": style})
+        return str(result or f"Basemap changed to {style!r}.")
+
+    @geo_tool(category="browser_map")
+    def add_marker(
+        lat: float,
+        lon: float,
+        popup: Optional[str] = None,
+        tooltip: Optional[str] = None,
+        name: Optional[str] = None,
+        color: str = "#3388ff",
+    ) -> str:
+        """Add a marker to the browser map."""
+        result = session.call(
+            "add_marker",
+            {
+                "lat": float(lat),
+                "lon": float(lon),
+                "popup": popup,
+                "tooltip": tooltip,
+                "name": name,
+                "color": color,
+            },
+        )
+        return str(result or f"Added marker at ({lat}, {lon}).")
+
+    @geo_tool(category="browser_map")
+    def add_geojson_data(
+        data: dict[str, Any],
+        name: str,
+        style: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Add an in-memory GeoJSON object to the browser map."""
+        result = session.call(
+            "add_geojson_data",
+            {"data": data, "name": name, "style": style or {}},
+        )
+        return str(result or f"Added GeoJSON layer {name!r}.")
+
+    @geo_tool(category="browser_map")
+    def add_vector_data(
+        url: str,
+        name: str,
+        style: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Add vector data from a URL to the browser map."""
+        result = session.call(
+            "add_vector_data",
+            {"url": url, "name": name, "style": style or {}},
+        )
+        return str(result or f"Added vector layer {name!r}.")
+
+    @geo_tool(category="browser_map")
+    def add_xyz_tile_layer(
+        url: str,
+        name: str,
+        attribution: str = "",
+    ) -> str:
+        """Add an XYZ raster tile layer to the browser map."""
+        result = session.call(
+            "add_xyz_tile_layer",
+            {"url": url, "name": name, "attribution": attribution},
+        )
+        return str(result or f"Added XYZ layer {name!r}.")
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def set_layer_visibility(name: str, visible: bool) -> str:
+        """Show or hide a browser map layer."""
+        result = session.call(
+            "set_layer_visibility",
+            {"name": name, "visible": bool(visible)},
+        )
+        return str(result or f"Layer {name!r} visibility set to {visible}.")
+
+    @geo_tool(category="browser_map", available_in=("full", "fast"))
+    def set_layer_opacity(name: str, opacity: float) -> str:
+        """Set browser map layer opacity between 0 and 1."""
+        value = max(0.0, min(1.0, float(opacity)))
+        result = session.call(
+            "set_layer_opacity",
+            {"name": name, "opacity": value},
+        )
+        return str(result or f"Layer {name!r} opacity set to {value}.")
+
+    @geo_tool(category="browser_map")
+    def query_rendered_features(
+        layers: Optional[list[str]] = None,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+    ) -> list[dict[str, Any]]:
+        """Query rendered features from the browser map."""
+        result = session.call(
+            "query_rendered_features",
+            {"layers": layers or [], "x": x, "y": y},
+        )
+        return result if isinstance(result, list) else []
+
+    @geo_tool(category="browser_map")
+    def screenshot_map() -> dict[str, Any]:
+        """Capture the browser map canvas as a PNG data URL."""
+        result = session.call("screenshot_map")
+        return result if isinstance(result, dict) else {"data_url": result}
+
+    @geo_tool(category="browser_map", requires_confirmation=True, destructive=True)
+    def remove_layer(name: str) -> str:
+        """Remove a layer from the browser map."""
+        result = session.call("remove_layer", {"name": name})
+        return str(result or f"Removed layer {name!r}.")
+
+    @geo_tool(category="browser_map", requires_confirmation=True, destructive=True)
+    def clear_layers() -> str:
+        """Remove user-added layers from the browser map."""
+        result = session.call("clear_layers")
+        return str(result or "Cleared browser map layers.")
+
+    return [
+        list_layers,
+        get_map_state,
+        set_center,
+        fly_to,
+        set_zoom,
+        zoom_to_bounds,
+        change_basemap,
+        add_marker,
+        add_geojson_data,
+        add_vector_data,
+        add_xyz_tile_layer,
+        set_layer_visibility,
+        set_layer_opacity,
+        query_rendered_features,
+        screenshot_map,
+        remove_layer,
+        clear_layers,
+    ]
+
+
+__all__ = ["browser_maplibre_tools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,11 @@ nasa-opera = ["earthaccess>=0.10"]
 whitebox = ["whitebox>=2.3.6"]
 hsae = ["hydrosovereign>=6.0.7"]
 ui = ["solara>=1.35", "starlette<2.0"]
+browser = ["fastapi>=0.115", "uvicorn[standard]>=0.30"]
 qgis = []
 providers = ["GeoAgent[openai,anthropic,gemini,ollama,litellm]"]
 all = [
-    "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,nasa-opera,whitebox,ui]",
+    "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,nasa-opera,whitebox,ui,browser]",
 ]
 dev = [
     "pytest>=8.0",

--- a/tests/test_browser_maplibre_tools.py
+++ b/tests/test_browser_maplibre_tools.py
@@ -1,0 +1,101 @@
+"""Tests for browser MapLibre GeoAgent tools."""
+
+from __future__ import annotations
+
+from geoagent.core.decorators import needs_confirmation
+from geoagent.tools.browser_maplibre import browser_maplibre_tools
+
+
+class FakeBrowserMapSession:
+    """Test double for browser map command sessions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def call(self, command: str, args: dict | None = None, **_kwargs):
+        self.calls.append((command, args or {}))
+        if command == "list_layers":
+            return [{"id": "cities", "type": "circle", "visible": True}]
+        if command == "get_map_state":
+            return {"center": [-83.92, 35.96], "zoom": 10}
+        if command == "query_rendered_features":
+            return [{"type": "Feature", "properties": {"name": "Knoxville"}}]
+        if command == "screenshot_map":
+            return {"data_url": "data:image/png;base64,abc"}
+        return f"ok:{command}"
+
+
+def _tools(session: FakeBrowserMapSession) -> dict[str, object]:
+    return {tool.tool_name: tool for tool in browser_maplibre_tools(session)}
+
+
+def test_browser_maplibre_tool_surface() -> None:
+    """Verify the browser MapLibre tool surface."""
+    names = {tool.tool_name for tool in browser_maplibre_tools(FakeBrowserMapSession())}
+    assert {
+        "list_layers",
+        "get_map_state",
+        "set_center",
+        "fly_to",
+        "set_zoom",
+        "zoom_to_bounds",
+        "change_basemap",
+        "add_marker",
+        "add_geojson_data",
+        "add_vector_data",
+        "add_xyz_tile_layer",
+        "set_layer_visibility",
+        "set_layer_opacity",
+        "query_rendered_features",
+        "screenshot_map",
+        "remove_layer",
+        "clear_layers",
+    }.issubset(names)
+
+
+def test_browser_maplibre_tools_send_expected_payloads() -> None:
+    """Verify tools translate Python arguments into browser commands."""
+    session = FakeBrowserMapSession()
+    tools = _tools(session)
+
+    assert tools["set_center"](lat=35.96, lon=-83.92, zoom=10) == "ok:set_center"
+    assert tools["add_marker"](lat=35.96, lon=-83.92, name="Knoxville") == (
+        "ok:add_marker"
+    )
+    assert tools["set_layer_opacity"](name="cities", opacity=2.0) == (
+        "ok:set_layer_opacity"
+    )
+
+    assert session.calls[0] == (
+        "set_center",
+        {"lat": 35.96, "lon": -83.92, "zoom": 10},
+    )
+    assert session.calls[1][0] == "add_marker"
+    assert session.calls[1][1]["name"] == "Knoxville"
+    assert session.calls[2] == (
+        "set_layer_opacity",
+        {"name": "cities", "opacity": 1.0},
+    )
+
+
+def test_browser_maplibre_query_tools_return_structured_results() -> None:
+    """Verify browser query tools preserve structured results."""
+    session = FakeBrowserMapSession()
+    tools = _tools(session)
+
+    assert tools["list_layers"]() == [
+        {"id": "cities", "type": "circle", "visible": True}
+    ]
+    assert tools["get_map_state"]()["zoom"] == 10
+    assert (
+        tools["query_rendered_features"](layers=["cities"])[0]["properties"]["name"]
+        == "Knoxville"
+    )
+    assert tools["screenshot_map"]()["data_url"].startswith("data:image/png")
+
+
+def test_browser_maplibre_destructive_tools_require_confirmation() -> None:
+    """Verify destructive browser tools are confirmation gated."""
+    tools = _tools(FakeBrowserMapSession())
+    assert needs_confirmation(tools["remove_layer"]) is True
+    assert needs_confirmation(tools["clear_layers"]) is True

--- a/tests/test_browser_maplibre_tools.py
+++ b/tests/test_browser_maplibre_tools.py
@@ -51,6 +51,27 @@ def test_browser_maplibre_tool_surface() -> None:
         "remove_layer",
         "clear_layers",
     }.issubset(names)
+    assert "run_maplibre_script" not in names
+
+
+def test_browser_maplibre_code_tool_is_opt_in() -> None:
+    """Verify arbitrary browser code execution is opt-in and confirmation gated."""
+    tools = {
+        tool.tool_name: tool
+        for tool in browser_maplibre_tools(FakeBrowserMapSession(), allow_code=True)
+    }
+
+    assert "run_maplibre_script" in tools
+    assert needs_confirmation(tools["run_maplibre_script"]) is True
+    assert tools["run_maplibre_script"](
+        code="return map.getZoom();",
+        description="Read the zoom level.",
+    ) == {
+        "success": True,
+        "message": "ok:run_maplibre_script",
+        "description": "Read the zoom level.",
+        "maplibre_script": "return map.getZoom();",
+    }
 
 
 def test_browser_maplibre_tools_send_expected_payloads() -> None:

--- a/tests/test_browser_server.py
+++ b/tests/test_browser_server.py
@@ -1,0 +1,73 @@
+"""Tests for the browser WebSocket server."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from geoagent.browser import server
+from geoagent.browser.server import create_browser_app
+
+
+def test_browser_websocket_accepts_connection() -> None:
+    """Verify the browser WebSocket route accepts and sends session metadata."""
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+
+    client = fastapi_testclient.TestClient(create_browser_app())
+    with client.websocket_connect("/geoagent/ws") as websocket:
+        message = websocket.receive_json()
+
+    assert message["type"] == "session"
+    assert message["sessionId"]
+    assert message["mapId"] == "default"
+
+
+def test_browser_websocket_streams_chat_deltas(monkeypatch) -> None:
+    """Verify browser chat uses stream_chat and emits incremental deltas."""
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+
+    class FakeAgent:
+        """Tiny browser agent test double."""
+
+        def __init__(self) -> None:
+            self._tool_calls = [{"name": "list_layers", "result": []}]
+            self._cancelled = []
+
+        async def stream_chat(self, prompt: str):
+            assert prompt == "hello"
+            yield {"data": "he"}
+            yield {"data": "llo"}
+            yield {"current_tool_use": {"name": "list_layers"}}
+            yield {
+                "result": SimpleNamespace(
+                    message={"content": [{"text": "hello"}]},
+                    metrics=SimpleNamespace(tool_metrics={"list_layers": {}}),
+                    stop_reason="end_turn",
+                )
+            }
+
+    monkeypatch.setattr(
+        server,
+        "for_browser_maplibre",
+        lambda **_kwargs: FakeAgent(),
+    )
+
+    client = fastapi_testclient.TestClient(create_browser_app())
+    with client.websocket_connect("/geoagent/ws") as websocket:
+        assert websocket.receive_json()["type"] == "session"
+        websocket.send_json({"type": "chat", "message": "hello", "mapId": "default"})
+
+        assert websocket.receive_json() == {"type": "chat_status", "status": "running"}
+        assert websocket.receive_json() == {"type": "chat_delta", "text": "he"}
+        assert websocket.receive_json() == {"type": "chat_delta", "text": "llo"}
+        assert websocket.receive_json() == {"type": "chat_tool", "name": "list_layers"}
+        final = websocket.receive_json()
+
+    assert final["type"] == "chat_result"
+    assert final["ok"] is True
+    assert final["answer"] == "hello"
+    assert final["executed_tools"] == ["list_layers"]
+    assert final["tool_calls"] == [{"name": "list_layers", "result": []}]
+    assert final["cancelled_tools"] == []
+    assert final["streamed"] is True

--- a/tests/test_browser_server.py
+++ b/tests/test_browser_server.py
@@ -23,6 +23,33 @@ def test_browser_websocket_accepts_connection() -> None:
     assert message["mapId"] == "default"
 
 
+def test_browser_code_confirmation_is_explicitly_opt_in() -> None:
+    """Verify only the browser code flag approves run_maplibre_script."""
+    code_request = SimpleNamespace(
+        tool_name="run_maplibre_script",
+        args={},
+        category="browser_map",
+    )
+    remove_request = SimpleNamespace(
+        tool_name="remove_layer",
+        args={},
+        category="browser_map",
+    )
+
+    assert (
+        server._browser_confirm_callback(False, False)(code_request) is False
+    )  # noqa: SLF001
+    assert (
+        server._browser_confirm_callback(True, False)(code_request) is True
+    )  # noqa: SLF001
+    assert (
+        server._browser_confirm_callback(True, False)(remove_request) is False
+    )  # noqa: SLF001
+    assert (
+        server._browser_confirm_callback(False, True)(remove_request) is True
+    )  # noqa: SLF001
+
+
 def test_browser_websocket_streams_chat_deltas(monkeypatch) -> None:
     """Verify browser chat uses stream_chat and emits incremental deltas."""
     fastapi_testclient = pytest.importorskip("fastapi.testclient")

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -154,3 +154,18 @@ def test_call_honors_explicit_zero_timeout(loop_thread: _LoopThread) -> None:
         session.call("noop", timeout_seconds=0.0)
     elapsed = time.monotonic() - started
     assert elapsed < 5.0, "Explicit zero timeout fell back to the session default."
+
+
+def test_call_timeout_is_total_deadline(loop_thread: _LoopThread) -> None:
+    """``wait_timeout`` covers send + response combined, not each phase separately."""
+    session = _make_session(loop_thread, timeout_seconds=0.3)
+    started = time.monotonic()
+    with pytest.raises(BrowserMapTimeoutError):
+        session.call("noop")
+    elapsed = time.monotonic() - started
+    # Without a shared deadline the send + response phases would each consume
+    # ``timeout_seconds``, doubling the total wait. Allow a small scheduling
+    # margin but reject anything that approaches the doubled budget.
+    assert (
+        elapsed < 0.5
+    ), f"call() exceeded its single-deadline timeout budget (took {elapsed:.2f}s)."

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -1,0 +1,156 @@
+"""Concurrency tests for ``BrowserMapSession``."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from geoagent.browser.session import BrowserMapSession, BrowserMapTimeoutError
+
+
+class _FakeWebSocket:
+    """Minimal async websocket stand-in that records sent payloads."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        """Record ``payload`` so tests can assert on outbound traffic."""
+        self.sent.append(payload)
+
+
+class _LoopThread:
+    """Run an asyncio event loop on a background thread for tests."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def stop(self) -> None:
+        """Stop the loop and join the worker thread."""
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=2.0)
+        self.loop.close()
+
+
+@pytest.fixture
+def loop_thread() -> _LoopThread:
+    """Provide a background event loop and tear it down after the test."""
+    runner = _LoopThread()
+    try:
+        yield runner
+    finally:
+        runner.stop()
+
+
+def _make_session(loop_thread: _LoopThread, **kwargs: Any) -> BrowserMapSession:
+    """Build a session bound to the background loop with a fake websocket."""
+    return BrowserMapSession(
+        websocket=_FakeWebSocket(),
+        loop=loop_thread.loop,
+        session_id="test-session",
+        timeout_seconds=kwargs.pop("timeout_seconds", 1.0),
+        **kwargs,
+    )
+
+
+def test_call_times_out_when_browser_does_not_reply(
+    loop_thread: _LoopThread,
+) -> None:
+    """``call`` raises ``BrowserMapTimeoutError`` when no result arrives."""
+    session = _make_session(loop_thread, timeout_seconds=0.1)
+    with pytest.raises(BrowserMapTimeoutError):
+        session.call("noop")
+
+
+def test_call_returns_when_resolve_result_unblocks(
+    loop_thread: _LoopThread,
+) -> None:
+    """``resolve_result`` releases the waiting ``call`` thread."""
+    session = _make_session(loop_thread, timeout_seconds=2.0)
+
+    def _resolve_after_delay() -> None:
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if session.websocket.sent:
+                command_id = session.websocket.sent[-1]["id"]
+                session.resolve_result(
+                    {"id": command_id, "ok": True, "result": {"value": 42}}
+                )
+                return
+            time.sleep(0.01)
+
+    threading.Thread(target=_resolve_after_delay, daemon=True).start()
+    assert session.call("get_value") == {"value": 42}
+
+
+def test_call_propagates_browser_error(loop_thread: _LoopThread) -> None:
+    """A non-ok result surfaces as ``RuntimeError`` to the caller."""
+    session = _make_session(loop_thread, timeout_seconds=2.0)
+
+    def _resolve_after_delay() -> None:
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if session.websocket.sent:
+                command_id = session.websocket.sent[-1]["id"]
+                session.resolve_result({"id": command_id, "ok": False, "error": "boom"})
+                return
+            time.sleep(0.01)
+
+    threading.Thread(target=_resolve_after_delay, daemon=True).start()
+    with pytest.raises(RuntimeError, match="boom"):
+        session.call("explode")
+
+
+def test_fail_all_unblocks_every_pending_call(
+    loop_thread: _LoopThread,
+) -> None:
+    """``fail_all`` releases all waiting threads with the supplied error."""
+    session = _make_session(loop_thread, timeout_seconds=2.0)
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(3)
+
+    def _waiter() -> None:
+        barrier.wait()
+        try:
+            session.call("noop")
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_waiter, daemon=True) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+
+    barrier.wait()
+
+    deadline = time.monotonic() + 1.0
+    while len(session.websocket.sent) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    session.fail_all("Browser WebSocket disconnected.")
+    for thread in threads:
+        thread.join(timeout=2.0)
+
+    assert len(errors) == 2
+    for err in errors:
+        assert isinstance(err, RuntimeError)
+        assert "Browser WebSocket disconnected." in str(err)
+
+
+def test_call_honors_explicit_zero_timeout(loop_thread: _LoopThread) -> None:
+    """Passing ``timeout_seconds=0`` does not silently fall back to the default."""
+    session = _make_session(loop_thread, timeout_seconds=30.0)
+    started = time.monotonic()
+    with pytest.raises(Exception):  # noqa: B017,PT011 - exact type is fast-path detail
+        session.call("noop", timeout_seconds=0.0)
+    elapsed = time.monotonic() - started
+    assert elapsed < 5.0, "Explicit zero timeout fell back to the session default."

--- a/tests/test_geoagent_factory.py
+++ b/tests/test_geoagent_factory.py
@@ -56,6 +56,23 @@ def test_for_browser_maplibre_registers_tools() -> None:
     assert "live\nMapLibre map" in a.context.metadata["system_prompt"]
 
 
+def test_for_browser_maplibre_code_tool_is_opt_in() -> None:
+    """Verify browser JavaScript execution is available only when enabled."""
+    session = object()
+    default_agent = for_browser_maplibre(session, model=_MockModel())
+    code_agent = for_browser_maplibre(
+        session,
+        model=_MockModel(),
+        allow_browser_code=True,
+    )
+
+    assert "run_maplibre_script" not in default_agent.strands_agent.tool_names
+    assert "run_maplibre_script" in code_agent.strands_agent.tool_names
+    assert "Browser JavaScript code execution is enabled" in (
+        code_agent.context.metadata["system_prompt"]
+    )
+
+
 def test_factory_accepts_gemini_provider() -> None:
     """Verify that factory accepts gemini provider."""
     m = MockLeafmap()

--- a/tests/test_geoagent_factory.py
+++ b/tests/test_geoagent_factory.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from geoagent import GeoAgentContext, create_agent, for_geoai, for_leafmap
+from geoagent import (
+    GeoAgentContext,
+    create_agent,
+    for_browser_maplibre,
+    for_geoai,
+    for_leafmap,
+)
 from geoagent.testing import MockLeafmap, MockQGISIface, MockQGISProject
 
 
@@ -37,6 +43,17 @@ def test_for_leafmap_accepts_provider_and_model_id() -> None:
     )
     assert a.config.provider == "anthropic"
     assert a.config.model == "claude-sonnet-4-6"
+
+
+def test_for_browser_maplibre_registers_tools() -> None:
+    """Verify the browser MapLibre factory registers browser tools."""
+    session = object()
+    a = for_browser_maplibre(session, model=_MockModel())
+    names = set(a.strands_agent.tool_names)
+    assert "get_map_state" in names
+    assert "add_marker" in names
+    assert a.context.metadata["integration"] == "browser_maplibre"
+    assert "live\nMapLibre map" in a.context.metadata["system_prompt"]
 
 
 def test_factory_accepts_gemini_provider() -> None:


### PR DESCRIPTION
## Summary
- Add `for_browser_maplibre` factory that binds a GeoAgent to a live MapLibre map running in a browser session, registering safe browser map tools.
- Ship a FastAPI/uvicorn WebSocket backend exposed via `geoagent browser`, plus a `BrowserMapSession` broker that bridges synchronous Strands tools to the async browser channel.
- Wire the new optional dependency group `GeoAgent[browser]` and add tests for the factory and browser tools.

## Test plan
- [x] `pytest tests/test_browser_maplibre_tools.py tests/test_geoagent_factory.py -q`
- [x] `pre-commit run --all-files`
- [ ] Manual smoke: `geoagent browser` and connect a MapLibre client over WebSocket