### PR TITLE
feat: add MiniMax image generation backend to generate_image

### DIFF
--- a/geoagent/tools/images.py
+++ b/geoagent/tools/images.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,15 @@ MINIMAX_DEFAULT_RESPONSE_FORMAT = "url"
 MINIMAX_MIN_DIMENSION = 512
 MINIMAX_MAX_DIMENSION = 2048
 MINIMAX_MAX_IMAGES = 9
+# MiniMax returns JPEG bytes for ``response_format="base64"``.
+MINIMAX_DEFAULT_IMAGE_FORMAT = ("jpg", "image/jpeg")
+
+IMAGE_SIGNATURES = (
+    (b"\x89PNG\r\n\x1a\n", "png", "image/png"),
+    (b"\xff\xd8\xff", "jpg", "image/jpeg"),
+    (b"GIF87a", "gif", "image/gif"),
+    (b"GIF89a", "gif", "image/gif"),
+)
 
 
 def _output_dir(output_dir: str | None = None) -> Path:
@@ -65,6 +75,16 @@ def _safe_image_stem(value: str | None = None) -> str:
     if not text:
         text = "geoagent_image"
     return text[:60]
+
+
+def _image_format(image_bytes: bytes, default: tuple[str, str]) -> tuple[str, str]:
+    """Return the ``(extension, mime_type)`` implied by the image bytes."""
+    for signature, extension, mime_type in IMAGE_SIGNATURES:
+        if image_bytes.startswith(signature):
+            return extension, mime_type
+    if image_bytes[:4] == b"RIFF" and image_bytes[8:12] == b"WEBP":
+        return "webp", "image/webp"
+    return default
 
 
 def _response_data_items(response: Any) -> list[Any]:
@@ -136,7 +156,7 @@ def _minimax_image_enabled() -> bool:
 def _minimax_image_endpoint() -> str:
     """Return the MiniMax image generation endpoint for the active region."""
     explicit = os.environ.get("MINIMAX_IMAGE_ENDPOINT", "").strip()
