### PR TITLE
Add EvoSkill starter workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ and `pydantic`. Geospatial packages and provider clients are optional extras:
 | `GeoAgent[providers]`   | OpenAI, Anthropic, Gemini, Ollama, LiteLLM, and vLLM clients.     |
 | `GeoAgent[all]`         | Most optional integrations. QGIS itself remains system-installed. |
 
+EvoSkill is supported as a development workflow for evolving Codex-compatible
+GeoAgent skills, but it is not bundled as a GeoAgent extra. Install it from
+its repository when needed:
+
+```bash
+pip install "git+https://github.com/sentient-agi/EvoSkill.git"
+```
+
+See [EvoSkill](docs/evoskill.md) for the Codex-oriented setup.
+
 Examples:
 
 ```bash
@@ -523,6 +533,8 @@ Runnable notebooks live under `docs/examples/`:
 - `docs/examples/qgis_agent.ipynb` — QGIS-oriented workflow using mocks.
 - `docs/examples/stac_workflow.ipynb` — STAC catalog search and mock QGIS loading.
 - `examples/nasa_opera_qgis.py` — NASA OPERA workflow for QGIS.
+- `examples/evoskill/`: EvoSkill starter prompt for evolving GeoAgent coding
+  skills.
 
 Prompt ideas:
 

--- a/docs/evoskill.md
+++ b/docs/evoskill.md
@@ -1,0 +1,81 @@
+# EvoSkill
+
+[EvoSkill](https://github.com/sentient-agi/EvoSkill) can evolve reusable
+agent skills from task failures. GeoAgent supports this as a development
+workflow for improving coding-agent behavior around GeoAgent issues and
+geospatial agent integrations.
+
+This integration is intentionally lightweight. GeoAgent does not depend on
+EvoSkill at runtime, and there is no `GeoAgent[evoskill]` extra yet because
+EvoSkill is not currently published on PyPI. Install EvoSkill directly from
+its repository when you want to run skill evolution.
+
+## Install
+
+From a GeoAgent development checkout:
+
+```bash
+pip install -e ".[dev]"
+pip install "git+https://github.com/sentient-agi/EvoSkill.git"
+```
+
+EvoSkill runs inside a git repository and creates local runtime files under
+`.evoskill/`. Those generated files are run state, not GeoAgent source files.
+
+## Initialize A Codex Skill Run
+
+Run EvoSkill from the GeoAgent repository root:
+
+```bash
+evoskill init
+```
+
+Choose the Codex runtime when prompted:
+
+```text
+Which agent runtime? codex
+```
+
+After initialization, verify `.evoskill/config.toml` contains a Codex harness:
+
+```toml
+[harness]
+name = "codex"
+```
+
+Then replace the generated `.evoskill/task.md` with the starter prompt from
+`examples/evoskill/task.md`, or use it as a template for a more specific
+GeoAgent issue set.
+
+## Run
+
+Start a local EvoSkill run:
+
+```bash
+evoskill run
+```
+
+Useful follow-up commands:
+
+```bash
+evoskill skills
+evoskill diff
+evoskill logs
+```
+
+EvoSkill writes learned skills under `.claude/skills/`. Its Codex harness
+creates a `.agents/skills/` symlink to that directory so Codex can discover
+the same generated skills. If `.agents/skills/` already exists as a real
+directory, replace it with the symlink that EvoSkill reports before using the
+skills with Codex.
+
+## Starter Files
+
+The tracked starter lives in `examples/evoskill/`:
+
+- `README.md` gives exact local commands and expected files.
+- `task.md` is a GeoAgent-focused EvoSkill task prompt.
+
+Do not commit generated `.evoskill/`, `.agents/`, or `.claude/skills/` run
+directories. Keep evolved skills under review before copying them into any
+shared agent environment.

--- a/examples/evoskill/README.md
+++ b/examples/evoskill/README.md
@@ -1,0 +1,49 @@
+# GeoAgent EvoSkill Starter
+
+This directory contains a starter task prompt for using EvoSkill to evolve
+Codex-discoverable skills for GeoAgent development work.
+
+## Setup
+
+Run these commands from the GeoAgent repository root:
+
+```bash
+pip install -e ".[dev]"
+pip install "git+https://github.com/sentient-agi/EvoSkill.git"
+evoskill init
+```
+
+During `evoskill init`, choose the Codex harness:
+
+```text
+Which agent runtime? codex
+```
+
+After initialization, `.evoskill/config.toml` should include:
+
+```toml
+[harness]
+name = "codex"
+```
+
+Copy this starter prompt into the EvoSkill project task file:
+
+```bash
+cp examples/evoskill/task.md .evoskill/task.md
+```
+
+Then start the run:
+
+```bash
+evoskill run
+```
+
+## Expected Local Files
+
+EvoSkill creates run state in `.evoskill/`.
+
+When the Codex harness runs, EvoSkill writes learned skills to
+`.claude/skills/` and creates `.agents/skills/` as a symlink to that directory
+so Codex can discover the skills.
+
+These generated directories are intentionally not tracked in GeoAgent.

--- a/examples/evoskill/task.md
+++ b/examples/evoskill/task.md
@@ -1,0 +1,43 @@
+# Task
+
+Improve a coding agent that works on the GeoAgent repository.
+
+The agent receives GitHub issue requests and must make focused, tested changes
+to GeoAgent without breaking existing package behavior. GeoAgent is a Python
+project built around Strands Agents, optional geospatial integrations,
+QGIS-safe tools, provider configuration, and documentation examples.
+
+The agent should:
+
+- inspect the relevant GeoAgent modules, tests, and docs before editing;
+- preserve optional dependency boundaries and import safety;
+- add Google-style docstrings for any new Python functions or methods;
+- keep runtime objects out of model-visible tool arguments;
+- update tests and documentation when public behavior changes;
+- avoid committing generated runtime files such as `.evoskill/`, `.agents/`,
+  `.claude/skills/`, build artifacts, caches, or local environment files.
+
+## Examples
+
+- "Add a new optional tool surface" -> identify the factory, tool module,
+  metadata, exports, tests, and docs that need to change.
+- "Fix a QGIS plugin regression" -> inspect plugin code and QGIS-safe tests,
+  keep imports safe outside QGIS, and avoid requiring a desktop QGIS runtime
+  for normal unit tests.
+- "Document a provider workflow" -> update README and docs pages with exact
+  install and usage commands without adding unnecessary package dependencies.
+
+## Output Format
+
+Return the minimal correct patch, explain the files changed, and report the
+tests or checks that were run.
+
+---
+
+# Constraints
+
+- Keep changes scoped to the issue.
+- Prefer existing GeoAgent patterns over new abstractions.
+- Do not add a dependency unless the issue explicitly requires it.
+- Do not mention local private environment details in public GitHub text.
+- Run targeted tests for the changed behavior and run pre-commit before push.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - Home: index.md
     - Installation: installation.md
     - Usage: usage.md
+    - EvoSkill: evoskill.md
     - QGIS Plugin: qgis-plugin.md
     - Changelog: https://github.com/opengeos/GeoAgent/releases
     - Report Issues: https://github.com/opengeos/GeoAgent/issues

--- a/tests/test_evoskill_docs.py
+++ b/tests/test_evoskill_docs.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_evoskill_docs.py
+++ b/tests/test_evoskill_docs.py
@@ -1,0 +1,35 @@
+"""Tests for the EvoSkill documentation starter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_evoskill_docs_cover_codex_workflow() -> None:
+    """Verify the EvoSkill docs describe the Codex setup workflow."""
+    docs = (ROOT / "docs" / "evoskill.md").read_text(encoding="utf-8")
+    assert "git+https://github.com/sentient-agi/EvoSkill.git" in docs
+    assert "evoskill init" in docs
+    assert "evoskill run" in docs
+    assert 'name = "codex"' in docs
+    assert ".agents/skills/" in docs
+    assert ".claude/skills/" in docs
+
+
+def test_evoskill_starter_files_are_tracked_inputs_only() -> None:
+    """Verify the EvoSkill starter has inputs without generated run state."""
+    starter = ROOT / "examples" / "evoskill"
+    readme = (starter / "README.md").read_text(encoding="utf-8")
+    task = (starter / "task.md").read_text(encoding="utf-8")
+
+    assert "evoskill init" in readme
+    assert "evoskill run" in readme
+    assert 'name = "codex"' in readme
+    assert "Improve a coding agent that works on the GeoAgent repository." in task
+
+    assert not (starter / ".evoskill").exists()
+    assert not (starter / ".agents").exists()
+    assert not (starter / ".claude").exists()


### PR DESCRIPTION
## Summary
- Add EvoSkill documentation for a lightweight GeoAgent skill-evolution workflow.
- Add a Codex-focused starter prompt under examples/evoskill/.
- Add tests that guard the documented commands and starter files.

Closes #67.

## Validation
- pytest tests/test_evoskill_docs.py
- mkdocs build --strict
- pre-commit run --all-files