### PR TITLE
fix: require openai>=2.0 and add a generic OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Many geospatial libraries need the same agent features:
 - bind an agent to a live map, QGIS session, dataset, or workflow object;
 - expose package functions as structured tools with docstrings and metadata;
 - support OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Bedrock,
-  OpenRouter, LiteLLM, vLLM, and local Ollama models;
+  OpenRouter, LiteLLM, any OpenAI-compatible server, vLLM, and local
+  Ollama models;
 - keep optional geospatial stacks optional;
 - ask for confirmation before deleting layers, saving files, or running
   expensive processing jobs;
@@ -84,7 +85,8 @@ and `pydantic`. Geospatial packages and provider clients are optional extras:
 | `GeoAgent[ollama]`      | Local Ollama model support.                                       |
 | `GeoAgent[litellm]`     | LiteLLM model support for many hosted and proxy providers.        |
 | `GeoAgent[openrouter]`  | OpenRouter support for DeepSeek, Qwen, and other hosted models.   |
-| `GeoAgent[vllm]`        | vLLM server support through the Strands community provider.       |
+| `GeoAgent[openai-compatible]` | Any OpenAI-compatible server, e.g. llama.cpp, LM Studio, vLLM. |
+| `GeoAgent[vllm]`        | vLLM through the Strands community provider. Not in `providers`/`all`; see note below. |
 | `GeoAgent[leafmap]`     | leafmap live map integration.                                     |
 | `GeoAgent[anymap]`      | anymap live map integration.                                      |
 | `GeoAgent[stac]`        | STAC client dependencies.                                         |
@@ -94,7 +96,7 @@ and `pydantic`. Geospatial packages and provider clients are optional extras:
 | `GeoAgent[earthengine]` | Google Earth Engine dependencies.                                 |
 | `GeoAgent[ui]`          | Solara UI dependencies.                                           |
 | `GeoAgent[browser]`     | FastAPI WebSocket backend for browser MapLibre apps.              |
-| `GeoAgent[providers]`   | OpenAI, Anthropic, Gemini, Ollama, LiteLLM, OpenRouter, and vLLM clients. |
+| `GeoAgent[providers]`   | OpenAI, Anthropic, Gemini, Ollama, LiteLLM, OpenRouter, and OpenAI-compatible clients. |
 | `GeoAgent[all]`         | Most optional integrations. QGIS itself remains system-installed. |
 
 Examples:
@@ -122,6 +124,7 @@ specified:
 | Google Gemini       | `GEMINI_API_KEY` or `GOOGLE_API_KEY`, optional `GEMINI_MODEL`      |
 | LiteLLM             | `LITELLM_API_KEY`, optional `LITELLM_MODEL` and `LITELLM_BASE_URL` |
 | OpenRouter          | `OPENROUTER_API_KEY`, optional `OPENROUTER_MODEL` and `OPENROUTER_BASE_URL` |
+| OpenAI-compatible   | `OPENAI_COMPATIBLE_BASE_URL`, `OPENAI_COMPATIBLE_MODEL`, optional `OPENAI_COMPATIBLE_API_KEY` |
 | vLLM                | `VLLM_BASE_URL`, `VLLM_MODEL_ID`, optional `VLLM_API_KEY`          |
 | Ollama              | `OLLAMA_HOST` or `USE_OLLAMA=1`, optional `OLLAMA_MODEL`           |
 
@@ -132,9 +135,32 @@ with optional `BEDROCK_MODEL`.
 ChatGPT/Codex OAuth uses the Codex browser login flow and the Codex Responses
 backend.
 
+The `openai-compatible` provider talks to any server that exposes the OpenAI
+Chat Completions API, including llama.cpp, LM Studio, Text Generation WebUI,
+and vLLM. Point it at the server's `/v1` URL. A model id is required because a
+generic endpoint has no default, and the API key is optional since most local
+servers ignore it:
+
+```python
+from geoagent import GeoAgent
+
+agent = GeoAgent(
+    provider="openai-compatible",
+    model="qwen3-8b",
+    openai_compatible_base_url="http://localhost:8000/v1",
+)
+```
+
 vLLM support expects a running vLLM server. When using GeoAgent tools, start
 the server with vLLM tool-calling support enabled for the selected model and
 chat template.
+
+The dedicated `vllm` provider depends on `strands-vllm`, which pins
+`openai<2.0` and therefore cannot be installed alongside the `openai>=2.0` that
+the default `openai-codex` provider requires. `GeoAgent[vllm]` is consequently
+excluded from `GeoAgent[providers]` and `GeoAgent[all]`. Prefer the
+`openai-compatible` provider pointed at your vLLM server's `/v1` URL, which
+needs no extra dependency.
 
 For notebooks and Python scripts, log in once with the CLI:
 
@@ -292,8 +318,8 @@ Anthropic, and Google Gemini providers from the browser UI.
 For a Node.js TypeScript MapLibre app that keeps model authentication on the
 server, see `examples/node_maplibre_strands_typescript/`. It supports
 the same provider ids as the GeoAgent/QGIS UI, including ChatGPT/Codex OAuth,
