### PR TITLE
tests: skip QGIS plugin tests when PyQt6 is unavailable

### DIFF
--- a/qgis_geoagent/tests/conftest.py
+++ b/qgis_geoagent/tests/conftest.py
@@ -7,24 +7,43 @@ from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
 ``QtWidgets`` in Qt6).
 
 PyQt6 is required for these tests. If it is not installed (for example in a
-contributor's bare environment), ``pytest.importorskip`` skips the suite
-instead of failing collection. CI installs PyQt6 explicitly.
+contributor's bare environment), pytest skips collecting the plugin test
+modules instead of failing before the rest of the suite can run. CI installs
+PyQt6 explicitly.
 """
 
 import sys
 import types
+from importlib import import_module
 from pathlib import Path
 
-import pytest
-
-PyQtCore = pytest.importorskip("PyQt6.QtCore")
-PyQtGui = pytest.importorskip("PyQt6.QtGui")
-PyQtNetwork = pytest.importorskip("PyQt6.QtNetwork")
-PyQtWidgets = pytest.importorskip("PyQt6.QtWidgets")
+try:
+    PyQtCore = import_module("PyQt6.QtCore")
+    PyQtGui = import_module("PyQt6.QtGui")
+    PyQtNetwork = import_module("PyQt6.QtNetwork")
+    PyQtWidgets = import_module("PyQt6.QtWidgets")
+except ImportError as exc:
+    PyQtCore = PyQtGui = PyQtNetwork = PyQtWidgets = None
+    PYQT6_SKIP_REASON = str(exc)
+else:
+    PYQT6_SKIP_REASON = ""
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 if str(PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(PLUGIN_ROOT))
+
+
+def pytest_ignore_collect(collection_path, config):  # noqa: ARG001
+    """Avoid importing PyQt-backed plugin tests when PyQt6 is unavailable."""
+    if not PYQT6_SKIP_REASON:
+        return None
+
+    path = Path(str(collection_path))
+    if path.name == "test_pyqt6_dependency.py":
+        return None
+    if path.name.startswith("test_") and path.suffix == ".py":
+        return True
+    return None
 
 
 def _make_strict_module(name: str, attrs: dict) -> types.ModuleType:
@@ -122,4 +141,5 @@ def _install_qgis_stub() -> None:
     qgis.core = qgis_core
 
 
-_install_qgis_stub()
+if not PYQT6_SKIP_REASON:
+    _install_qgis_stub()

--- a/qgis_geoagent/tests/test_pyqt6_dependency.py
+++ b/qgis_geoagent/tests/test_pyqt6_dependency.py
@@ -6,14 +6,30 @@ import pytest
 
 try:
     PyQtCore = import_module("PyQt6.QtCore")
+    PyQtGui = import_module("PyQt6.QtGui")
+    PyQtNetwork = import_module("PyQt6.QtNetwork")
+    PyQtWidgets = import_module("PyQt6.QtWidgets")
 except ImportError:
     PyQtCore = None
+    PyQtGui = None
+    PyQtNetwork = None
+    PyQtWidgets = None
 
 
 @pytest.mark.skipif(
-    PyQtCore is None, reason="PyQt6 is required for qgis_geoagent tests."
+    any(
+        module is None
+        for module in (PyQtCore, PyQtGui, PyQtNetwork, PyQtWidgets)
+    ),
+    reason="PyQt6 is required for qgis_geoagent tests.",
 )
 def test_pyqt6_available_for_qgis_plugin_tests() -> None:
     """Confirm PyQt6 is available before running plugin import tests."""
     assert PyQtCore is not None
+    assert PyQtGui is not None
+    assert PyQtNetwork is not None
+    assert PyQtWidgets is not None
     assert hasattr(PyQtCore, "QObject")
+    assert hasattr(PyQtGui, "QGuiApplication")
+    assert hasattr(PyQtNetwork, "QNetworkAccessManager")
+    assert hasattr(PyQtWidgets, "QWidget")

--- a/qgis_geoagent/tests/test_pyqt6_dependency.py
+++ b/qgis_geoagent/tests/test_pyqt6_dependency.py
@@ -17,10 +17,7 @@ except ImportError:
 
 
 @pytest.mark.skipif(
-    any(
-        module is None
-        for module in (PyQtCore, PyQtGui, PyQtNetwork, PyQtWidgets)
-    ),
+    any(module is None for module in (PyQtCore, PyQtGui, PyQtNetwork, PyQtWidgets)),
     reason="PyQt6 is required for qgis_geoagent tests.",
 )
 def test_pyqt6_available_for_qgis_plugin_tests() -> None:

--- a/qgis_geoagent/tests/test_pyqt6_dependency.py
+++ b/qgis_geoagent/tests/test_pyqt6_dependency.py
@@ -1,0 +1,19 @@
+"""Skip sentinel for optional PyQt6-backed plugin tests."""
+
+from importlib import import_module
+
+import pytest
+
+try:
+    PyQtCore = import_module("PyQt6.QtCore")
+except ImportError:
+    PyQtCore = None
+
+
+@pytest.mark.skipif(
+    PyQtCore is None, reason="PyQt6 is required for qgis_geoagent tests."
+)
+def test_pyqt6_available_for_qgis_plugin_tests() -> None:
+    """Confirm PyQt6 is available before running plugin import tests."""
+    assert PyQtCore is not None
+    assert hasattr(PyQtCore, "QObject")


### PR DESCRIPTION
## Summary

- Avoid importing PyQt-backed QGIS plugin tests when PyQt6 is not installed.
- Add a small dependency sentinel so `pytest qgis_geoagent/tests` reports a clear skip instead of failing collection or returning no collected tests.
- Keep the existing strict QGIS/PyQt shim behavior unchanged when PyQt6 is available.

## Checks

- `python -m pytest tests -q` -> 306 passed, 2 skipped
- `python -m pytest qgis_geoagent/tests -q` -> 1 skipped
- `python -m pytest -q` -> 306 passed, 3 skipped
- `python -m ruff check qgis_geoagent/tests/conftest.py qgis_geoagent/tests/test_pyqt6_dependency.py`
- `python -m pre_commit run --files qgis_geoagent/tests/conftest.py qgis_geoagent/tests/test_pyqt6_dependency.py`