### PR TITLE
fix(qgis): sync provider credentials across docks

### DIFF
--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -433,6 +433,11 @@ def _max_tokens_to_display(value):
 
 def _apply_environment_from_settings(settings):
     """Apply provider credentials from QSettings to the current QGIS process."""
+    # The settings and chat docks keep separate QSettings instances.
+    sync = getattr(settings, "sync", None)
+    if callable(sync):
+        sync()
+
     # Mapping of QSettings key names to environment variable names. The strings
     # are identifiers, not credentials; the actual values are read from QSettings
     # at runtime. ``# pragma: allowlist secret`` silences detect-secrets keyword

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -80,6 +80,10 @@ ENV_FALLBACKS = {
 
 def _apply_environment_from_settings(settings):
     """Apply saved provider credentials to the current process."""
+    sync = getattr(settings, "sync", None)
+    if callable(sync):
+        sync()
+
     for key, env_names in ENV_FALLBACKS.items():
         value = settings.value(f"{SETTINGS_PREFIX}{key}", "", type=str).strip()
         if not value:
@@ -1151,6 +1155,7 @@ class SettingsDockWidget(QDockWidget):
                 # secret to QSettings.
                 continue
             self.settings.setValue(f"{SETTINGS_PREFIX}{key}", current)
+        _apply_environment_from_settings(self.settings)
         self.status_label.setText("Settings saved")
         self.status_label.setStyleSheet("color: green; font-size: 10px;")
         self.iface.messageBar().pushSuccess("OpenGeoAgent", "Settings saved.")

--- a/qgis_geoagent/tests/test_chat_tool_inputs.py
+++ b/qgis_geoagent/tests/test_chat_tool_inputs.py
@@ -44,6 +44,19 @@ class _FakeSettings:
         return self.values.get(key, default)
 
 
+class _SyncingSettings(_FakeSettings):
+    """Expose pending values only after the consumer synchronizes settings."""
+
+    def __init__(self, pending):
+        super().__init__()
+        self.pending = dict(pending)
+        self.sync_calls = 0
+
+    def sync(self):
+        self.sync_calls += 1
+        self.values.update(self.pending)
+
+
 def _qimage_format(name):
     """Return QImage format across PyQt enum API variants."""
     container = getattr(QImage, "Format", QImage)
@@ -100,6 +113,30 @@ def test_apply_environment_sets_openrouter_values(monkeypatch) -> None:
 
     assert os.environ["OPENROUTER_BASE_URL"] == "https://openrouter.test/v1"
     assert os.environ["OPENROUTER_API_KEY"] == "test-key"
+
+
+def test_apply_environment_syncs_credentials_saved_by_settings_dock(
+    monkeypatch,
+) -> None:
+    """Chat reads provider values written through another QSettings instance."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    settings = _SyncingSettings(
+        {
+            f"{SETTINGS_PREFIX}gemini_api_key": "test-key",
+            f"{SETTINGS_PREFIX}ollama_host": "http://192.168.0.177:11434",
+        }
+    )
+
+    _apply_environment_from_settings(settings)
+
+    import os
+
+    assert settings.sync_calls == 1
+    assert os.environ["GEMINI_API_KEY"] == "test-key"
+    assert os.environ["GOOGLE_API_KEY"] == "test-key"
+    assert os.environ["OLLAMA_HOST"] == "http://192.168.0.177:11434"
 
 
 def test_conversation_markdown_includes_full_history() -> None:


### PR DESCRIPTION
Fixes #117

## Summary
- synchronize QSettings before the chat dock exports provider credentials and hosts
- apply freshly saved settings to the current QGIS process immediately
- add a regression test covering a Gemini API key and Ollama host written by another settings instance

## Testing
- `5 passed` in focused QGIS credential/environment tests
- `65 passed, 1 deselected` across `test_chat_tool_inputs.py` and `test_settings_diagnostics.py` (the deselected existing test requires a generated image file at a fixed `/tmp` path)
- `20 passed` in `tests/test_model_providers.py`
- `ruff check` on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured saved provider credentials and configuration values are immediately applied after saving settings.
  * Improved synchronization of settings before loading credentials, preventing stale values from being used.
  * Updated environment-based configuration handling for more reliable provider access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->