### PR TITLE
Add conditional SSL bypass for on-prem vLLM endpoints

### DIFF
--- a/qgis_geoagent/open_geoagent/dialogs/__init__.py
+++ b/qgis_geoagent/open_geoagent/dialogs/__init__.py
@@ -4,7 +4,6 @@ The dialog classes are imported lazily so opening one panel does not import
 all plugin dialogs and their helper modules.
 """
 
-
 # ---------------------------------------------------------------------------
 # Global SSL bypass — runs at plugin load time, before any provider client
 # is constructed.  Covers both sync (httpx.Client) and async

--- a/qgis_geoagent/open_geoagent/dialogs/__init__.py
+++ b/qgis_geoagent/open_geoagent/dialogs/__init__.py
@@ -4,6 +4,39 @@ The dialog classes are imported lazily so opening one panel does not import
 all plugin dialogs and their helper modules.
 """
 
+
+# ---------------------------------------------------------------------------
+# Global SSL bypass — runs at plugin load time, before any provider client
+# is constructed.  Covers both sync (httpx.Client) and async
+# (httpx.AsyncClient) paths used by the OpenAI SDK.
+# Only active when OPENAI_SSL_VERIFY=0 is set in the environment.
+# ---------------------------------------------------------------------------
+import os as _os
+import ssl as _ssl
+
+if _os.environ.get("OPENAI_SSL_VERIFY", "1").strip() == "0":
+    _ssl._create_default_https_context = _ssl._create_unverified_context  # noqa: SLF001
+
+    import httpx as _httpx
+
+    _OriginalClient = _httpx.Client
+    _OriginalAsyncClient = _httpx.AsyncClient
+
+    class _UnverifiedClient(_OriginalClient):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("verify", False)
+            super().__init__(*args, **kwargs)
+
+    class _UnverifiedAsyncClient(_OriginalAsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("verify", False)
+            super().__init__(*args, **kwargs)
+
+    _httpx.Client = _UnverifiedClient
+    _httpx.AsyncClient = _UnverifiedAsyncClient
+
+# ---------------------------------------------------------------------------
+
 __all__ = ["ChatDockWidget", "SettingsDockWidget", "UpdateCheckerDialog"]
 
 


### PR DESCRIPTION
Add conditional SSL bypass for on-prem vLLM endpoints

On-premises vLLM deployments commonly use self-signed certificates that
cause SSL verification failures in both the OpenAI SDK and the underlying
httpx transport layer. This change introduces an opt-in bypass controlled
by the OPENAI_SSL_VERIFY environment variable.

When OPENAI_SSL_VERIFY=0 is set:
- The default SSL context is replaced with an unverified one, covering
  any standard library consumers (urllib, etc.)
- httpx.Client and httpx.AsyncClient are monkey-patched with subclasses
  that default verify=False, covering the OpenAI SDK's sync and async
  transport paths.

No behaviour change when the environment variable is absent or set to
any value other than 0.

Testing
-------
Verified against an on-prem vLLM instance with a self-signed certificate
using both the chat and completions endpoints.

Notes
-----
This bypass is intended for internal/development environments only and
should never be enabled in production against public endpoints.