### PR TITLE
Fix QGIS plugin reload cleanup

### DIFF
--- a/qgis_geoagent/open_geoagent/open_geoagent.py
+++ b/qgis_geoagent/open_geoagent/open_geoagent.py
@@ -9,6 +9,9 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
 
 
+TOOLBAR_OBJECT_NAME = "OpenGeoAgentToolbar"
+MENU_TITLE = "&OpenGeoAgent"
+
 class OpenGeoAgent:
     """QGIS plugin that exposes GeoAgent through a dockable chat interface."""
 
@@ -53,11 +56,13 @@ class OpenGeoAgent:
 
     def initGui(self):
         """Create OpenGeoAgent menu entries and toolbar buttons."""
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
         self.menu = QMenu("&OpenGeoAgent")
         self.iface.mainWindow().menuBar().addMenu(self.menu)
 
         self.toolbar = QToolBar("OpenGeoAgent Toolbar")
-        self.toolbar.setObjectName("OpenGeoAgentToolbar")
+        self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
         self.iface.addToolBar(self.toolbar)
 
         icon_base = os.path.join(self.plugin_dir, "icons")
@@ -111,6 +116,93 @@ class OpenGeoAgent:
             parent=self.iface.mainWindow(),
         )
 
+
+    def _remove_toolbar(self, toolbar):
+        """Detach and schedule deletion of a plugin toolbar widget."""
+        if toolbar is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        actions = []
+        try:
+            actions = list(toolbar.actions())
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.clear()
+        except Exception:
+            pass  # nosec B110
+        for action in actions:
+            try:
+                action.deleteLater()
+            except Exception:
+                pass  # nosec B110
+        try:
+            main_window.removeToolBar(toolbar)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_toolbars_by_object_name(self):
+        """Remove current or stale plugin toolbars from QGIS."""
+        main_window = self.iface.mainWindow()
+        for toolbar in main_window.findChildren(QToolBar, TOOLBAR_OBJECT_NAME):
+            self._remove_toolbar(toolbar)
+
+    def _plugin_menu_titles(self):
+        """Return possible translated and untranslated plugin menu titles."""
+        titles = {MENU_TITLE}
+        translator = getattr(self, "tr", None)
+        if callable(translator):
+            try:
+                titles.add(translator(MENU_TITLE))
+            except Exception:
+                pass  # nosec B110
+        return titles
+
+    def _remove_menu(self, menu):
+        """Detach and schedule deletion of a plugin menu."""
+        if menu is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        try:
+            menu.clear()
+        except Exception:
+            pass  # nosec B110
+        try:
+            main_window.menuBar().removeAction(menu.menuAction())
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_menus_by_title(self):
+        """Remove current or stale plugin menus from QGIS."""
+        menu_bar = self.iface.mainWindow().menuBar()
+        titles = self._plugin_menu_titles()
+        for action in menu_bar.actions():
+            menu = action.menu()
+            if menu is not None and menu.title() in titles:
+                self._remove_menu(menu)
+
     def unload(self):
         """Remove plugin UI elements from QGIS."""
         if self._chat_dock:
@@ -135,6 +227,9 @@ class OpenGeoAgent:
             self.menu = None
 
         self.actions = []
+
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
 
     def toggle_chat_dock(self):
         """Toggle the chat dock widget."""

--- a/qgis_geoagent/open_geoagent/open_geoagent.py
+++ b/qgis_geoagent/open_geoagent/open_geoagent.py
@@ -8,9 +8,9 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
 
-
 TOOLBAR_OBJECT_NAME = "OpenGeoAgentToolbar"
 MENU_TITLE = "&OpenGeoAgent"
+
 
 class OpenGeoAgent:
     """QGIS plugin that exposes GeoAgent through a dockable chat interface."""
@@ -115,7 +115,6 @@ class OpenGeoAgent:
             status_tip="About OpenGeoAgent",
             parent=self.iface.mainWindow(),
         )
-
 
     def _remove_toolbar(self, toolbar):
         """Detach and schedule deletion of a plugin toolbar widget."""


### PR DESCRIPTION
## Summary

Fix QGIS Plugin Reloader warnings caused by custom plugin toolbars and menus that can remain attached to the QGIS main window after `unload()`.

## Changes

- Remove stale plugin toolbars by object name before creating a new toolbar.
- Detach and schedule stale toolbars for deletion during unload.
- Remove stale plugin menus by title before initialization and during unload.
- Keep cleanup best-effort so reload/unload can continue even if QGIS has already detached a widget.

## Validation

- Ran `python -m py_compile` on the changed plugin entry-point file.
- Ran `git diff --check`.
