### PR TITLE
fix: keep QGIS plugin actions out of native macOS menus

### DIFF
--- a/qgis_geoagent/open_geoagent/open_geoagent.py
+++ b/qgis_geoagent/open_geoagent/open_geoagent.py
@@ -12,6 +12,26 @@ TOOLBAR_OBJECT_NAME = "OpenGeoAgentToolbar"
 MENU_TITLE = "&OpenGeoAgent"
 
 
+def _set_no_native_menu_role(action):
+    """Keep plugin actions from moving into native macOS application menus.
+
+    Args:
+        action: QAction-like object whose native menu role should be disabled.
+    """
+    set_menu_role = getattr(action, "setMenuRole", None)
+    if not callable(set_menu_role):
+        return
+
+    menu_role = getattr(QAction, "MenuRole", None)
+    no_role = getattr(menu_role, "NoRole", None) if menu_role is not None else None
+    if no_role is None:
+        no_role = getattr(QAction, "NoRole", None)
+    if no_role is None:
+        return
+
+    set_menu_role(no_role)
+
+
 class OpenGeoAgent:
     """QGIS plugin that exposes GeoAgent through a dockable chat interface."""
 
@@ -39,6 +59,7 @@ class OpenGeoAgent:
     ):
         """Create a QAction and add it to the plugin menu and toolbar."""
         action = QAction(QIcon(icon_path), text, parent)
+        _set_no_native_menu_role(action)
         action.triggered.connect(callback)
         action.setEnabled(enabled_flag)
         action.setCheckable(checkable)

--- a/qgis_geoagent/tests/test_startup_performance.py
+++ b/qgis_geoagent/tests/test_startup_performance.py
@@ -80,3 +80,72 @@ def test_python_runtime_error_mentions_required_version(monkeypatch) -> None:
 
     assert deps_manager.python_runtime_supported() is False
     assert "Python 99.0 or newer" in deps_manager.python_runtime_error()
+
+
+def test_plugin_actions_disable_pyqt6_native_menu_roles(monkeypatch) -> None:
+    """PyQt6 actions should stay in the plugin menu on macOS.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing module attributes.
+    """
+    from open_geoagent import open_geoagent
+
+    class FakeAction:
+        """QAction stand-in with the PyQt6 MenuRole shape."""
+
+        class MenuRole:
+            """PyQt6-style QAction.MenuRole enum stand-in."""
+
+            NoRole = object()
+
+        def __init__(self) -> None:
+            """Initialize the captured menu role."""
+            self.menu_role = None
+
+        def setMenuRole(self, role) -> None:  # noqa: N802
+            """Capture the assigned role.
+
+            Args:
+                role: Menu role assigned by the plugin helper.
+            """
+            self.menu_role = role
+
+    monkeypatch.setattr(open_geoagent, "QAction", FakeAction)
+
+    action = FakeAction()
+    open_geoagent._set_no_native_menu_role(action)
+
+    assert action.menu_role is FakeAction.MenuRole.NoRole
+
+
+def test_plugin_actions_disable_pyqt5_native_menu_roles(monkeypatch) -> None:
+    """PyQt5 actions should stay in the plugin menu on macOS.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing module attributes.
+    """
+    from open_geoagent import open_geoagent
+
+    class FakeAction:
+        """QAction stand-in with the PyQt5 enum shape."""
+
+        NoRole = object()
+
+        def __init__(self) -> None:
+            """Initialize the captured menu role."""
+            self.menu_role = None
+
+        def setMenuRole(self, role) -> None:  # noqa: N802
+            """Capture the assigned role.
+
+            Args:
+                role: Menu role assigned by the plugin helper.
+            """
+            self.menu_role = role
+
+    monkeypatch.setattr(open_geoagent, "QAction", FakeAction)
+
+    action = FakeAction()
+    open_geoagent._set_no_native_menu_role(action)
+
+    assert action.menu_role is FakeAction.NoRole


### PR DESCRIPTION
## Summary
- Add `_set_no_native_menu_role` helper and apply it when building plugin QActions so they stay in the OpenGeoAgent toolbar/menu instead of being absorbed into the native macOS application menu.
- Works under both PyQt5 (flat `QAction.NoRole`) and PyQt6 (`QAction.MenuRole.NoRole`) without importing either binding directly.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest qgis_geoagent/tests/test_startup_performance.py`
- [ ] Load the plugin in QGIS on macOS and confirm the OpenGeoAgent entries appear in the plugin menu and toolbar.