-OpenAI, Anthropic, Gemini, Amazon Bedrock, OpenRouter, LiteLLM, vLLM, and
-Ollama.
+OpenAI, Anthropic, Gemini, Amazon Bedrock, OpenRouter, LiteLLM, any
+OpenAI-compatible server, vLLM, and Ollama.
 
 For local sessions where you want PyQGIS-style fallback behavior, add
 `--allow-browser-code`. This exposes `run_maplibre_script`, allowing the agent

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ See it in action:
 
 - A `GeoAgent` facade around a Strands `Agent`.
 - Provider configuration for OpenAI, Anthropic, Google Gemini, Bedrock,
-  OpenRouter, LiteLLM, vLLM, and Ollama.
+  OpenRouter, LiteLLM, any OpenAI-compatible server, vLLM, and Ollama.
 - `@geo_tool` metadata for category, safety, fast-mode filtering, and optional
   dependency checks.
 - Factories for common runtime environments:
@@ -95,6 +95,7 @@ GeoAgent can infer a provider from environment variables:
 | Google Gemini       | `GEMINI_API_KEY` or `GOOGLE_API_KEY`, optional `GEMINI_MODEL`      |
 | LiteLLM             | `LITELLM_API_KEY`, optional `LITELLM_MODEL` and `LITELLM_BASE_URL` |
 | OpenRouter          | `OPENROUTER_API_KEY`, optional `OPENROUTER_MODEL` and `OPENROUTER_BASE_URL` |
+| OpenAI-compatible   | `OPENAI_COMPATIBLE_BASE_URL`, `OPENAI_COMPATIBLE_MODEL`, optional `OPENAI_COMPATIBLE_API_KEY` |
 | vLLM                | `VLLM_BASE_URL`, `VLLM_MODEL_ID`, optional `VLLM_API_KEY`          |
 | Ollama              | `OLLAMA_HOST` or `USE_OLLAMA=1`, optional `OLLAMA_MODEL`           |
 
@@ -102,9 +103,17 @@ Bedrock is not auto-detected. Pass `provider="bedrock"` explicitly; it then
 uses the AWS credential chain, configured region, and Bedrock model access,
 with optional `BEDROCK_MODEL`.
 
+The `openai-compatible` provider talks to any server exposing the OpenAI Chat
+Completions API (llama.cpp, LM Studio, Text Generation WebUI, vLLM). Point it
+at the server's `/v1` URL and supply a model id.
+
 vLLM support expects a running vLLM server. When using GeoAgent tools, start
 the server with vLLM tool-calling support enabled for the selected model and
-chat template.
+chat template. The dedicated `vllm` provider depends on `strands-vllm`, which
+pins `openai<2.0` and cannot be installed alongside the `openai>=2.0` required
+by the default `openai-codex` provider, so `GeoAgent[vllm]` is excluded from
+`GeoAgent[providers]` and `GeoAgent[all]`. The `openai-compatible` provider is
+the dependency-free alternative.
 
 Explicit configuration is also supported:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,9 +22,17 @@ pip install -e ".[dev]"
 Configure API keys via environment variables (`OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` or `GOOGLE_API_KEY`,
 `LITELLM_API_KEY`, `OPENROUTER_API_KEY`, AWS credentials for Bedrock,
-`OLLAMA_HOST`, `VLLM_BASE_URL`, `VLLM_MODEL_ID`, etc.). See `GeoAgentConfig`
-in `geoagent.core.config`.
+`OLLAMA_HOST`, `OPENAI_COMPATIBLE_BASE_URL`, `VLLM_BASE_URL`, `VLLM_MODEL_ID`,
+etc.). See `GeoAgentConfig` in `geoagent.core.config`.
 
-For vLLM, install `GeoAgent[vllm]` or `GeoAgent[providers]`, run a vLLM server
-separately, and enable vLLM tool calling on the server when using GeoAgent
-tools.
+To use any OpenAI-compatible server (llama.cpp, LM Studio, Text Generation
+WebUI, vLLM), install `GeoAgent[openai-compatible]` or `GeoAgent[providers]`
+and set `OPENAI_COMPATIBLE_BASE_URL` to the server's `/v1` URL plus
+`OPENAI_COMPATIBLE_MODEL`.
+
+The dedicated vLLM provider needs `GeoAgent[vllm]`, a separately running vLLM
+server, and vLLM tool calling enabled on the server. `strands-vllm` pins
+`openai<2.0`, which conflicts with the `openai>=2.0` that the default
+`openai-codex` provider requires, so `GeoAgent[vllm]` is not part of
+`GeoAgent[providers]` or `GeoAgent[all]` and cannot share an environment with
+them. Prefer `openai-compatible` unless you specifically need `strands-vllm`.

--- a/docs/qgis-plugin.md
+++ b/docs/qgis-plugin.md
@@ -35,6 +35,7 @@ OpenGeoAgent supports the same provider families as GeoAgent:
 - Ollama
 - LiteLLM
 - OpenRouter
+- OpenAI-compatible (any server exposing the OpenAI API)
 - vLLM
 
 Use the settings panel to configure API keys, hosts, model defaults, and
@@ -46,10 +47,19 @@ API key in settings, or set `OPENROUTER_API_KEY`; the default model is
 `deepseek/deepseek-chat`, and Qwen model IDs such as `qwen/qwen3-32b` can be
 entered in the model field.
 
