### PR TITLE
fix(qgis): validate Python interpreters before venv creation

### DIFF
--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -150,15 +150,36 @@ def get_venv_site_packages(venv_dir: Optional[str] = None) -> str:
     return os.path.join(venv_dir, "lib", py_ver, "site-packages")
 
 
-def venv_exists() -> bool:
+def venv_exists(venv_dir: Optional[str] = None) -> bool:
     """Check if the plugin's virtual environment exists and has a Python executable.
+
+    Args:
+        venv_dir: Path to the venv directory. Defaults to get_venv_dir().
 
     Returns:
         True if the venv directory and Python executable exist.
     """
-    venv_dir = get_venv_dir()
+    if venv_dir is None:
+        venv_dir = get_venv_dir()
     python_path = get_venv_python_path(venv_dir)
     return os.path.isdir(venv_dir) and os.path.isfile(python_path)
+
+
+def venv_python_usable(venv_dir: Optional[str] = None) -> Tuple[bool, str]:
+    """Return whether the venv Python starts with the expected stdlib.
+
+    ``venv_exists`` intentionally stays cheap because it is used by settings
+    diagnostics and startup path checks. The installer calls this stronger
+    validation before reusing an existing venv for pip operations.
+    """
+    if venv_dir is None:
+        venv_dir = get_venv_dir()
+    python_path = get_venv_python_path(venv_dir)
+    if not os.path.isdir(venv_dir):
+        return False, f"Virtual environment does not exist: {venv_dir}"
+    if not os.path.isfile(python_path):
+        return False, f"Virtual environment Python is missing: {python_path}"
+    return _python_executable_usable(python_path)
 
 
 def ensure_venv_packages_available() -> bool:
