### PR TITLE
Bump OpenGeoAgent QGIS plugin patch version

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.7.1"
+version = "1.7.2"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -77,7 +77,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.7.1"
+current_version = "1.7.2"
 commit = true
 tag = true
 

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -418,7 +418,7 @@ def _add_existing_python_candidate(
 
 
 def _is_macos_qgis_app_bundle_python(path: str) -> bool:
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -426,7 +426,12 @@ def _is_macos_qgis_app_bundle_python(path: str) -> bool:
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _looks_like_python_executable(path)
     return False
 
 

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -46,7 +46,7 @@ icon=icons/icon.svg
 experimental=False
 deprecated=False
 
-changelog=
+changelog=Bump OpenGeoAgent QGIS plugin patch version.
     1.7.1 - Patch release
         - Raised package and plugin version metadata to 1.7.1
         - Raised the plugin dependency guidance to GeoAgent 1.7.1

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -46,7 +46,9 @@ icon=icons/icon.svg
 experimental=False
 deprecated=False
 
-changelog=Bump OpenGeoAgent QGIS plugin patch version.
+changelog=
+    1.7.2 - Patch release
+        - Bump OpenGeoAgent QGIS plugin patch version
     1.7.1 - Patch release
         - Raised package and plugin version metadata to 1.7.1
         - Raised the plugin dependency guidance to GeoAgent 1.7.1

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.7.1
+version=1.7.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
## Summary
- Bump the OpenGeoAgent QGIS plugin patch version in `metadata.txt`.

## Validation
- metadata version bump only
