### PR TITLE
feat(nasa-earthdata): add HLS RGB composite tool

### DIFF
--- a/geoagent/core/factory.py
+++ b/geoagent/core/factory.py
@@ -35,11 +35,22 @@ project.
 Workflow guidance:
 - Search the catalog first when the user names a topic rather than an exact
   NASA Earthdata short name.
+- When a catalog result includes a concept-id, pass it to granule search to
+  disambiguate duplicate short names.
 - If the user gives no location, use the current QGIS map extent.
+- Only use an orbit number filter when the user explicitly asks for a positive
+  orbit number.
 - Search granules before displaying footprints or loading rasters.
 - For raster display, choose a specific COG or GeoTIFF data link from search
   results. Loading data can download protected assets and requires user
   confirmation.
+- For HLS true-color or false-color composites, call
+  create_earthdata_rgb_composite with the three ordered band URLs. Do not
+  hand-write inline VRT XML or pass VRT XML strings to add_raster_layer; use
+  the composite tool so GDAL streams the COGs and preserves CRS and
+  geotransform metadata.
+- HLS Landsat false color NIR/Red/Green uses B05, B04, B03. HLS Sentinel-2
+  false color commonly uses B08, B04, B03.
 - Keep responses concise and include dataset short names, result counts,
   date ranges, and relevant first-result identifiers when available.
 """

--- a/geoagent/tools/nasa_earthdata.py
+++ b/geoagent/tools/nasa_earthdata.py
@@ -59,6 +59,9 @@ def _compact_catalog_row(row: dict[str, str]) -> dict[str, str]:
     keys = [
         "ShortName",
         "EntryTitle",
+        "concept-id",
+        "provider-id",
+        "Version",
         "Platform",
         "Instrument",
         "ProcessingLevel",
@@ -131,6 +134,26 @@ def _parse_bbox(bbox: str | list[float] | tuple[float, ...] | None) -> (
     if west >= east or south >= north:
         raise ValueError("bbox coordinates must satisfy west < east and south < north")
     return west, south, east, north
+
+
+def _normalize_orbit_number(value: Any) -> int | tuple[int, int] | None:
+    """Return a positive CMR orbit filter, ignoring unset UI/LLM defaults."""
+    if value is None or value == "":
+        return None
+
+    if isinstance(value, (list, tuple)):
+        numbers = [int(item) for item in value if item not in (None, "")]
+        positives = [number for number in numbers if number > 0]
+        if not positives:
+            return None
+        if len(positives) == 1:
+            return positives[0]
+        return positives[0], positives[1]
+
+    number = int(value)
+    if number <= 0:
+        return None
+    return number
 
 
 def _current_bbox_wgs84(iface: Any) -> tuple[float, float, float, float]:
@@ -246,6 +269,108 @@ def _safe_basename(value: str, *, fallback: str = "earthdata") -> str:
     return cleaned.strip("._") or fallback
 
 
+def _download_raster_source(
+    source: str,
+    target_dir: str,
+    earthaccess: Any,
+) -> str:
+    """Return a local raster path for an Earthdata URL or existing file."""
+    value = str(source or "").strip()
+    if not value:
+        raise ValueError("Raster source URL/path cannot be empty.")
+    if os.path.exists(value):
+        return value
+
+    basename = _safe_basename(value, fallback="earthdata_raster")
+    local_path = os.path.join(target_dir, basename)
+    if os.path.exists(local_path):
+        return local_path
+
+    downloaded = earthaccess.download([value], local_path=target_dir, threads=1) or []
+    for item in downloaded:
+        item_path = str(item)
+        if os.path.exists(item_path):
+            return item_path
+    if os.path.exists(local_path):
+        return local_path
+    raise RuntimeError(f"Downloaded raster was not found for {value!r}.")
+
+
+def _vsicurl_raster_source(source: str) -> str:
+    """Return a GDAL streaming source for a remote COG URL or local path."""
+    value = str(source or "").strip()
+    if not value:
+        raise ValueError("Raster source URL/path cannot be empty.")
+    if value.startswith("/vsicurl/") or value.startswith("/vsis3/"):
+        return value
+    if value.startswith(("http://", "https://")):
+        return f"/vsicurl/{value}"
+    if value.startswith("s3://"):
+        return f"/vsis3/{value[5:]}"
+    return value
+
+
+def _prime_earthdata_session(session: Any, url: str) -> None:
+    """Touch one protected URL so Earthdata redirects populate cookies."""
+    if not url.startswith(("http://", "https://")):
+        return
+    try:
+        with session.get(url, stream=True, timeout=60) as response:
+            response.raise_for_status()
+    except Exception:
+        pass
+
+
+def _write_gdal_cookie_file(session: Any) -> str | None:
+    """Write requests-session cookies in Netscape format for GDAL."""
+    cookies = getattr(session, "cookies", None)
+    if not cookies:
+        return None
+    cookie_file = os.path.join(
+        tempfile.gettempdir(), f"geoagent_earthdata_gdal_{uuid.uuid4().hex}.cookies"
+    )
+    with open(cookie_file, "w", encoding="utf-8") as f:
+        f.write("# Netscape HTTP Cookie File\n")
+        for cookie in cookies:
+            domain = cookie.domain or ""
+            include_subdomains = "TRUE" if domain.startswith(".") else "FALSE"
+            path = cookie.path or "/"
+            secure = "TRUE" if cookie.secure else "FALSE"
+            expires = str(cookie.expires or 0)
+            f.write(
+                "\t".join(
+                    [
+                        domain,
+                        include_subdomains,
+                        path,
+                        secure,
+                        expires,
+                        str(cookie.name),
+                        str(cookie.value),
+                    ]
+                )
+                + "\n"
+            )
+    return cookie_file
+
+
+def _configure_gdal_http_streaming(gdal: Any, cookie_file: str | None = None) -> None:
+    """Configure GDAL for authenticated /vsicurl/ Earthdata COG reads."""
+    if cookie_file:
+        gdal.SetConfigOption("GDAL_HTTP_COOKIEFILE", cookie_file)
+        gdal.SetConfigOption("GDAL_HTTP_COOKIEJAR", cookie_file)
+    netrc_path = os.path.expanduser("~/.netrc")
+    if os.path.exists(netrc_path):
+        gdal.SetConfigOption("GDAL_HTTP_NETRC", "YES")
+        gdal.SetConfigOption("GDAL_HTTP_NETRC_FILE", netrc_path)
+    gdal.SetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "EMPTY_DIR")
+    gdal.SetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", "tif,tiff,TIF,TIFF")
+    gdal.SetConfigOption("GDAL_HTTP_UNSAFESSL", "YES")
+    gdal.SetConfigOption("GDAL_HTTP_MAX_RETRY", "3")
+    gdal.SetConfigOption("VSI_CACHE", "TRUE")
+    gdal.SetConfigOption("VSI_CACHE_SIZE", "100000000")
+
+
 def _add_qgis_raster_layer(
     iface: Any,
     project_getter: Any,
@@ -260,6 +385,54 @@ def _add_qgis_raster_layer(
         layer = QgsRasterLayer(path_or_uri, layer_name)
         if not layer.isValid():
             return {"error": f"Failed to load raster from {path_or_uri}."}
+        project_getter().addMapLayer(layer)
+        iface.mapCanvas().refresh()
+        return {"success": True, "layer_name": layer_name}
+
+    return _on_gui(_run)
+
+
+def _add_qgis_rgb_raster_layer(
+    iface: Any,
+    project_getter: Any,
+    path_or_uri: str,
+    layer_name: str,
+) -> dict[str, Any]:
+    """Add an RGB raster layer to QGIS on the GUI thread."""
+
+    def _run() -> dict[str, Any]:
+        from qgis.core import QgsRasterLayer  # type: ignore[import-not-found]
+
+        layer = QgsRasterLayer(path_or_uri, layer_name)
+        if not layer.isValid():
+            return {"error": f"Failed to load raster from {path_or_uri}."}
+
+        try:
+            from qgis.core import (  # type: ignore[import-not-found]
+                QgsContrastEnhancement,
+                QgsMultiBandColorRenderer,
+            )
+
+            provider = layer.dataProvider()
+            renderer = QgsMultiBandColorRenderer(provider, 1, 2, 3)
+            for setter_name in (
+                "setRedContrastEnhancement",
+                "setGreenContrastEnhancement",
+                "setBlueContrastEnhancement",
+            ):
+                enhancement = QgsContrastEnhancement(provider.dataType(1))
+                enhancement.setMinimumValue(0)
+                enhancement.setMaximumValue(3000)
+                enhancement.setContrastEnhancementAlgorithm(
+                    QgsContrastEnhancement.StretchToMinimumMaximum
+                )
+                setter = getattr(renderer, setter_name, None)
+                if callable(setter):
+                    setter(enhancement)
+            layer.setRenderer(renderer)
+        except Exception:
+            pass
+
         project_getter().addMapLayer(layer)
         iface.mapCanvas().refresh()
         return {"success": True, "layer_name": layer_name}
@@ -369,7 +542,8 @@ def earthdata_tools(
         requires_packages=("earthaccess",),
     )
     def search_earthdata_data(
-        short_name: str,
+        short_name: str = "",
+        concept_id: Optional[str] = None,
         bbox: str | list[float] | None = None,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
@@ -390,8 +564,17 @@ def earthdata_tools(
             parsed_bbox = _current_bbox_wgs84(iface)
 
         _earthdata_login()
+        collection_id = (concept_id or "").strip()
+        dataset_short_name = (short_name or "").strip()
+        if collection_id:
+            dataset_param = {"concept_id": collection_id}
+        elif dataset_short_name:
+            dataset_param = {"short_name": dataset_short_name}
+        else:
+            raise ValueError("short_name or concept_id is required")
+
         search_params: dict[str, Any] = {
-            "short_name": short_name,
+            **dataset_param,
             "count": max(1, int(max_results)),
             "bounding_box": parsed_bbox,
         }
@@ -415,17 +598,20 @@ def earthdata_tools(
             search_params["day_night_flag"] = day_night
         if granule_id:
             search_params["granule_ur"] = granule_id
-        if orbit_number is not None:
-            search_params["orbit_number"] = orbit_number
+        normalized_orbit_number = _normalize_orbit_number(orbit_number)
+        if normalized_orbit_number is not None:
+            search_params["orbit_number"] = normalized_orbit_number
 
         results = list(earthaccess.search_data(**search_params))
         state["last_search_results"] = results
-        state["last_search_short_name"] = short_name
+        state["last_search_short_name"] = dataset_short_name
+        state["last_search_concept_id"] = collection_id
         state["last_search_bbox"] = parsed_bbox
 
         return {
             "count": len(results),
-            "short_name": short_name,
+            "short_name": dataset_short_name,
+            "concept_id": collection_id,
             "bbox": parsed_bbox,
             "granules": [_granule_summary(granule) for granule in results],
         }
@@ -536,6 +722,94 @@ def earthdata_tools(
 
     @geo_tool(
         category="nasa_earthdata",
+        name="create_earthdata_rgb_composite",
+        requires_confirmation=True,
+        long_running=True,
+        requires_packages=("earthaccess", "osgeo"),
+    )
+    def create_earthdata_rgb_composite(
+        red_url: str,
+        green_url: str,
+        blue_url: str,
+        layer_name: str = "NASA Earthdata RGB Composite",
+        cache_dir: Optional[str] = None,
+        stream: bool = True,
+    ) -> dict[str, Any]:
+        """Build a georeferenced RGB VRT from three Earthdata COG bands."""
+        import earthaccess
+        from osgeo import gdal  # type: ignore[import-not-found]
+
+        _earthdata_login()
+        cookie_file = None
+        if stream:
+            try:
+                session = earthaccess.get_requests_https_session()
+                _prime_earthdata_session(session, red_url)
+                cookie_file = _write_gdal_cookie_file(session)
+            except Exception:
+                cookie_file = None
+            _configure_gdal_http_streaming(gdal, cookie_file)
+            channel_sources = {
+                "red": _vsicurl_raster_source(red_url),
+                "green": _vsicurl_raster_source(green_url),
+                "blue": _vsicurl_raster_source(blue_url),
+            }
+        else:
+            target_dir = cache_dir or os.path.join(
+                os.path.expanduser("~"), "nasa_earthdata_cache"
+            )
+            os.makedirs(target_dir, exist_ok=True)
+            channel_sources = {
+                "red": _download_raster_source(red_url, target_dir, earthaccess),
+                "green": _download_raster_source(green_url, target_dir, earthaccess),
+                "blue": _download_raster_source(blue_url, target_dir, earthaccess),
+            }
+
+        safe_stem = _safe_basename(layer_name, fallback="earthdata_rgb")
+        vrt_path = os.path.join(
+            tempfile.gettempdir(), f"{safe_stem}_{uuid.uuid4().hex}.vrt"
+        )
+        vrt = gdal.BuildVRT(
+            vrt_path,
+            [
+                channel_sources["red"],
+                channel_sources["green"],
+                channel_sources["blue"],
+            ],
+            options=gdal.BuildVRTOptions(separate=True),
+        )
+        if vrt is None:
+            return {"error": "Failed to build georeferenced RGB VRT."}
+
+        for band_index, color_interp in enumerate(
+            (gdal.GCI_RedBand, gdal.GCI_GreenBand, gdal.GCI_BlueBand),
+            start=1,
+        ):
+            band = vrt.GetRasterBand(band_index)
+            if band is not None:
+                band.SetColorInterpretation(color_interp)
+        vrt.FlushCache()
+        vrt = None
+
+        if not os.path.exists(vrt_path):
+            return {"error": f"RGB VRT was not written: {vrt_path}"}
+
+        result = _add_qgis_rgb_raster_layer(iface, _project, vrt_path, layer_name)
+        if result.get("success"):
+            result.update(
+                {
+                    "path": vrt_path,
+                    "red_source": channel_sources["red"],
+                    "green_source": channel_sources["green"],
+                    "blue_source": channel_sources["blue"],
+                    "source_type": "stream" if stream else "download",
+                    "cookie_file": cookie_file or "",
+                }
+            )
+        return result
+
+    @geo_tool(
+        category="nasa_earthdata",
         name="open_nasa_earthdata_search_panel",
         requires_confirmation=True,
     )
@@ -558,6 +832,7 @@ def earthdata_tools(
         search_earthdata_data,
         display_earthdata_footprints,
         load_earthdata_raster,
+        create_earthdata_rgb_composite,
         open_nasa_earthdata_search_panel,
         open_nasa_earthdata_settings,
     ]

--- a/tests/test_nasa_earthdata_tools.py
+++ b/tests/test_nasa_earthdata_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 import sys
 import types
 
@@ -42,6 +43,7 @@ def test_earthdata_tools_expose_expected_surface() -> None:
     assert "search_earthdata_data" in tools
     assert "display_earthdata_footprints" in tools
     assert "load_earthdata_raster" in tools
+    assert "create_earthdata_rgb_composite" in tools
 
 
 def test_for_nasa_earthdata_registers_earthdata_and_qgis_tools() -> None:
@@ -114,10 +116,14 @@ def test_for_nasa_earthdata_chat_on_gui_thread_fails_closed(monkeypatch) -> None
 
 
 _FAKE_TSV = (
-    "ShortName\tEntryTitle\tSummary\tPlatform\tInstrument\n"
-    "MOD11A1\tMODIS Land Surface Temperature\tDaily LST product\tTerra\tMODIS\n"
-    "HLSL30\tHarmonized Landsat Sentinel-2 Landsat\tSurface reflectance\tLandsat\tOLI\n"
-    "GPM_3IMERGDF\tGPM IMERG Daily\tPrecipitation\tGPM\tIMERG\n"
+    "ShortName\tEntryTitle\tSummary\tPlatform\tInstrument\tconcept-id\t"
+    "provider-id\tVersion\n"
+    "MOD11A1\tMODIS Land Surface Temperature\tDaily LST product\tTerra\t"
+    "MODIS\tC123-LPDAAC\tLPDAAC\t6.1\n"
+    "HLSL30\tHarmonized Landsat Sentinel-2 Landsat\tSurface reflectance\t"
+    "Landsat\tOLI\tC2021957657-LPCLOUD\tLPCLOUD\t2.0\n"
+    "GPM_3IMERGDF\tGPM IMERG Daily\tPrecipitation\tGPM\tIMERG\t"
+    "C456-GES_DISC\tGES_DISC\t7\n"
 )
 
 
@@ -151,6 +157,7 @@ def test_search_earthdata_catalog_filters_and_max_results(monkeypatch) -> None:
     )
     assert result["count"] == 1
     assert result["datasets"][0]["ShortName"] == "MOD11A1"
+    assert result["datasets"][0]["concept-id"] == "C123-LPDAAC"
 
     capped = search(
         query="",
@@ -172,3 +179,179 @@ def test_load_catalog_rows_rejects_non_https(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="HTTPS"):
         nasa_earthdata_module._load_catalog_rows("http://example.com/catalog.tsv")
+
+
+def _install_fake_earthaccess(monkeypatch):
+    """Install a fake earthaccess module and return captured search calls."""
+    calls = []
+
+    def _login(strategy):
+        return types.SimpleNamespace(authenticated=True)
+
+    def _search_data(**kwargs):
+        calls.append(kwargs)
+        return [
+            {
+                "meta": {
+                    "native-id": "HLS.S30.T10SEG.2025168T184941.v2.0",
+                    "concept-id": "G3577700089-LPCLOUD",
+                    "collection-concept-id": "C2021957295-LPCLOUD",
+                },
+                "umm": {
+                    "TemporalExtent": {
+                        "RangeDateTime": {
+                            "BeginningDateTime": "2025-06-17T19:04:28.304Z",
+                            "EndingDateTime": "2025-06-17T19:04:28.304Z",
+                        }
+                    }
+                },
+            }
+        ]
+
+    def _download(*_args, **_kwargs):
+        raise AssertionError("RGB composite streaming should not download COGs")
+
+    fake_earthaccess = types.SimpleNamespace(
+        login=_login,
+        search_data=_search_data,
+        download=_download,
+    )
+    monkeypatch.setitem(sys.modules, "earthaccess", fake_earthaccess)
+    return calls
+
+
+def test_search_earthdata_data_ignores_zero_orbit_number(monkeypatch) -> None:
+    """Verify LLM/UI default zero does not become a CMR orbit filter."""
+    calls = _install_fake_earthaccess(monkeypatch)
+    tools = {tool.tool_name: tool for tool in earthdata_tools(object())}
+    search = tools["search_earthdata_data"]
+
+    result = search(
+        short_name="HLSS30",
+        bbox=[-122.55, 37.68, -122.32, 37.84],
+        start_date="2025-06-01",
+        end_date="2025-08-31",
+        max_results=20,
+        provider="LPCLOUD",
+        version="2.0",
+        cloud_cover_min=0,
+        cloud_cover_max=5,
+        orbit_number=0,
+    )
+
+    assert result["count"] == 1
+    assert calls[0]["short_name"] == "HLSS30"
+    assert calls[0]["bounding_box"] == (-122.55, 37.68, -122.32, 37.84)
+    assert calls[0]["cloud_cover"] == (0, 5)
+    assert "orbit_number" not in calls[0]
+
+
+def test_search_earthdata_data_prefers_concept_id(monkeypatch) -> None:
+    """Verify catalog concept IDs can disambiguate CMR granule searches."""
+    calls = _install_fake_earthaccess(monkeypatch)
+    tools = {tool.tool_name: tool for tool in earthdata_tools(object())}
+    search = tools["search_earthdata_data"]
+
+    result = search(
+        short_name="HLSS30",
+        concept_id="C2021957295-LPCLOUD",
+        bbox="-122.55,37.68,-122.32,37.84",
+        max_results=5,
+        orbit_number=123,
+    )
+
+    assert result["concept_id"] == "C2021957295-LPCLOUD"
+    assert calls[0]["concept_id"] == "C2021957295-LPCLOUD"
+    assert "short_name" not in calls[0]
+    assert calls[0]["orbit_number"] == 123
+
+
+def test_create_earthdata_rgb_composite_builds_vrt(monkeypatch) -> None:
+    """Verify RGB composites stream COGs through GDAL VRTs."""
+    _install_fake_earthaccess(monkeypatch)
+    red = "https://example.test/HLS.L30.B05.tif"
+    green = "https://example.test/HLS.L30.B04.tif"
+    blue = "https://example.test/HLS.L30.B03.tif"
+
+    captured = {}
+
+    class _FakeBand:
+        def __init__(self):
+            self.color_interp = None
+
+        def SetColorInterpretation(self, value):
+            self.color_interp = value
+
+    class _FakeVrt:
+        def __init__(self, path):
+            self.path = path
+            self.bands = [_FakeBand(), _FakeBand(), _FakeBand()]
+
+        def GetRasterBand(self, index):
+            return self.bands[index - 1]
+
+        def FlushCache(self):
+            with open(self.path, "w", encoding="utf-8") as f:
+                f.write("<VRTDataset><SRS>EPSG:32610</SRS></VRTDataset>")
+
+    class _FakeGdal:
+        GCI_RedBand = 3
+        GCI_GreenBand = 4
+        GCI_BlueBand = 5
+
+        @staticmethod
+        def SetConfigOption(name, value):
+            captured.setdefault("config", {})[name] = value
+
+        @staticmethod
+        def BuildVRTOptions(**kwargs):
+            captured["options"] = kwargs
+            return kwargs
+
+        @staticmethod
+        def BuildVRT(path, sources, options=None):
+            captured["path"] = path
+            captured["sources"] = sources
+            captured["build_options"] = options
+            return _FakeVrt(path)
+
+    fake_osgeo = types.ModuleType("osgeo")
+    fake_osgeo.gdal = _FakeGdal
+    monkeypatch.setitem(sys.modules, "osgeo", fake_osgeo)
+    monkeypatch.setitem(sys.modules, "osgeo.gdal", _FakeGdal)
+
+    def _fake_add_layer(_iface, _project_getter, path_or_uri, layer_name):
+        captured["loaded_path"] = path_or_uri
+        captured["layer_name"] = layer_name
+        return {"success": True, "layer_name": layer_name}
+
+    monkeypatch.setattr(
+        nasa_earthdata_module,
+        "_add_qgis_rgb_raster_layer",
+        _fake_add_layer,
+    )
+
+    tools = {tool.tool_name: tool for tool in earthdata_tools(object())}
+    create_composite = tools["create_earthdata_rgb_composite"]
+
+    result = create_composite(
+        red_url=red,
+        green_url=green,
+        blue_url=blue,
+        layer_name="HLS false color",
+    )
+
+    assert result["success"] is True
+    assert result["layer_name"] == "HLS false color"
+    assert result["path"].endswith(".vrt")
+    assert os.path.exists(result["path"])
+    assert captured["sources"] == [
+        f"/vsicurl/{red}",
+        f"/vsicurl/{green}",
+        f"/vsicurl/{blue}",
+    ]
+    assert captured["options"] == {"separate": True}
+    assert captured["loaded_path"] == result["path"]
+    assert result["source_type"] == "stream"
+    assert result["red_source"] == f"/vsicurl/{red}"
+    assert captured["config"]["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR"


### PR DESCRIPTION
## Summary
- Add `create_earthdata_rgb_composite` that streams three Earthdata COG bands through a GDAL VRT, producing a georeferenced QGIS layer with preserved CRS and geotransform metadata.
- Surface `concept-id`, `provider-id`, and `Version` in catalog results so granule search can disambiguate duplicate short names.
- Ignore zero-valued `orbit_number` defaults so unset UI/LLM inputs no longer narrow CMR queries.

## Test plan
- [x] `pytest tests/test_nasa_earthdata_tools.py -q`
- [x] `pre-commit run --all-files`
- [ ] Manual: in QGIS, run an HLS Sentinel-2 false-color request (B08/B04/B03) and confirm the resulting layer is georeferenced and renders as RGB.