### PR TITLE
feat(tools): add ESRI Wayback high-resolution timelapse imagery type

### DIFF
--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -199,8 +199,10 @@ Workflow guidance:
 - Confirm the imagery type and time window before launching long timelapse
   generation unless the request already provides them clearly.
 - Prefer Landsat for long historical change, Sentinel-2 for recent optical
-  detail, Sentinel-1 for radar/cloud-tolerant change, NAIP for US aerial
+  detail, Sentinel-1 for radar/cloud-tolerant change, ESRI Wayback for
+  high-resolution timelapse or Esri Wayback requests, NAIP for US aerial
   detail, MODIS NDVI for vegetation phenology, and GOES for weather animation.
+- ESRI Wayback does not require Earth Engine initialization.
 - Timelapse generation can take a while and requires user confirmation.
 - Keep responses concise and include imagery type, bbox, time window, and
   output path when available.

--- a/geoagent/tools/timelapse.py
+++ b/geoagent/tools/timelapse.py
@@ -45,6 +45,16 @@ TIMELAPSE_IMAGERY_TYPES: dict[str, dict[str, Any]] = {
         "default_bands": ["R", "G", "B"],
         "supports_frequency": False,
     },
+    "ESRI Wayback": {
+        "description": (
+            "High-resolution Esri World Imagery Wayback timelapses rendered "
+            "from historical XYZ/WMTS tiles without Earth Engine."
+        ),
+        "default_start_year": 2014,
+        "default_date_window": ["01-01", "12-31"],
+        "supports_frequency": False,
+        "requires_earth_engine": False,
+    },
     "MODIS NDVI": {
         "description": "Vegetation index phenology timelapses from MODIS.",
         "default_start_year": 2010,
@@ -146,6 +156,35 @@ def _load_timelapse_core(plugin: Any = None) -> Any:
     if not runtime_ready:
         raise RuntimeError(reason)
     return timelapse_core
+
+
+def _load_timelapse_external_sources(plugin: Any = None) -> Any:
+    """Import Timelapse external-source support without requiring Earth Engine."""
+    _add_plugin_parent_to_path(plugin)
+    _ensure_plugin_deps(plugin)
+    try:
+        from timelapse.core import external_sources
+    except Exception as exc:
+        raise RuntimeError(
+            "Could not import timelapse.core.external_sources. Make sure the "
+            "QGIS Timelapse plugin is installed, loaded, and up to date."
+        ) from exc
+
+    core = getattr(external_sources, "timelapse_core", None)
+    if core is not None:
+        try:
+            reload_deps = getattr(core, "reload_dependencies", None)
+            deps = reload_deps() if callable(reload_deps) else core.check_dependencies()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not check Timelapse external-source dependencies: {exc}"
+            ) from exc
+        if not deps.get("Pillow", True):
+            raise RuntimeError(
+                "Timelapse external-source dependencies are not importable: "
+                "Pillow. Open the Timelapse settings panel and install dependencies."
+            )
+    return external_sources
 
 
 def _parse_list(value: Any) -> list[str] | None:
@@ -292,6 +331,14 @@ def _normalise_imagery_type(imagery_type: str) -> str:
         "modis ndvi": "MODIS NDVI",
         "ndvi": "MODIS NDVI",
         "goes": "GOES",
+        "esri": "ESRI Wayback",
+        "esri wayback": "ESRI Wayback",
+        "arcgis wayback": "ESRI Wayback",
+        "world imagery wayback": "ESRI Wayback",
+        "wayback": "ESRI Wayback",
+        "high resolution": "ESRI Wayback",
+        "high res": "ESRI Wayback",
+        "highres": "ESRI Wayback",
     }
     try:
         return aliases[key]
@@ -629,11 +676,15 @@ def timelapse_tools(
         goes_scan: str = "full_disk",
         goes_band_combination: str = "true_color",
         goes_custom_bands: Any = None,
+        external_max_frames: int | None = None,
+        loop: int = 0,
     ) -> dict[str, Any]:
         """Create a Timelapse GIF from a bbox or the current QGIS extent.
 
         Args:
-            imagery_type: Landsat, Sentinel-2, Sentinel-1, NAIP, MODIS NDVI, or GOES.
+            imagery_type: Landsat, Sentinel-2, Sentinel-1, NAIP, ESRI Wayback,
+                MODIS NDVI, or GOES. Use ESRI Wayback for high-resolution
+                timelapse or Esri Wayback requests.
             bbox: Optional west,south,east,north WGS84 bbox. Uses current map
                 extent when omitted.
             output_path: Optional output GIF path.
@@ -652,6 +703,8 @@ def timelapse_tools(
             create_mp4: Also create MP4 when supported by the plugin core.
             add_bbox_to_map: Add the timelapse bbox as a QGIS polygon layer.
             bbox_layer_name: Optional QGIS layer name for the bbox layer.
+            external_max_frames: Optional cap for ESRI Wayback frames.
+            loop: GIF loop count for external sources.
         """
         try:
             imagery = _normalise_imagery_type(imagery_type)
