### PR TITLE
chore: bump version to 1.8.2

### DIFF
--- a/geoagent/__init__.py
+++ b/geoagent/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 
 from geoagent.core.config import GeoAgentConfig
 from geoagent.core.context import GeoAgentContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GeoAgent"
-version = "1.8.1"
+version = "1.8.2"
 description = "Centralized AI agent framework for Open Geospatial Python packages and QGIS plugins (Strands Agents)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -79,7 +79,7 @@ exclude = ["docs*", "tests*", "examples*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "1.8.1"
+current_version = "1.8.2"
 commit = true
 tag = true
 

--- a/qgis_geoagent/open_geoagent/metadata.txt
+++ b/qgis_geoagent/open_geoagent/metadata.txt
@@ -3,7 +3,7 @@ name=OpenGeoAgent
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAgent-powered multimodal AI chatbot for QGIS projects.
-version=1.8.1
+version=1.8.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.8.2 - Patch release
+        - Raised package and plugin version metadata to 1.8.2
+
     1.8.1 - Patch release
         - Raised package and plugin version metadata to 1.8.1
 


### PR DESCRIPTION
## Summary
- Bump the package version to 1.8.2 in pyproject.toml and geoagent/__init__.py
- Bump the OpenGeoAgent QGIS plugin version to 1.8.2 in metadata.txt and add a changelog entry

## Test plan
- [ ] pre-commit run --all-files passes
- [ ] Version strings read 1.8.2 in pyproject.toml, geoagent/__init__.py, and metadata.txt