### PR TITLE
fix(qgis): preserve XYZ tile URL templates and refresh canvas

### DIFF
--- a/geoagent/tools/qgis.py
+++ b/geoagent/tools/qgis.py
@@ -195,6 +195,7 @@ def _set_symbol_outline_color(symbol: Any, color: Any) -> bool:
 
 
 _ACTIVE_QGIS_HILLSHADE_TASKS: list[Any] = []
+_QGIS_XYZ_URL_SAFE_CHARS = ":/{}"
 
 
 def _is_raster_layer(layer: Any) -> bool:
@@ -376,6 +377,24 @@ def _apply_raster_symbology(
         )
         applied.update(style)
         return applied
+
+
+def _xyz_tile_uri(
+    url: str,
+    *,
+    zmin: Optional[int] = None,
+    zmax: Optional[int] = None,
+    attribution: Optional[str] = None,
+) -> str:
+    """Return a QGIS XYZ datasource URI for a tile URL template."""
+    # ``attribution`` is a display credit, not QGIS's HTTP ``referer`` field.
+    # Keep the argument for tool compatibility but do not send it to the provider.
+    parts = ["type=xyz", f"url={quote(url, safe=_QGIS_XYZ_URL_SAFE_CHARS)}"]
+    if zmin is not None:
+        parts.append(f"zmin={int(zmin)}")
+    if zmax is not None:
+        parts.append(f"zmax={int(zmax)}")
+    return "&".join(parts)
 
 
 def _transform_extent_to_canvas_crs(layer: Any, canvas: Any, extent: Any) -> Any:
@@ -1097,14 +1116,12 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
 
         def _run() -> str:
             """Run the worker body."""
-            parts = ["type=xyz", f"url={quote(url, safe='')}"]
-            if zmin is not None:
-                parts.append(f"zmin={int(zmin)}")
-            if zmax is not None:
-                parts.append(f"zmax={int(zmax)}")
-            if attribution:
-                parts.append(f"referer={quote(attribution, safe='')}")
-            uri = "&".join(parts)
+            uri = _xyz_tile_uri(
+                url,
+                zmin=zmin,
+                zmax=zmax,
+                attribution=attribution,
+            )
 
             layer: Any | None = None
             try:
@@ -1127,6 +1144,17 @@ def qgis_tools(iface: Any, project: Optional[Any] = None) -> list[Any]:
 
             if layer is None or (hasattr(layer, "isValid") and not layer.isValid()):
                 return f"Failed to load XYZ tile layer from {url!r}."
+            if hasattr(iface, "setActiveLayer"):
+                try:
+                    iface.setActiveLayer(layer)
+                except Exception:
+                    pass
+            try:
+                canvas = iface.mapCanvas()
+                if hasattr(canvas, "refresh"):
+                    canvas.refresh()
+            except Exception:
+                pass
             return f"Added XYZ tile layer {name!r}."
 
         return _on_gui(_run)

--- a/tests/test_qgis_tools.py
+++ b/tests/test_qgis_tools.py
@@ -14,7 +14,7 @@ import pytest
 
 from geoagent.core.decorators import needs_confirmation
 from geoagent.testing import MockQGISIface, MockQGISLayer, MockQGISProject
-from geoagent.tools.qgis import qgis_tools
+from geoagent.tools.qgis import _xyz_tile_uri, qgis_tools
 
 
 def _color_matches(actual, expected: str) -> bool:
@@ -442,6 +442,51 @@ def test_add_xyz_tile_layer_uses_raster_fallback() -> None:
     )
     assert "Added XYZ" in out
     assert "Tiles" in project.mapLayers()
+    assert (
+        project.mapLayersByName("Tiles")[0].source()
+        == "type=xyz&url=https://example.com/{z}/{x}/{y}.png"
+    )
+    assert iface.activeLayer() is project.mapLayersByName("Tiles")[0]
+    assert iface.mapCanvas().refresh_count == 1
+
+
+def test_xyz_tile_uri_keeps_template_url_readable() -> None:
+    """Verify QGIS XYZ URIs do not encode the whole tile URL."""
+    uri = _xyz_tile_uri(
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+        zmin=0,
+        zmax=19,
+        attribution="OpenStreetMap contributors",
+    )
+
+    assert "url=https://tile.openstreetmap.org/{z}/{x}/{y}.png" in uri
+    assert "https%3A%2F%2Ftile.openstreetmap.org" not in uri
+    assert "referer=" not in uri
+    assert "zmin=0" in uri
+    assert "zmax=19" in uri
+
+
+def test_xyz_tile_uri_for_openstreetmap() -> None:
+    """Verify the standard OSM tile URI works with QGIS's XYZ provider."""
+    uri = _xyz_tile_uri(
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+        zmin=0,
+        zmax=19,
+        attribution="© OpenStreetMap contributors",
+    )
+
+    assert uri == (
+        "type=xyz&url=https://tile.openstreetmap.org/{z}/{x}/{y}.png" "&zmin=0&zmax=19"
+    )
+
+
+def test_xyz_tile_uri_encodes_nested_query_parameters() -> None:
+    """Verify tile URL query params stay inside QGIS's url parameter."""
+    uri = _xyz_tile_uri("https://example.com/{z}/{x}/{y}.png?token=abc&v=1")
+
+    assert uri == (
+        "type=xyz&url=https://example.com/{z}/{x}/{y}.png" "%3Ftoken%3Dabc%26v%3D1"
+    )
 
 
 def test_buffer_active_layer_runs_processing_and_loads_output(


### PR DESCRIPTION
## Summary
- Extract a `_xyz_tile_uri` helper that keeps `{z}/{x}/{y}` placeholders and other URL-template characters unescaped, so QGIS's XYZ provider accepts standard tile URLs (OSM, etc.) instead of the over-encoded form.
- Drop the attribution-as-referer mapping (attribution is a display credit, not an HTTP referer) and document the reasoning in the helper.
- After adding an XYZ tile layer, set it as the active layer and refresh the map canvas so the tiles render immediately.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_qgis_tools.py -q`