### PR TITLE
Bump GeoAgent and OpenGeoAgent to 1.7.0

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.6.0"
+version = "1.7.0"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -77,7 +77,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.6.0"
+current_version = "1.7.0"
 commit = true
 tag = true
 

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -80,11 +80,11 @@ adds its site-packages directory when the plugin loads.
 Manual fallback:
 
 ```bash
-pip install "GeoAgent[providers]>=1.6.0"
-pip install "GeoAgent[stac]>=1.6.0"
-pip install "GeoAgent[whitebox]>=1.6.0"
-pip install "GeoAgent[earthdata,nasa-opera]>=1.6.0"
-pip install "GeoAgent[earthengine]>=1.6.0"
+pip install "GeoAgent[providers]>=1.7.0"
+pip install "GeoAgent[stac]>=1.7.0"
+pip install "GeoAgent[whitebox]>=1.7.0"
+pip install "GeoAgent[earthdata,nasa-opera]>=1.7.0"
+pip install "GeoAgent[earthengine]>=1.7.0"
 ```
 
 GEE Data Catalogs mode also expects the `gee_data_catalogs` Python module from

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -31,7 +31,7 @@ from qgis.PyQt.QtCore import QThread, pyqtSignal
 # Dependency specs: (import_name, pip_install_name)
 MIN_PYTHON_VERSION = (3, 11)
 CORE_RUNTIME_PACKAGES = [
-    ("geoagent", "GeoAgent[providers]>=1.6.0"),
+    ("geoagent", "GeoAgent[providers]>=1.7.0"),
     ("strands", "strands-agents>=1.37"),
     ("pydantic", "pydantic>=2.0"),
 ]
@@ -831,7 +831,7 @@ def create_venv(venv_dir: str) -> str:
         "This can happen when QGIS bundles Python in a way that prevents\n"
         "standard venv creation.\n\n"
         "You can try installing manually with:\n"
-        '  pip install "GeoAgent[providers]>=1.6.0"\n\n'
+        '  pip install "GeoAgent[providers]>=1.7.0"\n\n'
         "Details:\n" + "\n".join(f"  {d}" for d in details)
     )
 
@@ -973,7 +973,7 @@ class DepsInstallWorker(QThread):
                         False,
                         "pip is not available in the virtual environment.\n"
                         "Please install dependencies manually:\n"
-                        'pip install "GeoAgent[providers]>=1.6.0"',
+                        'pip install "GeoAgent[providers]>=1.7.0"',
                     )
                     return
             self.progress.emit(15, "Package installer ready.")

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -865,7 +865,7 @@ class SettingsDockWidget(QDockWidget):
                 self,
                 "Installation Failed",
                 f"Failed to install dependencies:\n\n{message}\n\n"
-                'Manual fallback: pip install "GeoAgent[providers]>=1.6.0"',
+                'Manual fallback: pip install "GeoAgent[providers]>=1.7.0"',
             )
 
         self._deps_worker = None

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.6.0
+version=1.7.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,10 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.7.0 - Minor update for Timelapse ESRI Wayback support
+        - Added Timelapse agent routing for high-resolution and ESRI Wayback requests
+        - Raised the plugin dependency guidance to GeoAgent 1.7.0
+
     1.6.0 - Minor update for provider token defaults
         - Added Auto max-token behavior so providers can use their native defaults
         - Improved Gemini token-limit handling and diagnostics

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -25,7 +25,7 @@ def test_all_dependencies_met_uses_lightweight_spec_checks(monkeypatch) -> None:
     monkeypatch.setattr(
         deps_manager,
         "CORE_RUNTIME_PACKAGES",
-        [("geoagent", "GeoAgent[providers]>=1.6.0"), ("strands", "strands-agents")],
+        [("geoagent", "GeoAgent[providers]>=1.7.0"), ("strands", "strands-agents")],
     )
     monkeypatch.setattr(deps_manager, "ensure_venv_packages_available", lambda: True)
 
@@ -49,7 +49,7 @@ def test_required_dependencies_include_core_runtime_packages() -> None:
     """Dependency gate should catch partial GeoAgent installs."""
     from open_geoagent.deps_manager import REQUIRED_PACKAGES
 
-    assert ("geoagent", "GeoAgent[providers]>=1.6.0") in REQUIRED_PACKAGES
+    assert ("geoagent", "GeoAgent[providers]>=1.7.0") in REQUIRED_PACKAGES
     assert ("strands", "strands-agents>=1.37") in REQUIRED_PACKAGES
     assert ("pydantic", "pydantic>=2.0") in REQUIRED_PACKAGES
 


### PR DESCRIPTION
## Summary

Bump the GeoAgent package and OpenGeoAgent QGIS plugin from 1.6.0 to 1.7.0.

This also updates the plugin dependency guidance, manual fallback commands, startup dependency tests, and plugin metadata changelog so the plugin points users at the matching GeoAgent release.

## Validation

- `.venv/bin/python -m ruff check geoagent/__init__.py qgis_geoagent/open_geoagent/deps_manager.py qgis_geoagent/open_geoagent/dialogs/settings_dock.py qgis_geoagent/tests/test_startup_performance.py`
- `.venv/bin/python -m pytest qgis_geoagent/tests/test_startup_performance.py -q`