@@ -739,6 +760,14 @@ def _verify_pip_and_return(python_path: str) -> str:
     Raises:
         RuntimeError: If pip cannot be made available.
     """
+    usable, reason = _python_executable_usable(python_path)
+    if not usable:
+        raise RuntimeError(
+            "Virtual environment Python is not usable.\n"
+            f"Python path: {python_path}\n"
+            f"Error: {reason}"
+        )
+
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
@@ -769,6 +798,35 @@ def _verify_pip_and_return(python_path: str) -> str:
         )
 
     return python_path
+
+
+def _truncated_subprocess_output(result) -> str:
+    """Return compact stderr/stdout text from a subprocess result."""
+    output = result.stderr or result.stdout or "Unknown error"
+    if len(output) > 1500:
+        output = output[:500] + "\n...\n" + output[-1000:]
+    return output
+
+
+def _ensure_usable_venv(
+    venv_dir: str,
+    progress_callback: Optional[Callable[[int, str], None]] = None,
+) -> str:
+    """Return a usable venv Python, recreating stale broken venvs when needed."""
+    if venv_exists(venv_dir):
+        usable, reason = venv_python_usable(venv_dir)
+        if usable:
+            return get_venv_python_path(venv_dir)
+        if progress_callback:
+            progress_callback(
+                5,
+                "Existing virtual environment is unusable; recreating it...",
+            )
+        _cleanup_partial_venv(venv_dir)
+
+    if progress_callback:
+        progress_callback(5, "Creating virtual environment...")
+    return create_venv(venv_dir)
 
 
 def create_venv(venv_dir: str) -> str:
@@ -816,13 +874,19 @@ def create_venv(venv_dir: str) -> str:
     except RuntimeError as exc:
         python_lookup_error = str(exc)
 
+    uv_error = ""
+
     # Strategy 0: Use uv venv when available (fastest, no pip needed). If the
     # official macOS QGIS bundle exposes only an unstartable python3.x binary,
-    # ask uv for the matching Python version instead of passing that path.
+    # require uv-managed Python for the matching version instead of letting uv
+    # reuse the broken app-bundle interpreter.
     if _uv_usable():
         uv_path = get_uv_path()
         uv_python = python_exe or _python_version_spec()
-        cmd = [uv_path, "venv", "--python", uv_python, venv_dir]
+        cmd = [uv_path, "venv"]
+        if python_exe is None:
+            cmd.append("--managed-python")
+        cmd += ["--python", uv_python, venv_dir]
         result = subprocess.run(  # nosec B603
             cmd,
             capture_output=True,
@@ -832,7 +896,15 @@ def create_venv(venv_dir: str) -> str:
             **kwargs,
         )
         if result.returncode == 0 and os.path.isfile(python_path):
-            return python_path
+            usable, reason = _python_executable_usable(python_path)
+            if usable:
+                return python_path
+            uv_error = (
+                "uv created a virtual environment, but its Python could not "
+                f"start: {reason}"
+            )
+        elif result.returncode != 0:
+            uv_error = result.stderr or result.stdout or ""
         # uv venv failed — clean up and fall through to pip strategies
         _cleanup_partial_venv(venv_dir)
 
@@ -843,7 +915,8 @@ def create_venv(venv_dir: str) -> str:
             "Could not create a virtual environment because no working Python "
             "interpreter was found. uv was either unavailable or could not "
             f"create one from the {_python_version_spec()} version request.\n\n"
-            f"{python_lookup_error}"
+            + (f"uv error: {uv_error}\n\n" if uv_error else "")
+            + python_lookup_error
         )
 
     cmd = [python_exe, "-m", "venv", venv_dir]
@@ -902,6 +975,8 @@ def create_venv(venv_dir: str) -> str:
     ]
     if subprocess_error:
         details.append(f"Subprocess error: {subprocess_error}")
+    if uv_error:
+        details.append(f"uv error: {uv_error}")
     if strategy3_error:
         details.append(f"Strategy 3 error: {strategy3_error}")
 
@@ -939,7 +1014,25 @@ def install_packages(
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
+    usable, reason = venv_python_usable(venv_dir)
+    if not usable:
+        return (
+            False,
+            "Virtual environment Python is not usable. Re-run dependency "
+            f"installation to recreate it.\nPython path: {python_path}\n"
+            f"Error: {reason}",
+        )
+
     use_uv = _uv_usable()
+    pip_cmd = [
+        python_path,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--disable-pip-version-check",
+        "--prefer-binary",
+    ] + packages
     if use_uv:
         uv_path = get_uv_path()
         cmd = [
@@ -951,15 +1044,7 @@ def install_packages(
             "--upgrade",
         ] + packages
     else:
-        cmd = [
-            python_path,
-            "-m",
-            "pip",
-            "install",
-            "--upgrade",
-            "--disable-pip-version-check",
-            "--prefer-binary",
-        ] + packages
+        cmd = pip_cmd
 
     if progress_callback:
         installer = "uv" if use_uv else "pip"
@@ -974,15 +1059,41 @@ def install_packages(
         **kwargs,
     )
 
-    if result.returncode != 0:
-        error_output = result.stderr or result.stdout or "Unknown error"
-        # Truncate long error messages
-        if len(error_output) > 1000:
-            error_output = "..." + error_output[-1000:]
-        installer = "uv pip" if use_uv else "pip"
-        return False, f"{installer} install failed:\n{error_output}"
+    if result.returncode == 0:
+        return True, "Packages installed successfully."
 
-    return True, "Packages installed successfully."
+    error_output = _truncated_subprocess_output(result)
+
+    if use_uv:
+        if progress_callback:
+            progress_callback(45, "uv install failed, retrying with pip...")
+        try:
+            _verify_pip_and_return(python_path)
+        except RuntimeError as exc:
+            return (
+                False,
+                "uv pip install failed and pip fallback is unavailable.\n\n"
+                f"uv error:\n{error_output}\n\npip bootstrap error:\n{exc}",
+            )
+
+        pip_result = subprocess.run(  # nosec B603
+            pip_cmd,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            env=env,
+            **kwargs,
+        )
+        if pip_result.returncode == 0:
+            return True, "Packages installed successfully."
+        return (
+            False,
+            "uv pip install failed, and pip fallback also failed.\n\n"
+            f"uv error:\n{error_output}\n\n"
+            f"pip error:\n{_truncated_subprocess_output(pip_result)}",
+        )
+
+    return False, f"pip install failed:\n{error_output}"
 
 
 class DepsInstallWorker(QThread):
@@ -1021,14 +1132,15 @@ class DepsInstallWorker(QThread):
                 else:
                     self.progress.emit(5, "uv ready.")
 
-            # Step 1: Create venv if needed
-            if not venv_exists():
-                self.progress.emit(5, "Creating virtual environment...")
-                try:
-                    create_venv(venv_dir)
-                except RuntimeError as e:
-                    self.finished.emit(False, str(e))
-                    return
+            # Step 1: Create venv if needed, or recreate stale broken venvs
+            try:
+                _ensure_usable_venv(
+                    venv_dir,
+                    progress_callback=lambda p, m: self.progress.emit(p, m),
+                )
+            except RuntimeError as e:
+                self.finished.emit(False, str(e))
+                return
             self.progress.emit(10, "Virtual environment ready.")
 
             # Step 2: Verify pip (only needed when not using uv)

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -368,6 +368,11 @@ def _python_executable_names() -> List[str]:
     return names
 
 
+def _python_version_spec() -> str:
+    """Return the Python major.minor version required by this QGIS session."""
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
 def _looks_like_python_executable(path: Optional[str]) -> bool:
     """Return True when *path* names a Python interpreter binary."""
     if not path:
@@ -389,6 +394,54 @@ def _add_existing_python_candidate(
         return
     candidates.append(normalized)
     seen.add(normalized)
+
+
+def _python_executable_usable(path: str) -> Tuple[bool, str]:
+    """Return whether *path* can run as the current QGIS Python version.
+
+    Some official macOS QGIS app bundles include a ``python3.x`` binary whose
+    embedded prefix still points at the QGIS build machine. The file exists and
+    looks correct, but a subprocess fails before startup with ``No module named
+    encodings``. Validate candidates before using them for ``venv`` or ``uv``.
+    """
+    code = (
+        "import encodings, sys; "
+        f"raise SystemExit(0 if sys.version_info[:2] == "
+        f"({sys.version_info.major}, {sys.version_info.minor}) else 3)"
+    )
+    try:
+        result = subprocess.run(  # nosec B603
+            [path, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_get_clean_env(),
+            **_get_subprocess_kwargs(),
+        )
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+    if result.returncode == 0:
+        return True, ""
+    if result.returncode == 3:
+        return False, f"wrong Python version; need {_python_version_spec()}"
+
+    error = (result.stderr or result.stdout or f"exit code {result.returncode}").strip()
+    if len(error) > 500:
+        error = "..." + error[-500:]
+    return False, error
+
+
+def _first_usable_python_candidate(
+    candidates: List[str], rejected: List[str]
+) -> Optional[str]:
+    """Return the first candidate that starts successfully."""
+    for candidate in candidates:
+        usable, reason = _python_executable_usable(candidate)
+        if usable:
+            return candidate
+        rejected.append(f"{candidate}: {reason}")
+    return None
 
 
 def _macos_bundle_dirs(path: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
@@ -483,6 +536,7 @@ def _find_python_executable() -> str:
     """
     candidates: List[str] = []
     seen = set()