@@ -662,102 +715,139 @@ def timelapse_tools(
                     return extent_result
                 parsed_bbox = list(extent_result["bbox"])
 
-            core = _load_timelapse_core(plugin)
-            if not core.is_ee_initialized():
-                if not core.initialize_ee(project=gee_project):
-                    return {
-                        "success": False,
-                        "error": "Failed to initialize Earth Engine.",
-                        "imagery_type": imagery,
-                        "bbox": parsed_bbox,
-                    }
-
             west, south, east, north = parsed_bbox
-            roi = core.bbox_to_ee_geometry(west, south, east, north)
             output = os.path.abspath(
                 os.path.expanduser(output_path or _default_output_path(imagery))
             )
             os.makedirs(os.path.dirname(output), exist_ok=True)
             current_year = datetime.now().year
             parsed_bands = _parse_list(bands)
-            common = {
-                "roi": roi,
-                "out_gif": output,
-                "dimensions": int(dimensions),
-                "frames_per_second": int(fps),
-                "title": title,
-                "add_text": bool(add_text),
-                "font_size": int(font_size),
-                "font_color": font_color,
-                "add_progress_bar": bool(add_progress_bar),
-                "progress_bar_color": progress_bar_color,
-                "progress_bar_height": int(progress_bar_height),
-                "mp4": bool(create_mp4),
-            }
 
-            if imagery == "NAIP":
-                result = core.create_naip_timelapse(
-                    **common,
-                    start_year=start_year or 2010,
-                    end_year=end_year or current_year,
-                    bands=parsed_bands or ["R", "G", "B"],
-                    step=int(step),
+            if imagery == "ESRI Wayback":
+                external_sources = _load_timelapse_external_sources(plugin)
+                max_frames = (
+                    int(external_max_frames)
+                    if external_max_frames is not None and int(external_max_frames) > 0
+                    else None
                 )
-            elif imagery == "Sentinel-2":
-                result = core.create_sentinel2_timelapse(
-                    **common,
-                    start_year=start_year or 2018,
+                frames = external_sources.esri_wayback_frames(
+                    start_year=start_year or 2014,
                     end_year=end_year or current_year,
-                    start_date=start_date or "06-10",
-                    end_date=end_date or "09-20",
-                    bands=parsed_bands or ["NIR", "Red", "Green"],
-                    apply_fmask=bool(apply_fmask),
-                    cloud_pct=int(cloud_pct),
-                    frequency=frequency,
                     step=int(step),
+                    max_frames=max_frames,
                 )
-            elif imagery == "Sentinel-1":
-                result = core.create_sentinel1_timelapse(
-                    **common,
-                    start_year=start_year or 2018,
-                    end_year=end_year or current_year,
-                    start_date=start_date or "01-01",
-                    end_date=end_date or "12-31",
-                    bands=parsed_bands or ["VV"],
-                    orbit=_parse_list(orbit) or ["ascending", "descending"],
-                    frequency=frequency,
-                    step=int(step),
-                )
-            elif imagery == "Landsat":
-                result = core.create_landsat_timelapse(
-                    **common,
-                    start_year=start_year or 1990,
-                    end_year=end_year or current_year,
-                    start_date=start_date or "06-10",
-                    end_date=end_date or "09-20",
-                    bands=parsed_bands or ["NIR", "Red", "Green"],
-                    apply_fmask=bool(apply_fmask),
-                    frequency=frequency,
-                    step=int(step),
-                )
-            elif imagery == "MODIS NDVI":
-                result = core.create_modis_ndvi_timelapse(
-                    **common,
-                    data=modis_satellite,
-                    band=modis_band,
-                    start_date=start_date or f"{start_year or 2010}-01-01",
-                    end_date=end_date or f"{end_year or current_year}-12-31",
+                bbox_dict = {
+                    "xmin": west,
+                    "ymin": south,
+                    "xmax": east,
+                    "ymax": north,
+                }
+                result = external_sources.create_external_timelapse(
+                    frames=frames,
+                    bbox=bbox_dict,
+                    out_gif=output,
+                    dimensions=int(dimensions),
+                    frames_per_second=int(fps),
+                    title=title,
+                    add_text=bool(add_text),
+                    font_size=int(font_size),
+                    font_color=font_color,
+                    add_progress_bar=bool(add_progress_bar),
+                    progress_bar_color=progress_bar_color,
+                    progress_bar_height=int(progress_bar_height),
+                    loop=int(loop),
+                    mp4=bool(create_mp4),
                 )
             else:
-                result = core.create_goes_timelapse(
-                    **common,
-                    start_date=start_date or "2021-10-24T14:00:00",
-                    end_date=end_date or "2021-10-25T01:00:00",
-                    data=goes_satellite,
-                    scan=goes_scan,
-                    band_combination=goes_band_combination,
-                    custom_bands=_parse_list(goes_custom_bands),
-                )
+                core = _load_timelapse_core(plugin)
+                if not core.is_ee_initialized():
+                    if not core.initialize_ee(project=gee_project):
+                        return {
+                            "success": False,
+                            "error": "Failed to initialize Earth Engine.",
+                            "imagery_type": imagery,
+                            "bbox": parsed_bbox,
+                        }
+
+                roi = core.bbox_to_ee_geometry(west, south, east, north)
+                common = {
+                    "roi": roi,
+                    "out_gif": output,
+                    "dimensions": int(dimensions),
+                    "frames_per_second": int(fps),
+                    "title": title,
+                    "add_text": bool(add_text),
+                    "font_size": int(font_size),
+                    "font_color": font_color,
+                    "add_progress_bar": bool(add_progress_bar),
+                    "progress_bar_color": progress_bar_color,
+                    "progress_bar_height": int(progress_bar_height),
+                    "mp4": bool(create_mp4),
+                }
+
+                if imagery == "NAIP":
+                    result = core.create_naip_timelapse(
+                        **common,
+                        start_year=start_year or 2010,
+                        end_year=end_year or current_year,
+                        bands=parsed_bands or ["R", "G", "B"],
+                        step=int(step),
+                    )
+                elif imagery == "Sentinel-2":
+                    result = core.create_sentinel2_timelapse(
+                        **common,
+                        start_year=start_year or 2018,
+                        end_year=end_year or current_year,
+                        start_date=start_date or "06-10",
+                        end_date=end_date or "09-20",
+                        bands=parsed_bands or ["NIR", "Red", "Green"],
+                        apply_fmask=bool(apply_fmask),
+                        cloud_pct=int(cloud_pct),
+                        frequency=frequency,
+                        step=int(step),
+                    )
+                elif imagery == "Sentinel-1":
+                    result = core.create_sentinel1_timelapse(
+                        **common,
+                        start_year=start_year or 2018,
+                        end_year=end_year or current_year,
+                        start_date=start_date or "01-01",
+                        end_date=end_date or "12-31",
+                        bands=parsed_bands or ["VV"],
+                        orbit=_parse_list(orbit) or ["ascending", "descending"],
+                        frequency=frequency,
+                        step=int(step),
+                    )
+                elif imagery == "Landsat":
+                    result = core.create_landsat_timelapse(
+                        **common,
+                        start_year=start_year or 1990,
+                        end_year=end_year or current_year,
+                        start_date=start_date or "06-10",
+                        end_date=end_date or "09-20",
+                        bands=parsed_bands or ["NIR", "Red", "Green"],
+                        apply_fmask=bool(apply_fmask),
+                        frequency=frequency,
+                        step=int(step),
+                    )
+                elif imagery == "MODIS NDVI":
+                    result = core.create_modis_ndvi_timelapse(
+                        **common,
+                        data=modis_satellite,
+                        band=modis_band,
+                        start_date=start_date or f"{start_year or 2010}-01-01",
+                        end_date=end_date or f"{end_year or current_year}-12-31",
+                    )
+                else:
+                    result = core.create_goes_timelapse(
+                        **common,
+                        start_date=start_date or "2021-10-24T14:00:00",
+                        end_date=end_date or "2021-10-25T01:00:00",
+                        data=goes_satellite,
+                        scan=goes_scan,
+                        band_combination=goes_band_combination,
+                        custom_bands=_parse_list(goes_custom_bands),
+                    )
 
             result_path = os.path.abspath(os.path.expanduser(str(result or output)))
             bbox_layer = None

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -202,8 +202,8 @@ WORKFLOW_PROMPTS = {
     ],
     "Timelapse": [
         (
-            "Create a Landsat timelapse for the current map extent from 1990 "
-            "to the present."
+            "Create a high-resolution ESRI Wayback timelapse for the current "
+            "map extent from 2014 to the present."
         ),
         (
             "List the available timelapse imagery types and recommend one for "

--- a/tests/test_timelapse_tools.py
+++ b/tests/test_timelapse_tools.py
@@ -52,6 +52,23 @@ class _FakeTimelapseCore:
         return kwargs["out_gif"]
 
 
+class _FakeExternalSources:
+    """Small external-source stand-in for ESRI Wayback dispatch tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def esri_wayback_frames(self, **kwargs):
+        """Record ESRI Wayback frame selection."""
+        self.calls.append(("esri_wayback_frames", kwargs))
+        return [{"label": "2024-01-01"}]
+
+    def create_external_timelapse(self, **kwargs):
+        """Record external timelapse rendering."""
+        self.calls.append(("create_external_timelapse", kwargs))
+        return kwargs["out_gif"]
+
+
 def test_timelapse_module_imports_without_qgis_or_plugin() -> None:
     """Verify Timelapse tools are import-safe outside QGIS."""
     assert "geoagent.tools.timelapse" in sys.modules
@@ -85,6 +102,20 @@ def test_timelapse_tools_expose_expected_surface() -> None:
     assert tools["create_timelapse"]._geoagent_meta.long_running
     assert tools["open_timelapse_panel"]._geoagent_meta.requires_confirmation
     assert tools["open_timelapse_settings"]._geoagent_meta.requires_confirmation
+
+
+def test_list_timelapse_imagery_types_includes_esri_wayback() -> None:
+    """Verify ESRI Wayback is advertised for high-resolution timelapses."""
+    tools = {tool.tool_name: tool for tool in timelapse_tools(object())}
+
+    result = tools["list_timelapse_imagery_types"].__wrapped__()
+
+    esri = next(
+        item for item in result["imagery_types"] if item["name"] == "ESRI Wayback"
+    )
+    assert esri["default_start_year"] == 2014
+    assert esri["requires_earth_engine"] is False
+    assert "High-resolution" in esri["description"]
 
 
 def test_get_current_timelapse_extent_uses_canvas_extent() -> None:
@@ -212,6 +243,66 @@ def test_create_timelapse_dispatches_to_landsat_core(monkeypatch, tmp_path) -> N
     assert kwargs["start_year"] == 2001
     assert kwargs["end_year"] == 2003
     assert kwargs["bands"] == ["NIR", "Red", "Green"]
+
+
+def test_create_timelapse_dispatches_high_resolution_to_esri_wayback(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify high-resolution requests use ESRI Wayback external rendering."""
+    external = _FakeExternalSources()
+    monkeypatch.setattr(
+        timelapse,
+        "_load_timelapse_external_sources",
+        lambda plugin=None: external,
+    )
+    monkeypatch.setattr(
+        timelapse,
+        "_load_timelapse_core",
+        lambda plugin=None: pytest.fail("ESRI Wayback must not load EE core"),
+    )
+    output = tmp_path / "wayback.gif"
+    project = MockQGISProject()
+    iface = MockQGISIface(project)
+    tools = {tool.tool_name: tool for tool in timelapse_tools(iface, project)}
+
+    result = tools["create_timelapse"].__wrapped__(
+        imagery_type="high-resolution",
+        bbox="-85,34,-83,36",
+        output_path=str(output),
+        start_year=2018,
+        end_year=2024,
+        step=2,
+        external_max_frames=10,
+        create_mp4=True,
+        bbox_layer_name="Wayback BBOX",
+    )
+
+    assert result["success"] is True
+    assert result["imagery_type"] == "ESRI Wayback"
+    assert result["output_path"] == str(output)
+    assert result["mp4_path"] == str(Path(tmp_path / "wayback.mp4"))
+    assert result["images"][0]["alt"] == "ESRI Wayback timelapse"
+    assert result["bbox_layer"]["layer_name"] == "Wayback BBOX"
+    frames_call, render_call = external.calls
+    assert frames_call == (
+        "esri_wayback_frames",
+        {
+            "start_year": 2018,
+            "end_year": 2024,
+            "step": 2,
+            "max_frames": 10,
+        },
+    )
+    assert render_call[0] == "create_external_timelapse"
+    assert render_call[1]["frames"] == [{"label": "2024-01-01"}]
+    assert render_call[1]["bbox"] == {
+        "xmin": -85.0,
+        "ymin": 34.0,
+        "xmax": -83.0,
+        "ymax": 36.0,
+    }
+    assert render_call[1]["out_gif"] == str(output)
+    assert render_call[1]["mp4"] is True
 
 
 def test_open_timelapse_panels_use_plugin_instance() -> None:


### PR DESCRIPTION
## Summary
- Add an ESRI Wayback imagery type that renders high-resolution timelapses from Esri World Imagery Wayback tiles without requiring Earth Engine.
- Wire the new type into the QGIS Timelapse external-source path, factory guidance, and the QGIS workflow prompt; add `external_max_frames` and `loop` controls.
- Cover the dispatch path with tests that confirm Earth Engine is not loaded for ESRI Wayback requests.

## Test plan
- [x] pre-commit run --all-files
- [ ] pytest tests/test_timelapse_tools.py -q