-    if explicit:
+    if explicit and urllib.parse.urlparse(explicit).scheme in ("http", "https"):
         return explicit
     region = os.environ.get("MINIMAX_API_REGION", "").strip().lower()
     return MINIMAX_IMAGE_ENDPOINTS.get(
@@ -207,8 +227,12 @@ def _post_minimax_image(
             "Content-Type": "application/json",
         },
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        return response.read()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace").strip()
+        raise urllib.error.URLError(f"HTTP {exc.code}: {detail or exc.reason}") from exc
 
 
 def _generate_minimax_image(
@@ -301,16 +325,17 @@ def _generate_minimax_image(
         except (binascii.Error, ValueError) as exc:
             decode_errors.append(f"item {index}: {exc}")
             continue
+        extension, mime_type = _image_format(image_bytes, MINIMAX_DEFAULT_IMAGE_FORMAT)
         stem = _safe_image_stem(prompt)
         suffix = time.strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"{stem}-{suffix}-{index}.png"
+        path = out_dir / f"{stem}-{suffix}-{index}.{extension}"
         with open(path, "wb") as f:
             f.write(image_bytes)
         images.append(
             {
                 "path": str(path),
-                "format": "png",
-                "mime_type": "image/png",
+                "format": extension,
+                "mime_type": mime_type,
                 "revised_prompt": "",
             }
         )
@@ -385,10 +410,15 @@ def image_generation_tools() -> list[Any]:
 
         Args:
             prompt: Visual description of the image to generate.
-            size: One of 1024x1024, 1024x1536, 1536x1024, or auto.
-            quality: One of low, medium, high, or auto.
+            size: One of 1024x1024, 1024x1536, 1536x1024, or auto. On the
+                MiniMax path each dimension must be 512-2048 and divisible
+                by 8, and is ignored when ``aspect_ratio`` is set.
+            quality: One of low, medium, high, or auto. Ignored by MiniMax.
             model: Image model to use. Defaults to ``GEOAGENT_IMAGE_MODEL``
-                when set, otherwise the backend default.
+                when set, otherwise the backend default. MiniMax is used only
+                when no model is requested or the requested model is a
+                MiniMax model, so an explicit OpenAI model still reaches
+                OpenAI.
             output_dir: Optional directory for the generated image.
             aspect_ratio: MiniMax aspect ratio (for example ``1:1`` or
                 ``16:9``). When set it takes priority over ``size``.
@@ -406,7 +436,13 @@ def image_generation_tools() -> list[Any]:
         prompt = str(prompt or "").strip()
         if not prompt:
             return {"success": False, "error": "Image prompt is empty."}
-        if _minimax_image_enabled():
+        selected_model = (
+            str(model or "").strip()
+            or os.environ.get("GEOAGENT_IMAGE_MODEL", "").strip()
+        )
+        if _minimax_image_enabled() and (
+            not selected_model or selected_model in MINIMAX_IMAGE_MODELS
+        ):
             return _generate_minimax_image(
                 prompt=prompt,
                 size=size,

--- a/geoagent/tools/images.py
+++ b/geoagent/tools/images.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import base64
 import binascii
+import json
 import os
 import tempfile
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +22,29 @@ DEFAULT_IMAGE_QUALITY = "low"
 DEFAULT_IMAGE_TIMEOUT = 180.0
 SUPPORTED_IMAGE_SIZES = {"1024x1024", "1024x1536", "1536x1024", "auto"}
 SUPPORTED_IMAGE_QUALITIES = {"low", "medium", "high", "auto"}
+
+MINIMAX_DEFAULT_IMAGE_MODEL = "image-01"
+MINIMAX_IMAGE_MODELS = {"image-01", "image-01-live"}
+MINIMAX_IMAGE_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/image_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/image_generation",
+}
+MINIMAX_DEFAULT_REGION = "global_en"
+MINIMAX_ASPECT_RATIOS = {
+    "1:1",
+    "16:9",
+    "4:3",
+    "3:2",
+    "2:3",
+    "3:4",
+    "9:16",
+    "21:9",
+}
+MINIMAX_RESPONSE_FORMATS = {"url", "base64"}
+MINIMAX_DEFAULT_RESPONSE_FORMAT = "url"
+MINIMAX_MIN_DIMENSION = 512
+MINIMAX_MAX_DIMENSION = 2048
+MINIMAX_MAX_IMAGES = 9
 
 
 def _output_dir(output_dir: str | None = None) -> Path:
@@ -102,13 +128,240 @@ def _generate_openai_image(
     )
 
 
+def _minimax_image_enabled() -> bool:
+    """Return True when a MiniMax API key is configured."""
+    return bool(os.environ.get("MINIMAX_API_KEY", "").strip())
+
+
+def _minimax_image_endpoint() -> str:
+    """Return the MiniMax image generation endpoint for the active region."""
+    explicit = os.environ.get("MINIMAX_IMAGE_ENDPOINT", "").strip()
+    if explicit:
+        return explicit
+    region = os.environ.get("MINIMAX_API_REGION", "").strip().lower()
+    return MINIMAX_IMAGE_ENDPOINTS.get(
+        region, MINIMAX_IMAGE_ENDPOINTS[MINIMAX_DEFAULT_REGION]
+    )
+
+
+def _minimax_image_model(model: str) -> str:
+    """Resolve the MiniMax image model from the argument or environment."""
+    requested = str(model or "").strip()
+    if requested in MINIMAX_IMAGE_MODELS:
+        return requested
+    configured = os.environ.get("GEOAGENT_IMAGE_MODEL", "").strip()
+    if configured in MINIMAX_IMAGE_MODELS:
+        return configured
+    return MINIMAX_DEFAULT_IMAGE_MODEL
+
+
+def _minimax_response_format(response_format: str) -> str:
+    """Resolve the MiniMax response format (``url`` or ``base64``)."""
+    requested = str(response_format or "").strip().lower()
+    if requested in MINIMAX_RESPONSE_FORMATS:
+        return requested
+    configured = os.environ.get("MINIMAX_IMAGE_RESPONSE_FORMAT", "").strip().lower()
+    if configured in MINIMAX_RESPONSE_FORMATS:
+        return configured
+    return MINIMAX_DEFAULT_RESPONSE_FORMAT
+
+
+def _minimax_dimensions(size: str) -> tuple[int, int] | None:
+    """Parse a ``WIDTHxHEIGHT`` string into MiniMax-compatible dimensions."""
+    text = str(size or "").strip().lower()
+    if "x" not in text:
+        return None
+    width_text, _, height_text = text.partition("x")
+    try:
+        width = int(width_text)
+        height = int(height_text)
+    except ValueError:
+        return None
+    for value in (width, height):
+        if (
+            value < MINIMAX_MIN_DIMENSION
+            or value > MINIMAX_MAX_DIMENSION
+            or value % 8 != 0
+        ):
+            return None
+    return width, height
+
+
+def _minimax_status_code(base_resp: Any) -> Any:
+    """Read ``base_resp.status_code`` from the MiniMax response."""
+    if isinstance(base_resp, dict):
+        return base_resp.get("status_code")
+    return getattr(base_resp, "status_code", None)
+
+
+def _post_minimax_image(
+    endpoint: str, api_key: str, payload: dict[str, Any], timeout: float
+) -> bytes:
+    """POST a JSON payload to the MiniMax image endpoint and return the body."""
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def _generate_minimax_image(
+    *,
+    prompt: str,
+    size: str,
+    model: str,
+    output_dir: str,
+    aspect_ratio: str,
+    response_format: str,
+    seed: int,
+    n: int,
+    prompt_optimizer: bool,
+    subject_reference: str,
+) -> dict[str, Any]:
+    """Generate an image with the MiniMax image generation endpoint."""
+    api_key = os.environ.get("MINIMAX_API_KEY", "").strip()
+    endpoint = _minimax_image_endpoint()
+    resolved_model = _minimax_image_model(model)
+    fmt = _minimax_response_format(response_format)
+    count = n if isinstance(n, int) and 1 <= n <= MINIMAX_MAX_IMAGES else 1
+
+    payload: dict[str, Any] = {
+        "model": resolved_model,
+        "prompt": prompt,
+        "response_format": fmt,
+        "n": count,
+    }
+    ratio = str(aspect_ratio or "").strip()
+    if ratio in MINIMAX_ASPECT_RATIOS:
+        payload["aspect_ratio"] = ratio
+    else:
+        dimensions = _minimax_dimensions(size)
+        if dimensions is not None:
+            payload["width"], payload["height"] = dimensions
+    if isinstance(seed, int) and seed > 0:
+        payload["seed"] = seed
+    if prompt_optimizer:
+        payload["prompt_optimizer"] = True
+    reference = str(subject_reference or "").strip()
+    if reference:
+        payload["subject_reference"] = [{"type": "character", "image_file": reference}]
+
+    timeout = _image_timeout()
+    try:
+        raw = _post_minimax_image(endpoint, api_key, payload, timeout)
+    except (urllib.error.URLError, OSError) as exc:
+        return {
+            "success": False,
+            "error": (
+                f"Image generation request failed with {resolved_model} "
+                f"within {timeout:g}s: {exc}"
+            ),
+            "model": resolved_model,
+            "timeout": timeout,
+        }
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        return {
+            "success": False,
+            "error": f"The image API returned an unreadable response: {exc}",
+            "model": resolved_model,
+        }
+
+    status_code = _minimax_status_code(data.get("base_resp"))
+    if status_code not in (0, "0"):
+        base_resp = data.get("base_resp") or {}
+        status_msg = ""
+        if isinstance(base_resp, dict):
+            status_msg = str(base_resp.get("status_msg") or "")
+        return {
+            "success": False,
+            "error": (
+                f"Image generation failed (status_code {status_code})"
+                + (f": {status_msg}" if status_msg else ".")
+            ),
+            "model": resolved_model,
+            "status_code": status_code,
+        }
+
+    payload_data = data.get("data") or {}
+    out_dir = _output_dir(output_dir or None)
+    images: list[dict[str, Any]] = []
+    decode_errors: list[str] = []
+    for index, value in enumerate(payload_data.get("image_base64") or [], start=1):
+        try:
+            image_bytes = base64.b64decode(str(value), validate=True)
+        except (binascii.Error, ValueError) as exc:
+            decode_errors.append(f"item {index}: {exc}")
+            continue
+        stem = _safe_image_stem(prompt)
+        suffix = time.strftime("%Y%m%d-%H%M%S")
+        path = out_dir / f"{stem}-{suffix}-{index}.png"
+        with open(path, "wb") as f:
+            f.write(image_bytes)
+        images.append(
+            {
+                "path": str(path),
+                "format": "png",
+                "mime_type": "image/png",
+                "revised_prompt": "",
+            }
+        )
+    for value in payload_data.get("image_urls") or []:
+        if value:
+            images.append(
+                {
+                    "url": str(value),
+                    "format": "url",
+                    "mime_type": "",
+                    "revised_prompt": "",
+                }
+            )
+
+    if not images:
+        error_message = "The image API response did not include an image."
+        if decode_errors:
+            error_message = (
+                "The image API returned invalid base64 payload(s): "
+                + "; ".join(decode_errors)
+            )
+        return {
+            "success": False,
+            "error": error_message,
+            "model": resolved_model,
+        }
+
+    metadata = data.get("metadata") or {}
+    return {
+        "success": True,
+        "prompt": prompt,
+        "model": resolved_model,
+        "requested_model": resolved_model,
+        "response_format": fmt,
+        "timeout": timeout,
+        "images": images,
+        "path": images[0].get("path", ""),
+        "url": images[0].get("url", ""),
+        "success_count": metadata.get("success_count"),
+        "failed_count": metadata.get("failed_count"),
+        "message": f"Generated {len(images)} image(s).",
+    }
+
+
 def image_generation_tools() -> list[Any]:
     """Return tools for generating standalone image files."""
 
     @geo_tool(
         category="image_generation",
         description=(
-            "Generate an image from a text prompt using the OpenAI Images API. "
+            "Generate an image from a text prompt. "
             "Use this when the user asks to create, draw, render, or generate "
             "a picture."
         ),
@@ -121,6 +374,12 @@ def image_generation_tools() -> list[Any]:
         quality: str = DEFAULT_IMAGE_QUALITY,
         model: str = "",
         output_dir: str = "",
+        aspect_ratio: str = "",
+        response_format: str = "",
+        seed: int = 0,
+        n: int = 1,
+        prompt_optimizer: bool = False,
+        subject_reference: str = "",
     ) -> dict[str, Any]:
         """Generate an image file from a text prompt.
 
@@ -128,9 +387,17 @@ def image_generation_tools() -> list[Any]:
             prompt: Visual description of the image to generate.
             size: One of 1024x1024, 1024x1536, 1536x1024, or auto.
             quality: One of low, medium, high, or auto.
-            model: OpenAI image model to use. Defaults to
-                ``GEOAGENT_IMAGE_MODEL`` when set, otherwise gpt-image-2.
+            model: Image model to use. Defaults to ``GEOAGENT_IMAGE_MODEL``
+                when set, otherwise the backend default.
             output_dir: Optional directory for the generated image.
+            aspect_ratio: MiniMax aspect ratio (for example ``1:1`` or
+                ``16:9``). When set it takes priority over ``size``.
+            response_format: MiniMax output format, ``url`` or ``base64``.
+            seed: Optional MiniMax random seed for reproducible images.
+            n: Number of MiniMax images to generate (1-9).
+            prompt_optimizer: Enable MiniMax automatic prompt optimization.
+            subject_reference: Optional MiniMax character reference image
+                (URL or base64) to keep a consistent subject.
 
         Returns:
             A JSON-friendly result containing local image file paths and image
@@ -139,6 +406,19 @@ def image_generation_tools() -> list[Any]:
         prompt = str(prompt or "").strip()
         if not prompt:
             return {"success": False, "error": "Image prompt is empty."}
+        if _minimax_image_enabled():
+            return _generate_minimax_image(
+                prompt=prompt,
+                size=size,
+                model=model,
+                output_dir=output_dir,
+                aspect_ratio=aspect_ratio,
+                response_format=response_format,
+                seed=seed,
+                n=n,
+                prompt_optimizer=prompt_optimizer,
+                subject_reference=subject_reference,
+            )
         if not os.environ.get("OPENAI_API_KEY"):
             return {
                 "success": False,

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 import sys
 import types
+import urllib.error
 import urllib.request
 
 from geoagent.tools.images import image_generation_tools
@@ -15,6 +17,19 @@ def _get_generate_image():
     """Return the ``generate_image`` tool callable."""
     tools = {item.tool_name: item for item in image_generation_tools()}
     return tools["generate_image"]
+
+
+def _use_minimax_env(monkeypatch):
+    """Configure a hermetic MiniMax-only environment for a test."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    for name in (
+        "MINIMAX_API_REGION",
+        "MINIMAX_IMAGE_ENDPOINT",
+        "MINIMAX_IMAGE_RESPONSE_FORMAT",
+        "GEOAGENT_IMAGE_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _stub_minimax_urlopen(monkeypatch, response_body, captured):
@@ -52,9 +67,7 @@ def test_generate_image_uses_minimax_url_response(monkeypatch) -> None:
         "metadata": {"success_count": "1", "failed_count": "0"},
         "base_resp": {"status_code": 0, "status_msg": "success"},
     }
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
-    monkeypatch.delenv("MINIMAX_API_REGION", raising=False)
+    _use_minimax_env(monkeypatch)
     _stub_minimax_urlopen(monkeypatch, body, captured)
 
     result = _get_generate_image().__wrapped__(
@@ -80,13 +93,13 @@ def test_generate_image_uses_minimax_url_response(monkeypatch) -> None:
 def test_generate_image_writes_minimax_base64_bytes(monkeypatch, tmp_path) -> None:
     """Verify MiniMax base64 responses are decoded and written to files."""
     captured: dict = {}
-    image_payload = base64.b64encode(b"minimax-png").decode("ascii")
+    image_bytes = b"\x89PNG\r\n\x1a\nminimax"
     body = {
-        "data": {"image_base64": [image_payload]},
+        "data": {"image_base64": [base64.b64encode(image_bytes).decode("ascii")]},
         "metadata": {"success_count": 1, "failed_count": 0},
         "base_resp": {"status_code": 0, "status_msg": "success"},
     }
-    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    _use_minimax_env(monkeypatch)
     _stub_minimax_urlopen(monkeypatch, body, captured)
 
     result = _get_generate_image().__wrapped__(
@@ -100,9 +113,32 @@ def test_generate_image_writes_minimax_base64_bytes(monkeypatch, tmp_path) -> No
     assert result["model"] == "image-01-live"
     path = result["images"][0]["path"]
     assert path.endswith(".png")
+    assert result["images"][0]["mime_type"] == "image/png"
     filename = path.split("/")[-1]
-    assert (tmp_path / filename).read_bytes() == b"minimax-png"
+    assert (tmp_path / filename).read_bytes() == image_bytes
     assert captured["payload"]["response_format"] == "base64"
+
+
+def test_generate_image_minimax_base64_defaults_to_jpeg(monkeypatch, tmp_path) -> None:
+    """Verify MiniMax base64 bytes are saved with their sniffed image format."""
+    captured: dict = {}
+    image_bytes = b"\xff\xd8\xff\xe0minimax"
+    body = {
+        "data": {"image_base64": [base64.b64encode(image_bytes).decode("ascii")]},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    _use_minimax_env(monkeypatch)
+    _stub_minimax_urlopen(monkeypatch, body, captured)
+
+    result = _get_generate_image().__wrapped__(
+        "orange tabby cat",
+        output_dir=str(tmp_path),
+        response_format="base64",
+    )
+
+    assert result["success"] is True
+    assert result["images"][0]["path"].endswith(".jpg")
+    assert result["images"][0]["mime_type"] == "image/jpeg"
 
 
 def test_generate_image_minimax_cn_region_endpoint(monkeypatch) -> None:
@@ -112,7 +148,7 @@ def test_generate_image_minimax_cn_region_endpoint(monkeypatch) -> None:
         "data": {"image_urls": ["https://example.com/b.png"]},
         "base_resp": {"status_code": 0, "status_msg": "success"},
     }
-    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    _use_minimax_env(monkeypatch)
     monkeypatch.setenv("MINIMAX_API_REGION", "cn_zh")
     _stub_minimax_urlopen(monkeypatch, body, captured)
 
@@ -122,6 +158,23 @@ def test_generate_image_minimax_cn_region_endpoint(monkeypatch) -> None:
     assert captured["url"] == "https://api.minimaxi.com/v1/image_generation"
 
 
+def test_generate_image_minimax_rejects_non_http_endpoint(monkeypatch) -> None:
+    """Verify a non-http endpoint override falls back to the region default."""
+    captured: dict = {}
+    body = {
+        "data": {"image_urls": ["https://example.com/c.png"]},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    _use_minimax_env(monkeypatch)
+    monkeypatch.setenv("MINIMAX_IMAGE_ENDPOINT", "file:///etc/passwd")
+    _stub_minimax_urlopen(monkeypatch, body, captured)
+
+    result = _get_generate_image().__wrapped__("a salt flat")
+
+    assert result["success"] is True
+    assert captured["url"] == "https://api.minimax.io/v1/image_generation"
+
+
 def test_generate_image_minimax_reports_status_error(monkeypatch) -> None:
     """Verify a non-zero base_resp status_code is surfaced as an error."""
     captured: dict = {}
@@ -129,7 +182,7 @@ def test_generate_image_minimax_reports_status_error(monkeypatch) -> None:
         "data": {},
         "base_resp": {"status_code": 1004, "status_msg": "authentication failed"},
     }
-    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    _use_minimax_env(monkeypatch)
     _stub_minimax_urlopen(monkeypatch, body, captured)
 
     result = _get_generate_image().__wrapped__("a coastline")
@@ -137,6 +190,63 @@ def test_generate_image_minimax_reports_status_error(monkeypatch) -> None:
     assert result["success"] is False
     assert result["status_code"] == 1004
     assert "authentication failed" in result["error"]
+
+
+def test_generate_image_minimax_surfaces_http_error_body(monkeypatch) -> None:
+    """Verify the MiniMax HTTP error payload is included in the error text."""
+
+    def _fake_urlopen(request, timeout=None):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            429,
+            "Too Many Requests",
+            {},
+            io.BytesIO(b'{"base_resp":{"status_msg":"rate limit reached"}}'),
+        )
+
+    _use_minimax_env(monkeypatch)
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    result = _get_generate_image().__wrapped__("a glacier")
+
+    assert result["success"] is False
+    assert "HTTP 429" in result["error"]
+    assert "rate limit reached" in result["error"]
+
+
+def test_generate_image_explicit_openai_model_bypasses_minimax(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify an explicit OpenAI model still reaches OpenAI when MiniMax is set."""
+    image_payload = base64.b64encode(b"fake-png").decode("ascii")
+    calls: dict = {}
+
+    class _Images:
+        def generate(self, **kwargs):
+            calls.update(kwargs)
+            item = types.SimpleNamespace(
+                b64_json=image_payload,
+                revised_prompt="",
+                url=None,
+            )
+            return types.SimpleNamespace(data=[item])
+
+    class _Client:
+        def __init__(self, **kwargs) -> None:
+            self.images = _Images()
+
+    _use_minimax_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))
+
+    result = _get_generate_image().__wrapped__(
+        "a fjord",
+        model="gpt-image-1",
+        output_dir=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert calls["model"] == "gpt-image-1"
 
 
 def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None:

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -3,10 +3,140 @@
 from __future__ import annotations
 
 import base64
+import json
 import sys
 import types
+import urllib.request
 
 from geoagent.tools.images import image_generation_tools
+
+
+def _get_generate_image():
+    """Return the ``generate_image`` tool callable."""
+    tools = {item.tool_name: item for item in image_generation_tools()}
+    return tools["generate_image"]
+
+
+def _stub_minimax_urlopen(monkeypatch, response_body, captured):
+    """Patch ``urlopen`` to capture the request and return ``response_body``."""
+
+    class _Response:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self._body
+
+    def _fake_urlopen(request, timeout=None):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(request.header_items())
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return _Response(json.dumps(response_body).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+
+def test_generate_image_uses_minimax_url_response(monkeypatch) -> None:
+    """Verify MiniMax URL responses return image links from image_urls."""
+    captured: dict = {}
+    body = {
+        "id": "trace-id",
+        "data": {"image_urls": ["https://example.com/a.png"]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.delenv("MINIMAX_API_REGION", raising=False)
+    _stub_minimax_urlopen(monkeypatch, body, captured)
+
+    result = _get_generate_image().__wrapped__(
+        "a mountain landscape",
+        aspect_ratio="16:9",
+        prompt_optimizer=True,
+    )
+
+    assert result["success"] is True
+    assert result["model"] == "image-01"
+    assert result["images"][0]["url"] == "https://example.com/a.png"
+    assert result["success_count"] == "1"
+    assert captured["url"] == "https://api.minimax.io/v1/image_generation"
+    assert captured["payload"]["model"] == "image-01"
+    assert captured["payload"]["prompt"] == "a mountain landscape"
+    assert captured["payload"]["aspect_ratio"] == "16:9"
+    assert captured["payload"]["prompt_optimizer"] is True
+    assert captured["payload"]["response_format"] == "url"
+    header_keys = {key.lower(): value for key, value in captured["headers"].items()}
+    assert header_keys["authorization"] == "Bearer test-key"
+
+
+def test_generate_image_writes_minimax_base64_bytes(monkeypatch, tmp_path) -> None:
+    """Verify MiniMax base64 responses are decoded and written to files."""
+    captured: dict = {}
+    image_payload = base64.b64encode(b"minimax-png").decode("ascii")
+    body = {
+        "data": {"image_base64": [image_payload]},
+        "metadata": {"success_count": 1, "failed_count": 0},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    _stub_minimax_urlopen(monkeypatch, body, captured)
+
+    result = _get_generate_image().__wrapped__(
+        "orange tabby cat",
+        output_dir=str(tmp_path),
+        response_format="base64",
+        model="image-01-live",
+    )
+
+    assert result["success"] is True
+    assert result["model"] == "image-01-live"
+    path = result["images"][0]["path"]
+    assert path.endswith(".png")
+    filename = path.split("/")[-1]
+    assert (tmp_path / filename).read_bytes() == b"minimax-png"
+    assert captured["payload"]["response_format"] == "base64"
+
+
+def test_generate_image_minimax_cn_region_endpoint(monkeypatch) -> None:
+    """Verify the CN region selects the minimaxi endpoint host."""
+    captured: dict = {}
+    body = {
+        "data": {"image_urls": ["https://example.com/b.png"]},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setenv("MINIMAX_API_REGION", "cn_zh")
+    _stub_minimax_urlopen(monkeypatch, body, captured)
+
+    result = _get_generate_image().__wrapped__("a river delta")
+
+    assert result["success"] is True
+    assert captured["url"] == "https://api.minimaxi.com/v1/image_generation"
+
+
+def test_generate_image_minimax_reports_status_error(monkeypatch) -> None:
+    """Verify a non-zero base_resp status_code is surfaced as an error."""
+    captured: dict = {}
+    body = {
+        "data": {},
+        "base_resp": {"status_code": 1004, "status_msg": "authentication failed"},
+    }
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    _stub_minimax_urlopen(monkeypatch, body, captured)
+
+    result = _get_generate_image().__wrapped__("a coastline")
+
+    assert result["success"] is False
+    assert result["status_code"] == 1004
+    assert "authentication failed" in result["error"]
 
 
 def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None:
@@ -30,6 +160,7 @@ def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None
             self.images = _Images()
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))
 
     tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
@@ -52,6 +183,7 @@ def test_generate_image_writes_openai_image_bytes(monkeypatch, tmp_path) -> None
 def test_generate_image_reports_missing_api_key(monkeypatch) -> None:
     """Verify image generation gives a clear setup error without API key."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
 
     tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
     result = tool.__wrapped__("orange tabby cat")
@@ -87,6 +219,7 @@ def test_generate_image_falls_back_on_unverified_gpt_image_2(
             self.images = _Images()
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))
 
     tool = {item.tool_name: item for item in image_generation_tools()}["generate_image"]
@@ -122,6 +255,7 @@ def test_generate_image_uses_configured_model_and_timeout(
             self.images = _Images()
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.setenv("GEOAGENT_IMAGE_MODEL", "gpt-image-1")
     monkeypatch.setenv("GEOAGENT_IMAGE_TIMEOUT", "5")
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_Client))


### PR DESCRIPTION
Reason: The generate_image tool was hard-wired to one image backend and could not use the MiniMax /v1/image_generation endpoints, image-01 models, request fields, or response schema.

## What changed

`generate_image` now routes to the MiniMax image generation endpoint when a
`MINIMAX_API_KEY` is configured, while the existing behaviour is unchanged when
it is not set.

- Adds MiniMax global (`api.minimax.io`) and CN (`api.minimaxi.com`)
  `/v1/image_generation` endpoints, selected via `MINIMAX_API_REGION`
  (`global_en` default / `cn_zh`) with an optional `MINIMAX_IMAGE_ENDPOINT`
  override.
- Supports the `image-01` and `image-01-live` models (default `image-01`),
  resolved from the `model` argument or `GEOAGENT_IMAGE_MODEL`.
- Sends the documented request fields: `model`, `prompt`, `aspect_ratio`
  (or `width`/`height` derived from `size`), `response_format` (`url` or
  `base64`), `seed`, `n`, `prompt_optimizer`, and `subject_reference`.
- Parses the response schema: `data.image_urls` and `data.image_base64`,
  `metadata.success_count` / `failed_count`, and surfaces
  `base_resp.status_code` (with `status_msg`) for non-zero error codes.
- Base64 images are decoded and written to files; URL images (24h TTL) are
  returned as links, keeping the existing `images` result shape the UI renders.

New optional `generate_image` parameters (`aspect_ratio`, `response_format`,
`seed`, `n`, `prompt_optimizer`, `subject_reference`) default to no-ops so
existing callers are unaffected.

## Checks

- `python -m pytest tests/test_image_tools.py -q` — 8 passed
- `python -m pytest tests/test_geoagent_chat_mock.py tests/test_ui_app.py tests/test_model_providers.py -q` — 45 passed
- `python -m black --check geoagent/tools/images.py tests/test_image_tools.py` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax image generation alongside the existing provider.
  * Supports configurable aspect ratios, response formats, image counts, seeds, prompt optimization, and subject references.
  * Handles image URLs and base64-encoded responses, with optional file output and automatic image-format detection.
  * Supports regional endpoints and clear provider error reporting.
  * Preserves explicit selection of the existing provider when requested.

* **Tests**
  * Added coverage for MiniMax responses, regional routing, format handling, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->