### PR TITLE
chore: bump version to 1.8.1

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.8.0"
+version = "1.8.1"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -79,7 +79,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.8.0"
+current_version = "1.8.1"
 commit = true
 tag = true
 

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.8.0
+version=1.8.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.8.1 - Patch release
+        - Raised package and plugin version metadata to 1.8.1
+
     1.8.0 - Minor release
         - Raised package and plugin version metadata to 1.8.0
         - Raised the plugin dependency guidance to GeoAgent 1.8.0


### PR DESCRIPTION
## Summary
- Raise package and QGIS plugin metadata from 1.8.0 to 1.8.1
- Add a 1.8.1 changelog entry in the OpenGeoAgent plugin metadata

## Test plan
- [ ] `pre-commit run --all-files`
- [ ] `pytest tests/ -q`