+    rejected: List[str] = []
 
     # Strategy 1: Python may expose the real interpreter separately from the
     # GUI application executable.
@@ -490,15 +544,19 @@ def _find_python_executable() -> str:
         candidates, seen, getattr(sys, "_base_executable", None)
     )
     _add_existing_python_candidate(candidates, seen, sys.executable)
-    if candidates:
-        return candidates[0]
+    python_exe = _first_usable_python_candidate(candidates, rejected)
+    if python_exe:
+        return python_exe
 
     if platform.system() == "Darwin" or sys.platform == "darwin":
+        start = len(candidates)
         _add_macos_python_candidates(candidates, seen)
-        if candidates:
-            return candidates[0]
+        python_exe = _first_usable_python_candidate(candidates[start:], rejected)
+        if python_exe:
+            return python_exe
 
     if platform.system() != "Windows":
+        start = len(candidates)
         prefix_candidates = (
             getattr(sys, "base_prefix", None),
             getattr(sys, "base_exec_prefix", None),
@@ -524,13 +582,19 @@ def _find_python_executable() -> str:
 
         for name in _python_executable_names():
             _add_existing_python_candidate(candidates, seen, shutil.which(name))
-        if candidates:
-            return candidates[0]
+        python_exe = _first_usable_python_candidate(candidates[start:], rejected)
+        if python_exe:
+            return python_exe
+
+        details = "\n".join(f"  {item}" for item in rejected[:8])
+        if len(rejected) > 8:
+            details += f"\n  ... {len(rejected) - 8} more rejected candidates"
 
         raise RuntimeError(
             "Could not find a Python interpreter for dependency installation.\n"
             f"sys.executable is not Python: {sys.executable}\n"
             "OpenGeoAgent cannot safely run QGIS itself as a Python executable."
+            + (f"\nRejected Python candidates:\n{details}" if details else "")
         )
 
     # Strategy 2: Check if sys.executable is already Python
@@ -745,11 +809,20 @@ def create_venv(venv_dir: str) -> str:
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
-    # Strategy 0: Use uv venv when available (fastest, no pip needed)
+    python_exe: Optional[str] = None
+    python_lookup_error = ""
+    try:
+        python_exe = _find_python_executable()
+    except RuntimeError as exc:
+        python_lookup_error = str(exc)
+
+    # Strategy 0: Use uv venv when available (fastest, no pip needed). If the
+    # official macOS QGIS bundle exposes only an unstartable python3.x binary,
+    # ask uv for the matching Python version instead of passing that path.
     if _uv_usable():
         uv_path = get_uv_path()
-        python_exe = _find_python_executable()
-        cmd = [uv_path, "venv", "--python", python_exe, venv_dir]
+        uv_python = python_exe or _python_version_spec()
+        cmd = [uv_path, "venv", "--python", uv_python, venv_dir]
         result = subprocess.run(  # nosec B603
             cmd,
             capture_output=True,
@@ -764,8 +837,14 @@ def create_venv(venv_dir: str) -> str:
         _cleanup_partial_venv(venv_dir)
 
     # Strategy 1: Subprocess with the real Python executable
-    python_exe = _find_python_executable()
     subprocess_error = ""
+    if python_exe is None:
+        raise RuntimeError(
+            "Could not create a virtual environment because no working Python "
+            "interpreter was found. uv was either unavailable or could not "
+            f"create one from the {_python_version_spec()} version request.\n\n"
+            f"{python_lookup_error}"
+        )
 
     cmd = [python_exe, "-m", "venv", venv_dir]
     result = subprocess.run(  # nosec B603

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -592,7 +592,7 @@ def _find_python_executable() -> str:
 
         raise RuntimeError(
             "Could not find a Python interpreter for dependency installation.\n"
-            f"sys.executable is not Python: {sys.executable}\n"
+            f"sys.executable is not a usable Python interpreter: {sys.executable}\n"
             "OpenGeoAgent cannot safely run QGIS itself as a Python executable."
             + (f"\nRejected Python candidates:\n{details}" if details else "")
         )

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -417,6 +417,19 @@ def _add_existing_python_candidate(
     seen.add(normalized)
 
 
+def _is_macos_qgis_app_bundle_python(path: str) -> bool:
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _python_executable_usable(path: str) -> Tuple[bool, str]:
     """Return whether *path* can run as the current QGIS Python version.
 
@@ -443,6 +456,12 @@ def _python_executable_usable(path: str) -> Tuple[bool, str]:
         return False, f"{type(exc).__name__}: {exc}"
 
     if result.returncode == 0:
+        if _is_macos_qgis_app_bundle_python(path):
+            return (
+                False,
+                "QGIS app-bundle Python is not safe for creating virtual "
+                "environments; use uv-managed Python instead.",
+            )
         return True, ""
     if result.returncode == 3:
         return False, f"wrong Python version; need {_python_version_spec()}"

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -278,10 +278,85 @@ def test_create_venv_lets_uv_resolve_python_version_when_bundle_python_is_broken
     assert commands[0] == [
         "/tmp/uv",
         "venv",
+        "--managed-python",
         "--python",
         deps_manager._python_version_spec(),
         venv_dir,
     ]
+
+
+def test_ensure_usable_venv_recreates_existing_broken_venv(
+    monkeypatch, tmp_path
+) -> None:
+    """A stale venv with a broken Python executable should not be reused."""
+    from open_geoagent import deps_manager
+
+    venv_dir = str(tmp_path / "venv")
+    python_path = Path(deps_manager.get_venv_python_path(venv_dir))
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("", encoding="utf-8")
+    stale_marker = Path(venv_dir) / "stale.txt"
+    stale_marker.write_text("stale", encoding="utf-8")
+    progress = []
+
+    def fake_create_venv(path):
+        assert path == venv_dir
+        recreated_python = Path(deps_manager.get_venv_python_path(path))
+        recreated_python.parent.mkdir(parents=True, exist_ok=True)
+        recreated_python.write_text("", encoding="utf-8")
+        return str(recreated_python)
+
+    monkeypatch.setattr(
+        deps_manager,
+        "venv_python_usable",
+        lambda _path: (False, "No module named 'encodings'"),
+    )
+    monkeypatch.setattr(deps_manager, "create_venv", fake_create_venv)
+
+    assert deps_manager._ensure_usable_venv(
+        venv_dir, progress_callback=lambda p, m: progress.append((p, m))
+    ) == str(python_path)
+    assert not stale_marker.exists()
+    assert any("unusable" in message for _percent, message in progress)
+
+
+def test_install_packages_falls_back_to_pip_when_uv_install_fails(
+    monkeypatch, tmp_path
+) -> None:
+    """Dependency installation should retry with pip when uv pip fails."""
+    from open_geoagent import deps_manager
+    import open_geoagent.uv_manager as uv_manager
+
+    venv_dir = str(tmp_path / "venv")
+    python_path = Path(deps_manager.get_venv_python_path(venv_dir))
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("", encoding="utf-8")
+    commands = []
+    progress = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        if cmd[:3] == ["/tmp/uv", "pip", "install"]:
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="uv failed")
+        return types.SimpleNamespace(returncode=0, stdout="pip ok", stderr="")
+
+    monkeypatch.setattr(deps_manager, "_uv_usable", lambda: True)
+    monkeypatch.setattr(uv_manager, "get_uv_path", lambda: "/tmp/uv")
+    monkeypatch.setattr(deps_manager, "venv_python_usable", lambda _path: (True, ""))
+    monkeypatch.setattr(deps_manager, "_verify_pip_and_return", lambda path: path)
+    monkeypatch.setattr(deps_manager.subprocess, "run", fake_run)
+
+    success, message = deps_manager.install_packages(
+        venv_dir,
+        ["GeoAgent[providers]>=1.7.0"],
+        progress_callback=lambda p, m: progress.append((p, m)),
+    )
+
+    assert success is True
+    assert message == "Packages installed successfully."
+    assert commands[0][:3] == ["/tmp/uv", "pip", "install"]
+    assert commands[1][:4] == [str(python_path), "-m", "pip", "install"]
+    assert any("retrying with pip" in message for _percent, message in progress)
 
 
 def test_provider_test_worker_uses_ollama_safe_smoke_prompt(monkeypatch) -> None:

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -160,6 +160,34 @@ def test_find_python_executable_finds_macos_bundle_python(
     assert deps_manager._find_python_executable() == str(python_binary)
 
 
+def test_python_executable_usable_rejects_qgis_app_bundle_python(
+    monkeypatch, tmp_path
+) -> None:
+    """A startable QGIS.app Python wrapper still should not be used for venv."""
+    from open_geoagent import deps_manager
+
+    python_binary = (
+        tmp_path / "QGIS-final-4_0_2.app" / "Contents" / "MacOS" / "python"
+    )
+    python_binary.parent.mkdir(parents=True)
+    python_binary.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(deps_manager.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(deps_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        deps_manager.subprocess,
+        "run",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            returncode=0, stdout="", stderr=""
+        ),
+    )
+
+    usable, reason = deps_manager._python_executable_usable(str(python_binary))
+
+    assert usable is False
+    assert "QGIS app-bundle Python" in reason
+
+
 def test_find_python_executable_skips_unstartable_macos_bundle_python(
     monkeypatch, tmp_path
 ) -> None:

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -166,9 +166,7 @@ def test_python_executable_usable_rejects_qgis_app_bundle_python(
     """A startable QGIS.app Python wrapper still should not be used for venv."""
     from open_geoagent import deps_manager
 
-    python_binary = (
-        tmp_path / "QGIS-final-4_0_2.app" / "Contents" / "MacOS" / "python"
-    )
+    python_binary = tmp_path / "QGIS-final-4_0_2.app" / "Contents" / "MacOS" / "python"
     python_binary.parent.mkdir(parents=True)
     python_binary.write_text("", encoding="utf-8")
 

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -116,6 +116,11 @@ def test_find_python_executable_uses_macos_base_executable(
     monkeypatch.setattr(
         deps_manager.sys, "_base_executable", str(python_binary), raising=False
     )
+    monkeypatch.setattr(
+        deps_manager,
+        "_python_executable_usable",
+        lambda path: (path == str(python_binary), "broken"),
+    )
 
     assert deps_manager._find_python_executable() == str(python_binary)
 
@@ -146,8 +151,68 @@ def test_find_python_executable_finds_macos_bundle_python(
     monkeypatch.setattr(deps_manager.sys, "_base_prefix", str(macos_dir), raising=False)
     monkeypatch.setattr(deps_manager.sys, "prefix", str(macos_dir))
     monkeypatch.setattr(deps_manager.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        deps_manager,
+        "_python_executable_usable",
+        lambda path: (path == str(python_binary), "broken"),
+    )
 
     assert deps_manager._find_python_executable() == str(python_binary)
+
+
+def test_find_python_executable_skips_unstartable_macos_bundle_python(
+    monkeypatch, tmp_path
+) -> None:
+    """The official macOS app python may exist but fail before importing encodings."""
+    import sys
+
+    from open_geoagent import deps_manager
+
+    macos_dir = tmp_path / "QGIS.app" / "Contents" / "MacOS"
+    macos_dir.mkdir(parents=True)
+    qgis_binary = macos_dir / "QGIS"
+    broken_python = macos_dir / (
+        f"python{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    path_python = (
+        tmp_path / "bin" / (f"python{sys.version_info.major}.{sys.version_info.minor}")
+    )
+    path_python.parent.mkdir()
+    qgis_binary.write_text("", encoding="utf-8")
+    broken_python.write_text("", encoding="utf-8")
+    path_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(deps_manager.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(deps_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(deps_manager.sys, "executable", str(qgis_binary))
+    monkeypatch.setattr(
+        deps_manager.sys, "_base_executable", str(broken_python), raising=False
+    )
+    monkeypatch.setattr(deps_manager.sys, "_base_prefix", str(macos_dir), raising=False)
+    monkeypatch.setattr(deps_manager.sys, "base_prefix", str(tmp_path), raising=False)
+    monkeypatch.setattr(
+        deps_manager.sys, "base_exec_prefix", str(tmp_path), raising=False
+    )
+    monkeypatch.setattr(deps_manager.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(
+        deps_manager.shutil,
+        "which",
+        lambda name: (
+            str(path_python)
+            if name == f"python{sys.version_info.major}.{sys.version_info.minor}"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        deps_manager,
+        "_python_executable_usable",
+        lambda path: (
+            path == str(path_python),
+            "No module named 'encodings'" if path == str(broken_python) else "",
+        ),
+    )
+
+    assert deps_manager._find_python_executable() == str(path_python)
 
 
 def test_find_python_executable_refuses_non_python_without_candidate(
@@ -179,6 +244,44 @@ def test_find_python_executable_refuses_non_python_without_candidate(
         assert "cannot safely run QGIS itself" in str(exc)
     else:
         raise AssertionError("Expected RuntimeError")
+
+
+def test_create_venv_lets_uv_resolve_python_version_when_bundle_python_is_broken(
+    monkeypatch, tmp_path
+) -> None:
+    """uv can create the matching venv when app-bundle Python cannot start."""
+    from open_geoagent import deps_manager
+    import open_geoagent.uv_manager as uv_manager
+
+    commands = []
+    venv_dir = str(tmp_path / "venv")
+    expected_python = deps_manager.get_venv_python_path(venv_dir)
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        if cmd[:2] == ["/tmp/uv", "venv"]:
+            Path(expected_python).parent.mkdir(parents=True, exist_ok=True)
+            Path(expected_python).write_text("", encoding="utf-8")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(deps_manager, "python_runtime_supported", lambda: True)
+    monkeypatch.setattr(deps_manager, "_uv_usable", lambda: True)
+    monkeypatch.setattr(uv_manager, "get_uv_path", lambda: "/tmp/uv")
+    monkeypatch.setattr(
+        deps_manager,
+        "_find_python_executable",
+        lambda: (_ for _ in ()).throw(RuntimeError("No module named 'encodings'")),
+    )
+    monkeypatch.setattr(deps_manager.subprocess, "run", fake_run)
+
+    assert deps_manager.create_venv(venv_dir) == expected_python
+    assert commands[0] == [
+        "/tmp/uv",
+        "venv",
+        "--python",
+        deps_manager._python_version_spec(),
+        venv_dir,
+    ]
 
 
 def test_provider_test_worker_uses_ollama_safe_smoke_prompt(monkeypatch) -> None:

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -119,7 +119,7 @@ def test_find_python_executable_uses_macos_base_executable(
     monkeypatch.setattr(
         deps_manager,
         "_python_executable_usable",
-        lambda path: (path == str(python_binary), "broken"),
+        lambda path: ((True, "") if path == str(python_binary) else (False, "broken")),
     )
 
     assert deps_manager._find_python_executable() == str(python_binary)
@@ -154,7 +154,7 @@ def test_find_python_executable_finds_macos_bundle_python(
     monkeypatch.setattr(
         deps_manager,
         "_python_executable_usable",
-        lambda path: (path == str(python_binary), "broken"),
+        lambda path: ((True, "") if path == str(python_binary) else (False, "broken")),
     )
 
     assert deps_manager._find_python_executable() == str(python_binary)


### PR DESCRIPTION
## Summary
- Probe Python interpreter candidates with a short subprocess so unstartable binaries (e.g. the official macOS QGIS bundle's python3.x failing with "No module named 'encodings'") are skipped instead of being passed to uv or venv.
- When no startable interpreter is found, ask uv to resolve the matching Python version spec so venv creation can still succeed on affected macOS installations.
- Surface rejected candidates and their reasons in the RuntimeError message to make diagnosis easier.

## Test plan
- [x] pre-commit run --all-files
- [ ] pytest qgis_geoagent/tests/test_settings_diagnostics.py
- [ ] Manual: trigger venv creation on an official macOS QGIS app bundle and confirm it falls back to uv with the matching version