+The `openai-compatible` provider works with any server exposing the OpenAI
+Chat Completions API, such as llama.cpp, LM Studio, Text Generation WebUI, or
+vLLM. Set the OpenAI-compatible base URL in settings (or
+`OPENAI_COMPATIBLE_BASE_URL`) to the server's `/v1` URL and enter a model id in
+the **Model** field. The API key is optional; most local servers ignore it.
+
 vLLM requires a separately running vLLM server. Configure the vLLM base URL and
 model in settings, or set `VLLM_BASE_URL` and `VLLM_MODEL_ID`. GeoAgent tool
 use requires the vLLM server to be started with tool-calling support for the
-selected model and chat template.
+selected model and chat template. The dedicated `vllm` provider needs
+`strands-vllm`, which pins `openai<2.0` and is therefore no longer installed by
+the **Core Providers** dependency group; the `openai-compatible` provider is
+the recommended way to reach a vLLM server.
 
 ## Sample Data
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -42,7 +42,8 @@ The first screen is the chat-and-map workspace. It includes:
 
 - a persistent interactive map where layers accumulate across prompts;
 - provider and model controls for OpenAI, ChatGPT/Codex OAuth, Anthropic,
-  Google Gemini, Bedrock, OpenRouter, LiteLLM, vLLM, and Ollama;
+  Google Gemini, Bedrock, OpenRouter, LiteLLM, any OpenAI-compatible server,
+  vLLM, and Ollama;
 - a fast-mode toggle for lower-latency map-control prompts;
 - an auto-approve toggle for confirmation-required tools;
 - chat history for the current browser session;

--- a/geoagent/core/config.py
+++ b/geoagent/core/config.py
@@ -16,6 +16,7 @@ ProviderName = Literal[
     "ollama",
     "litellm",
     "openrouter",
+    "openai-compatible",
     "vllm",
 ]
 
@@ -40,6 +41,8 @@ def _default_provider_from_env() -> ProviderName:
         or os.environ.get("LITELLM_BASE_URL")
     ):
         return "litellm"
+    if os.environ.get("OPENAI_COMPATIBLE_BASE_URL"):
+        return "openai-compatible"
     if os.environ.get("VLLM_BASE_URL") or os.environ.get("VLLM_MODEL_ID"):
         return "vllm"
     if os.environ.get("OLLAMA_HOST") or os.environ.get("USE_OLLAMA") == "1":
@@ -55,6 +58,8 @@ class GeoAgentConfig(BaseModel):
     ``OPENAI_CODEX_ACCESS_TOKEN``,
     ``GEMINI_API_KEY`` / ``GOOGLE_API_KEY``, ``LITELLM_API_KEY``,
     ``OPENROUTER_API_KEY``,
+    ``OPENAI_COMPATIBLE_BASE_URL`` / ``OPENAI_COMPATIBLE_API_KEY`` /
+    ``OPENAI_COMPATIBLE_MODEL``,
     ``VLLM_BASE_URL`` / ``VLLM_MODEL_ID``,
     ``AWS_REGION`` / default AWS credential chain for Bedrock, etc.).
 
@@ -68,6 +73,8 @@ class GeoAgentConfig(BaseModel):
         openai_codex_base_url: ChatGPT/Codex backend base URL.
         litellm_base_url: Optional LiteLLM proxy or OpenAI-compatible base URL.
         openrouter_base_url: OpenRouter OpenAI-compatible API base URL.
+        openai_compatible_base_url: Base URL of any OpenAI-compatible server,
+            for example ``http://localhost:8000/v1``.
         vllm_base_url: vLLM OpenAI-compatible API base URL.
     """
 
@@ -91,6 +98,10 @@ class GeoAgentConfig(BaseModel):
     openrouter_base_url: Optional[str] = Field(
         default=None,
         description="OpenRouter OpenAI-compatible API base URL.",
+    )
+    openai_compatible_base_url: Optional[str] = Field(
+        default=None,
+        description="Base URL of any OpenAI-compatible server.",
     )
     vllm_base_url: Optional[str] = Field(
         default=None,

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -94,12 +94,15 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
             from strands.models.openai_responses import OpenAIResponsesModel
         except ImportError as exc:
             raise ImportError(
-                "The openai-codex provider uses the OpenAI Responses API, which "
-                "requires the openai package version 2.0 or newer. Upgrade with "
-                "`pip install -U 'GeoAgent[openai]'` (or `pip install -U "
-                "'openai>=2'`) and restart QGIS or your Python session. To stay "
-                "on openai 1.x, switch the provider to 'openai', which uses the "
-                f"Chat Completions API instead. Original error: {exc}"
+                "The openai-codex provider could not import the OpenAI Responses "
+                "API model from strands. This usually means the installed openai "
+                "package is too old, because the Responses API requires the "
+                "openai package version 2.0 or newer. Upgrade with `pip install "
+                "-U 'GeoAgent[openai]'` (or `pip install -U 'openai>=2'`) and "
+                "restart QGIS or your Python session. To stay on openai 1.x, "
+                "switch the provider to 'openai', which uses the Chat Completions "
+                "API instead. If openai 2.x is already installed, the original "
+                f"error below has the real cause. Original error: {exc}"
             ) from exc
 
         model_id = cfg.model or os.environ.get("OPENAI_CODEX_MODEL", "gpt-5.5")

--- a/geoagent/core/model.py
+++ b/geoagent/core/model.py
@@ -90,7 +90,17 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
         )
 
     if provider == "openai-codex":
-        from strands.models.openai_responses import OpenAIResponsesModel
+        try:
+            from strands.models.openai_responses import OpenAIResponsesModel
+        except ImportError as exc:
+            raise ImportError(
+                "The openai-codex provider uses the OpenAI Responses API, which "
+                "requires the openai package version 2.0 or newer. Upgrade with "
+                "`pip install -U 'GeoAgent[openai]'` (or `pip install -U "
+                "'openai>=2'`) and restart QGIS or your Python session. To stay "
+                "on openai 1.x, switch the provider to 'openai', which uses the "
+                f"Chat Completions API instead. Original error: {exc}"
+            ) from exc
 
         model_id = cfg.model or os.environ.get("OPENAI_CODEX_MODEL", "gpt-5.5")
         client_args = dict(cfg.client_args)
@@ -223,6 +233,48 @@ def resolve_model(config: GeoAgentConfig | None = None, **overrides: Any) -> Any
             or "https://openrouter.ai/api/v1"
         )
         client_args["base_url"] = base_url
+        params = _token_param("max_tokens", cfg.max_tokens)
+        if not _model_uses_default_temperature_only(model_id):
+            params["temperature"] = cfg.temperature
+        return OpenAIModel(
+            client_args=client_args,
+            model_id=model_id,
+            params=params,
+        )
+
+    if provider == "openai-compatible":
+        from strands.models.openai import OpenAIModel
+
+        client_args = dict(cfg.client_args)
+        base_url = (
+            client_args.get("base_url")
+            or cfg.openai_compatible_base_url
+            or os.environ.get("OPENAI_COMPATIBLE_BASE_URL")
+        )
+        if not base_url:
+            raise ValueError(
+                "The openai-compatible provider requires the base URL of an "
+                "OpenAI-compatible server, for example http://localhost:8000/v1. "
+                "Set OPENAI_COMPATIBLE_BASE_URL, pass "
+                "openai_compatible_base_url=..., or configure it in OpenGeoAgent "
+                "Settings."
+            )
+        model_id = cfg.model or os.environ.get("OPENAI_COMPATIBLE_MODEL")
+        if not model_id:
+            raise ValueError(
+                "The openai-compatible provider requires a model id, because a "
+                "generic endpoint has no default. Pass model=..., set "
+                "OPENAI_COMPATIBLE_MODEL, or configure the model in OpenGeoAgent "
+                "Settings."
+            )
+        client_args["base_url"] = base_url
+        # Local servers usually ignore the key, but the OpenAI SDK rejects an
+        # empty one, so fall back to the same placeholder the vLLM path uses.
+        client_args["api_key"] = (
+            client_args.get("api_key")
+            or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
+            or "EMPTY"
+        )
         params = _token_param("max_tokens", cfg.max_tokens)
         if not _model_uses_default_temperature_only(model_id):
             params["temperature"] = cfg.temperature

--- a/geoagent/ui/app.py
+++ b/geoagent/ui/app.py
@@ -22,6 +22,7 @@ PROVIDER_NAMES: tuple[str, ...] = (
     "bedrock",
     "litellm",
     "openrouter",
+    "openai-compatible",
     "ollama",
     "vllm",
 )
@@ -34,6 +35,7 @@ DEFAULT_MODEL_BY_PROVIDER: dict[str, str] = {
     "bedrock": "us.anthropic.claude-sonnet-4-6",
     "litellm": "openai/gpt-5.5",
     "openrouter": "deepseek/deepseek-chat",
+    "openai-compatible": "",
     "ollama": "qwen3.5:4b",
     "vllm": "",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,17 @@ dependencies = [
 geoagent = "geoagent.cli:main"
 
 [project.optional-dependencies]
-openai = ["openai>=1.0"]
+openai = ["openai>=2.0"]
 anthropic = ["anthropic>=0.40"]
 gemini = ["strands-agents[gemini]>=1.37", "google-genai>=1.0"]
 ollama = ["ollama>=0.3"]
 litellm = ["strands-agents[litellm]>=1.37"]
-openrouter = ["openai>=1.0"]
+openrouter = ["openai>=2.0"]
+openai-compatible = ["openai>=2.0"]
+# strands-vllm pins openai<2.0, which conflicts with the openai>=2.0 needed by
+# the default openai-codex provider, so this extra is not part of `providers`
+# or `all`. Point the `openai-compatible` provider at a vLLM server's /v1 URL
+# to use vLLM alongside the rest of the stack.
 vllm = ["strands-vllm"]
 bedrock = []
 leafmap = ["leafmap>=0.43"]
@@ -61,7 +66,9 @@ hsae = ["hydrosovereign>=6.0.7"]
 ui = ["solara>=1.35", "starlette<2.0"]
 browser = ["fastapi>=0.115", "uvicorn[standard]>=0.30"]
 qgis = []
-providers = ["GeoAgent[openai,anthropic,gemini,ollama,litellm,openrouter,vllm]"]
+providers = [
+    "GeoAgent[openai,anthropic,gemini,ollama,litellm,openrouter,openai-compatible]",
+]
 all = [
     "GeoAgent[providers,leafmap,anymap,geoai,geemap,earthengine,stac,earthdata,nasa-opera,whitebox,ui,browser]",
 ]

--- a/qgis_geoagent/README.md
+++ b/qgis_geoagent/README.md
@@ -22,7 +22,7 @@ GitHub update checker.
 - Tool permission profiles, defaulting to trusted auto-approval
 - Project-scoped chat history with Markdown import/export
 - Compact jobs panel for active and completed GeoAgent requests
-- Provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, OpenRouter, LiteLLM, and vLLM
+- Provider and model controls for Bedrock, OpenAI, ChatGPT/Codex OAuth, Anthropic, Google Gemini, Ollama, OpenRouter, LiteLLM, OpenAI-compatible servers, and vLLM
 - Settings panel for model defaults, API keys, hosts, AWS region, provider
   smoke tests, and redacted diagnostics export
 - Dependency installer that installs core provider packages or selected
@@ -125,16 +125,26 @@ applied to the current QGIS process before each chat request:
 - Ollama: `OLLAMA_HOST`
 - LiteLLM: `LITELLM_API_KEY` and optional `LITELLM_BASE_URL`
 - OpenRouter: `OPENROUTER_API_KEY` and optional `OPENROUTER_BASE_URL`
+- OpenAI-compatible: `OPENAI_COMPATIBLE_BASE_URL` and optional
+  `OPENAI_COMPATIBLE_API_KEY`
 - vLLM: `VLLM_BASE_URL` and optional `VLLM_API_KEY`
 
 OpenRouter can be used for DeepSeek and Qwen models. The default model is
 `deepseek/deepseek-chat`; enter a Qwen model ID such as `qwen/qwen3-32b` in the
 **Model** setting to use Qwen through OpenRouter.
 
+The `openai-compatible` provider reaches any server exposing the OpenAI Chat
+Completions API (llama.cpp, LM Studio, Text Generation WebUI, vLLM). Set the
+OpenAI-compatible base URL to the server's `/v1` URL and enter a model id in
+the **Model** setting; the API key is optional.
+
 vLLM requires a separately running vLLM server. The model id is supplied via
 the **Model** setting (or `VLLM_MODEL_ID` if no QGIS setting is saved). GeoAgent
 tool use requires the server to be started with tool-calling support for the
-selected model and chat template.
+selected model and chat template. `strands-vllm` pins `openai<2.0`, which
+conflicts with the `openai>=2.0` the default `openai-codex` provider needs, so
+it is no longer part of the **Core Providers** dependency group. Prefer the
+`openai-compatible` provider.
 
 Default models:
 
@@ -148,6 +158,7 @@ Default models:
 | Ollama | `qwen3.5:4b` |
 | LiteLLM | `openai/gpt-5.5` |
 | OpenRouter | `deepseek/deepseek-chat` |
+| OpenAI-compatible | Use `OPENAI_COMPATIBLE_MODEL` or enter a model |
 | vLLM | Use `VLLM_MODEL_ID` or enter a model |
 
 ## Chat Workflow

--- a/qgis_geoagent/open_geoagent/deps_manager.py
+++ b/qgis_geoagent/open_geoagent/deps_manager.py
@@ -36,13 +36,18 @@ CORE_RUNTIME_PACKAGES = [
     ("pydantic", "pydantic>=2.0"),
 ]
 PROVIDER_PACKAGES = [
-    ("openai", "openai>=1.0"),
+    # openai>=2.0 is required by the default openai-codex provider, which uses
+    # the Responses API. Older 1.x releases fail at import time.
+    ("openai", "openai>=2.0"),
     ("anthropic", "anthropic>=0.40"),
     ("google.genai", "google-genai>=1.0"),
     ("ollama", "ollama>=0.3"),
     ("litellm", "strands-agents[litellm]>=1.37"),
-    ("strands_vllm", "strands-vllm"),
 ]
+# strands-vllm is deliberately absent: it pins openai<2.0, which cannot resolve
+# against the openai>=2.0 that GeoAgent[providers] and the default openai-codex
+# provider require, so including it here breaks the whole install. Reach a vLLM
+# server through the openai-compatible provider and its /v1 URL instead.
 WHITEBOX_PACKAGES = [("whitebox", "whitebox>=2.3.6")]
 NASA_PACKAGES = [("earthaccess", "earthaccess>=0.10")]
 GEE_PACKAGES = [

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -82,6 +82,7 @@ DEFAULT_MODELS = {
     "ollama": "qwen3.5:4b",
     "litellm": "openai/gpt-5.5",
     "openrouter": "deepseek/deepseek-chat",
+    "openai-compatible": "",
     "vllm": "",
 }
 PROVIDERS = [
@@ -92,6 +93,7 @@ PROVIDERS = [
     "ollama",
     "openai",
     "openai-codex",
+    "openai-compatible",
     "openrouter",
     "vllm",
 ]
@@ -455,6 +457,10 @@ def _apply_environment_from_settings(settings):
         "litellm_base_url": "LITELLM_BASE_URL",
         "openrouter_api_key": "OPENROUTER_API_KEY",  # pragma: allowlist secret
         "openrouter_base_url": "OPENROUTER_BASE_URL",
+        "openai_compatible_api_key": (  # pragma: allowlist secret
+            "OPENAI_COMPATIBLE_API_KEY",
+        ),
+        "openai_compatible_base_url": "OPENAI_COMPATIBLE_BASE_URL",
         "vllm_api_key": "VLLM_API_KEY",  # pragma: allowlist secret
         "vllm_base_url": "VLLM_BASE_URL",
     }

--- a/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/chat_dock.py
@@ -457,9 +457,7 @@ def _apply_environment_from_settings(settings):
         "litellm_base_url": "LITELLM_BASE_URL",
         "openrouter_api_key": "OPENROUTER_API_KEY",  # pragma: allowlist secret
         "openrouter_base_url": "OPENROUTER_BASE_URL",
-        "openai_compatible_api_key": (  # pragma: allowlist secret
-            "OPENAI_COMPATIBLE_API_KEY",
-        ),
+        "openai_compatible_api_key": "OPENAI_COMPATIBLE_API_KEY",  # pragma: allowlist secret
         "openai_compatible_base_url": "OPENAI_COMPATIBLE_BASE_URL",
         "vllm_api_key": "VLLM_API_KEY",  # pragma: allowlist secret
         "vllm_base_url": "VLLM_BASE_URL",

--- a/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
+++ b/qgis_geoagent/open_geoagent/dialogs/settings_dock.py
@@ -74,6 +74,8 @@ ENV_FALLBACKS = {
     "litellm_base_url": ("LITELLM_BASE_URL",),
     "openrouter_api_key": ("OPENROUTER_API_KEY",),
     "openrouter_base_url": ("OPENROUTER_BASE_URL",),
+    "openai_compatible_api_key": ("OPENAI_COMPATIBLE_API_KEY",),
+    "openai_compatible_base_url": ("OPENAI_COMPATIBLE_BASE_URL",),
     "vllm_api_key": ("VLLM_API_KEY",),
     "vllm_base_url": ("VLLM_BASE_URL",),
 }
@@ -690,6 +692,23 @@ class SettingsDockWidget(QDockWidget):
         )
         credentials_form.addRow("OpenRouter base URL:", self.openrouter_base_url_input)
 
+        self.openai_compatible_key_input = QLineEdit()
+        self.openai_compatible_key_input.setEchoMode(password_mode)
+        self.openai_compatible_key_input.setPlaceholderText(
+            "Optional; often unused by local servers"
+        )
+        credentials_form.addRow(
+            "OpenAI-compatible API key:", self.openai_compatible_key_input
+        )
+
+        self.openai_compatible_base_url_input = QLineEdit()
+        self.openai_compatible_base_url_input.setPlaceholderText(
+            "http://localhost:8000/v1"
+        )
+        credentials_form.addRow(
+            "OpenAI-compatible base URL:", self.openai_compatible_base_url_input
+        )
+
         self.vllm_key_input = QLineEdit()
         self.vllm_key_input.setEchoMode(password_mode)
         self.vllm_key_input.setPlaceholderText("Optional; often EMPTY for local vLLM")
@@ -1132,6 +1151,8 @@ class SettingsDockWidget(QDockWidget):
             ("litellm_base_url", self.litellm_base_url_input),
             ("openrouter_api_key", self.openrouter_key_input),
             ("openrouter_base_url", self.openrouter_base_url_input),
+            ("openai_compatible_api_key", self.openai_compatible_key_input),
+            ("openai_compatible_base_url", self.openai_compatible_base_url_input),
             ("vllm_api_key", self.vllm_key_input),
             ("vllm_base_url", self.vllm_base_url_input),
         )
@@ -1306,6 +1327,8 @@ class SettingsDockWidget(QDockWidget):
             "litellm_base_url",
             "openrouter_api_key",
             "openrouter_base_url",
+            "openai_compatible_api_key",
+            "openai_compatible_base_url",
             "vllm_api_key",
             "vllm_base_url",
             *OAUTH_CONFIG_KEYS,

--- a/qgis_geoagent/tests/test_settings_diagnostics.py
+++ b/qgis_geoagent/tests/test_settings_diagnostics.py
@@ -123,11 +123,41 @@ def test_settings_environment_sets_openrouter_values(monkeypatch) -> None:
     assert os.environ["OPENROUTER_API_KEY"] == "test-key"
 
 
-def test_core_provider_dependencies_include_vllm() -> None:
-    """Verify Core Providers installs the vLLM client."""
+def test_settings_environment_sets_openai_compatible_values(monkeypatch) -> None:
+    """Verify settings apply generic OpenAI-compatible environment variables."""
+    import os
+
+    monkeypatch.delenv("OPENAI_COMPATIBLE_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    settings = _FakeSettings(
+        {
+            f"{SETTINGS_PREFIX}openai_compatible_base_url": "http://localhost:8000/v1",
+            f"{SETTINGS_PREFIX}openai_compatible_api_key": "test-key",
+        }
+    )
+
+    _apply_environment_from_settings(settings)
+
+    assert os.environ["OPENAI_COMPATIBLE_BASE_URL"] == "http://localhost:8000/v1"
+    assert os.environ["OPENAI_COMPATIBLE_API_KEY"] == "test-key"
+
+
+def test_core_provider_dependencies_exclude_vllm() -> None:
+    """Verify Core Providers omits the vLLM client.
+
+    ``strands-vllm`` pins ``openai<2.0``, which cannot coexist with the
+    ``openai>=2.0`` the default openai-codex provider requires.
+    """
     from open_geoagent.deps_manager import REQUIRED_PACKAGES
 
-    assert ("strands_vllm", "strands-vllm") in REQUIRED_PACKAGES
+    assert ("strands_vllm", "strands-vllm") not in REQUIRED_PACKAGES
+
+
+def test_core_provider_dependencies_require_openai_2() -> None:
+    """Verify the plugin installs an openai release with the Responses API."""
+    from open_geoagent.deps_manager import REQUIRED_PACKAGES
+
+    assert ("openai", "openai>=2.0") in REQUIRED_PACKAGES
 
 
 def test_uv_usable_requires_successful_verification(monkeypatch) -> None:

--- a/tests/test_model_providers.py
+++ b/tests/test_model_providers.py
@@ -108,6 +108,8 @@ def test_openai_codex_is_default_provider_without_env(monkeypatch) -> None:
         "OPENROUTER_BASE_URL",
         "VLLM_BASE_URL",
         "VLLM_MODEL_ID",
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "OPENAI_COMPATIBLE_MODEL",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -131,6 +133,8 @@ def test_openai_codex_can_be_selected_from_environment(monkeypatch) -> None:
         "OPENROUTER_BASE_URL",
         "VLLM_BASE_URL",
         "VLLM_MODEL_ID",
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "OPENAI_COMPATIBLE_MODEL",
     ]:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("OPENAI_CODEX_ACCESS_TOKEN", "codex-token")
@@ -153,6 +157,8 @@ def test_litellm_can_be_selected_from_environment(monkeypatch) -> None:
         "OPENROUTER_API_KEY",
         "OPENROUTER_MODEL",
         "OPENROUTER_BASE_URL",
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "OPENAI_COMPATIBLE_MODEL",
     ]:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm.example.test")
@@ -175,6 +181,8 @@ def test_openrouter_can_be_selected_from_environment(monkeypatch) -> None:
         "LITELLM_BASE_URL",
         "VLLM_BASE_URL",
         "VLLM_MODEL_ID",
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "OPENAI_COMPATIBLE_MODEL",
     ]:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
@@ -198,6 +206,8 @@ def test_vllm_can_be_selected_from_environment(monkeypatch) -> None:
         "OPENROUTER_API_KEY",
         "OPENROUTER_MODEL",
         "OPENROUTER_BASE_URL",
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "OPENAI_COMPATIBLE_MODEL",
     ]:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
@@ -459,3 +469,121 @@ def test_resolve_vllm_requires_model_id(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="vLLM provider requires a model id"):
         resolve_model(GeoAgentConfig(provider="vllm"))
+
+
+def test_openai_compatible_config_is_valid() -> None:
+    """Verify that a generic OpenAI-compatible server is an accepted provider."""
+    cfg = GeoAgentConfig(
+        provider="openai-compatible",
+        model="qwen3-8b",
+        openai_compatible_base_url="http://localhost:8000/v1",
+    )
+
+    assert cfg.provider == "openai-compatible"
+    assert cfg.model == "qwen3-8b"
+    assert cfg.openai_compatible_base_url == "http://localhost:8000/v1"
+
+
+def test_openai_compatible_can_be_selected_from_environment(monkeypatch) -> None:
+    """Verify a generic base URL selects the openai-compatible provider."""
+    for key in [
+        "OPENAI_API_KEY",
+        "OPENAI_CODEX_ACCESS_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OLLAMA_HOST",
+        "USE_OLLAMA",
+        "LITELLM_API_KEY",
+        "LITELLM_MODEL",
+        "LITELLM_BASE_URL",
+        "OPENROUTER_API_KEY",
+        "OPENROUTER_MODEL",
+        "OPENROUTER_BASE_URL",
+        "VLLM_BASE_URL",
+        "VLLM_MODEL_ID",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", "http://localhost:8000/v1")
+
+    assert GeoAgentConfig().provider == "openai-compatible"
+
+
+def test_resolve_openai_compatible_model(monkeypatch) -> None:
+    """Verify a generic endpoint resolves to the OpenAI chat completions model."""
+    fake_model = _install_fake_openai_model(monkeypatch)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "local-key")
+
+    model = resolve_model(
+        GeoAgentConfig(
+            provider="openai-compatible",
+            model="qwen3-8b",
+            openai_compatible_base_url="http://localhost:8000/v1",
+            temperature=0.3,
+            max_tokens=512,
+        )
+    )
+
+    assert isinstance(model, fake_model)
+    assert model.kwargs == {
+        "client_args": {
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "local-key",
+        },
+        "model_id": "qwen3-8b",
+        "params": {"temperature": 0.3, "max_tokens": 512},
+    }
+
+
+def test_resolve_openai_compatible_defaults_api_key(monkeypatch) -> None:
+    """Verify keyless local servers still get a non-empty placeholder key."""
+    _install_fake_openai_model(monkeypatch)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", "http://localhost:1234/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_MODEL", "local-model")
+
+    model = resolve_model(GeoAgentConfig(provider="openai-compatible"))
+
+    assert model.kwargs["client_args"]["api_key"] == "EMPTY"
+    assert model.kwargs["client_args"]["base_url"] == "http://localhost:1234/v1"
+    assert model.kwargs["model_id"] == "local-model"
+
+
+def test_resolve_openai_compatible_requires_base_url(monkeypatch) -> None:
+    """Verify a missing base URL reports a clear, actionable error."""
+    _install_fake_openai_model(monkeypatch)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_BASE_URL", raising=False)
+
+    with pytest.raises(ValueError, match="requires the base URL"):
+        resolve_model(GeoAgentConfig(provider="openai-compatible", model="qwen3-8b"))
+
+
+def test_resolve_openai_compatible_requires_model_id(monkeypatch) -> None:
+    """Verify a missing model id reports a clear, actionable error."""
+    _install_fake_openai_model(monkeypatch)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_MODEL", raising=False)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", "http://localhost:8000/v1")
+
+    with pytest.raises(ValueError, match="requires a model id"):
+        resolve_model(GeoAgentConfig(provider="openai-compatible"))
+
+
+def test_openai_codex_reports_openai_version_requirement(monkeypatch) -> None:
+    """Verify an unimportable Responses API explains the openai>=2.0 upgrade."""
+    monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models",
+        types.ModuleType("strands.models"),
+    )
+    # A module without OpenAIResponsesModel makes the `from ... import` raise
+    # ImportError, the same failure mode as an installed openai 1.x.
+    monkeypatch.setitem(
+        sys.modules,
+        "strands.models.openai_responses",
+        types.ModuleType("strands.models.openai_responses"),
+    )
+    monkeypatch.setenv("OPENAI_CODEX_ACCESS_TOKEN", "codex-token")
+
+    with pytest.raises(ImportError, match=r"requires the openai package"):
+        resolve_model(GeoAgentConfig(provider="openai-codex", model="gpt-5.5"))


### PR DESCRIPTION
Fixes #118. Closes #125.

## #118 — `OpenAIResponsesModel requires openai>=2.0.0` on Test Provider

The default `openai-codex` provider builds a Strands `OpenAIResponsesModel`, which validates the OpenAI SDK version at import time and raises on anything below 2.0. Both the `openai` extra and the QGIS plugin's `PROVIDER_PACKAGES` pinned only `openai>=1.0`, so a fresh install could resolve to a 1.x release and every **Test Provider** click failed with the raw `ImportError` the reporter screenshotted.

- Raise the floor to `openai>=2.0` in `pyproject.toml` and in the plugin's dependency manager.
- Wrap the import in `resolve_model` so the message explains the upgrade and the `openai` provider fallback, instead of leaking the Strands internal error.

Verified on the real path: `pip install ".[providers]"` into a clean venv now yields openai 2.53.0, and `resolve_model(provider="openai-codex")` returns an `OpenAIResponsesModel`.

## #125 — generic OpenAI-compatible endpoints

New `openai-compatible` provider for any server exposing the OpenAI Chat Completions API — llama.cpp, LM Studio, Text Generation WebUI, vLLM.

| Setting | Environment variable |
| --- | --- |
| Base URL (required) | `OPENAI_COMPATIBLE_BASE_URL` |
| Model id (required) | `OPENAI_COMPATIBLE_MODEL` |
| API key (optional) | `OPENAI_COMPATIBLE_API_KEY` |

```python
agent = GeoAgent(
    provider="openai-compatible",
    model="qwen3-8b",
    openai_compatible_base_url="http://localhost:8000/v1",
)
```

A model id is required because a generic endpoint has no sensible default. The API key falls back to the `EMPTY` placeholder the vLLM path already uses, so keyless local servers work. Wired into the Solara UI and the QGIS plugin (provider list, default models, credential fields, environment mapping, settings reset).

Verified with a real round trip: a local stub server received `POST /v1/chat/completions` with the configured model and `Authorization: Bearer EMPTY`, and the agent returned the streamed reply.

## Heads-up: vLLM extra is no longer in `providers` / `all`

`strands-vllm` (latest, 0.0.6) hard-pins `openai<2.0.0`, so it cannot resolve alongside the `openai>=2.0` this PR requires. Leaving it in `GeoAgent[providers]` makes that extra uninstallable outright, so it is now excluded from `providers`, `all`, and the plugin's **Core Providers** group.

- The standalone `GeoAgent[vllm]` extra is unchanged, for dedicated environments that do not need `openai-codex`.
- The new `openai-compatible` provider reaches a vLLM server's `/v1` URL with no extra dependency, so this is a soft landing rather than a capability loss.

This is the one judgment call in the PR that has user-visible packaging impact — happy to revisit if you would rather keep vLLM bundled and solve #118 a different way.

## Testing

- `pytest tests/` — 329 passed, 2 skipped (7 new provider tests).
- `pre-commit run --files <changed>` — clean.
- Clean-venv `pip install ".[providers]"` and a live round trip, as described above.

Note: the `deploy` check fails on pre-existing mkdocs strict-mode docstring warnings in `geoagent/core/registry.py` (from 7abc595), unrelated to this branch.